### PR TITLE
Add vi.js to autocomplete

### DIFF
--- a/specs/vi.js
+++ b/specs/vi.js
@@ -1,0 +1,9 @@
+var completionSpec = {
+
+    name: "vi",
+    description: "Vi[m] is an one of two powerhouse text editors in the Unix world, the other being EMACS",
+    args: {
+        template: "filepaths"
+    },
+    subcommands: []
+}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds a new (very basic) spec for `vi`

**What is the current behavior? (You can also link to an open issue here)**
No autocompletion on files when using the `vi` command

**What is the new behavior (if this is a feature change)?**
Shows an autocompletion list of files to open with `vi`
