### PR TITLE
feat: add `git rebase --skip` to git spec

### DIFF
--- a/specs/git.js
+++ b/specs/git.js
@@ -295,6 +295,7 @@ var completionSpec = {
             options: [
                 { name: ["--continue"], description: "continue the rebasing after conflict resolution" },
                 { name: ["--abort"], description: "stop rebase" },
+                { name: ["--skip"], description: "skips a commit" },
                 {
                     name: ["-i"],
                     description: "interactive"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This PR adds the `--skip` flag to the autocomplete for `git rebase`

**What is the current behavior? (You can also link to an open issue here)**

Right now, there is no autocomplete suggestion for `--skip`

**What is the new behavior (if this is a feature change)?**

`--skip` is now an autocomplete option

**Additional info:**

N/A