### PR TITLE
add pre-subcommand Git options

### DIFF
--- a/specs/git.js
+++ b/specs/git.js
@@ -122,6 +122,94 @@ var completionSpec = {
 
     name: "git",
     description: "the stupid content tracker",
+    options: [
+        {
+            name: "--version",
+            description: "Output version"
+        },
+        {
+            name: "--help",
+            description: "Output help"
+        },
+        {
+            name: "-C",
+            insertValue: "-C ",
+            args: {
+                name: "path",
+                template: "folders"
+            },
+            description: "Run as if git was started in \<path\>"
+        },
+        {
+            name: "-c name=value",
+            insertValue: "-c ",
+            description: "Pass a config parameter to the command"
+        },
+        {
+            name: "--exec-path[=<path>]",
+            insertValue: "--exec-path",
+            args: {
+                name: "path",
+                isOptional: true,
+                template: "folders",
+            },
+            description: "Get or set GIT_EXEC_PATH for core Git programs"
+        },
+        {
+            name: "--html-path",
+            description: "Print Git’s HTML documentation path"
+        },
+        {
+            name: "--man-path",
+            description: "Print the manpath for this version of Git"
+        },
+        {
+            name: "--info-path",
+            description: "Print the info path documenting this version of Git"
+        },
+        {
+            name: ["-p", "--paginate"],
+            description: "Pipe output into `less` or custom $PAGER"
+        },
+        {
+            name: "--no-pager",
+            description: "Do not pipe Git output into a pager"
+        },
+        {
+            name: "--no-replace-objects",
+            description: "Do not use replacement refs"
+        },
+        {
+            name: "--bare",
+            description: "Treat the repository as a bare repository"
+        },
+        {
+            name: "--git-dir=<path>",
+            insertValue: "--git-dir=",
+            args: {
+                name: "path",
+                template: "folders"
+            },
+            description: "Set the path to the repository dir (`.git`)"
+        },
+        {
+            name: "--work-tree=<path>",
+            insertValue: "--work-tree=",
+            args: {
+                name: "path",
+                template: "folders"
+            },
+            description: "Set working tree path"
+        },
+        {
+            name: "--namespace=<name>",
+            insertValue: "--namespace=",
+            args: {
+                name: "name",
+            },
+            description: "Set the Git namespace"
+        },
+    ],
     subcommands: [
         {
             name: "commit",

--- a/specs/git.js
+++ b/specs/git.js
@@ -138,7 +138,7 @@ var completionSpec = {
                 name: "path",
                 template: "folders"
             },
-            description: "Run as if git was started in \<path\>"
+            description: "Run as if git was started in &lt;path&gt;"
         },
         {
             name: "-c name=value",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Expanding the autocomplete spec for Git to support options that come before the subcommand, e.g. I often use `git --no-pager diff <file>`.

**What is the current behavior? (You can also link to an open issue here)**
Currently no support for options before subcommand

**What is the new behavior (if this is a feature change)?**

**Additional info:**