### PR TITLE
Update git fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,61 @@
 {
   "name": "linter",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "linter",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "joi": "^17.3.0"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
+    "node_modules/joi": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
+      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    }
+  },
   "dependencies": {
     "@hapi/hoek": {
       "version": "9.1.1",

--- a/specs/git.js
+++ b/specs/git.js
@@ -750,6 +750,14 @@ var completionSpec = {
                     description: "By default, tags that point at objects that are downloaded from the remote repository are fetched and stored locally. This option disables this automatic tag following",
                 },
                 {
+                    name: ["--refmap"],
+                    insertValue: "--refmap {cursor}",
+                    args: {
+                        name: 'refspec',
+                    },
+                    description: "When fetching refs listed on the command line, use the specified refspec (can be given more than once) to map the refs to remote-tracking branches, instead of the values of remote.*.fetch configuration variables for the remote repository",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -697,6 +697,10 @@ var completionSpec = {
                     description: "By default, Git will report, to the server, commits reachable from all local refs to find common commits in an attempt to reduce the size of the to-be-received packfile",
                 },
                 {
+                    name: ["--dry-run"],
+                    description: "Show what would be done, without making any changes.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -811,6 +811,14 @@ var completionSpec = {
                     description: "By default git fetch refuses to update the head which corresponds to the current branch. This flag disables the check. This is purely for the internal use for git pull to communicate with git fetch, and unless you are implementing your own Porcelain you are not supposed to use it.",
                 },
                 {
+                    name: ["--upload-pack"],
+                    insertValue: "--upload-pack {cursor}",
+                    args: {
+                        name: 'upload-pack',
+                    },
+                    description: "When given, and the repository to fetch from is handled by git fetch-pack, --exec=<upload-pack> is passed to the command to specify non-default path for the command run on the other end.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -758,6 +758,10 @@ var completionSpec = {
                     description: "When fetching refs listed on the command line, use the specified refspec (can be given more than once) to map the refs to remote-tracking branches, instead of the values of remote.*.fetch configuration variables for the remote repository",
                 },
                 {
+                    name: ["-t", "--tags"],
+                    description: "By default, tags that point at objects that are downloaded from the remote repository are fetched and stored locally. This option disables this automatic tag following",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -871,6 +871,10 @@ var completionSpec = {
                     name: ["-6", "--ipv6"],
                     description: "Use IPv6 addresses only, ignoring IPv4 addresses.",
                 },
+                {
+                    name: "--stdin",
+                    description: "Read refspecs, one per line, from stdin in addition to those provided as arguments. The \"tag <name>\" format is not supported",
+                },
             ]
         },
         {

--- a/specs/git.js
+++ b/specs/git.js
@@ -681,6 +681,10 @@ var completionSpec = {
                     description: "Deepen or shorten the history of a shallow repository to exclude commits reachable from a specified remote branch or tag. This option can be specified multiple times",
                 },
                 {
+                    name: ["--unshallow"],
+                    description: "If the source repository is shallow, fetch as much as possible so that the current repository has the same history as the source repository",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -673,6 +673,14 @@ var completionSpec = {
                     description: "Deepen or shorten the history of a shallow repository to include all reachable commits after <date>",
                 },
                 {
+                    name: ["--shallow-exclude"],
+                    insertValue: "--shallow-exclude {cursor}",
+                    args: {
+                        name: 'revision',
+                    },
+                    description: "Deepen or shorten the history of a shallow repository to exclude commits reachable from a specified remote branch or tag. This option can be specified multiple times",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -838,6 +838,10 @@ var completionSpec = {
                     description: "Transmit the given string to the server when communicating using protocol version 2. The given string must not contain a NUL or LF character. ",
                 },
                 {
+                    name: ["--show-forced-updates"],
+                    description: "By default, git checks if a branch is force-updated during fetch. This can be disabled through fetch.showForcedUpdates, but the --show-forced-updates option guarantees this check occurs",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -706,7 +706,7 @@ var completionSpec = {
                 },
                 {
                     name: ["--negotiation-tip"],
-                    insertValue: "--negotiation-tip {cursor}",
+                    insertValue: "--negotiation-tip ",
                     args: {
                         name: 'commit|glob',
                         generators: generators.commits,
@@ -790,7 +790,7 @@ var completionSpec = {
                 //     description: "When fetching refs listed on the command line, use the specified refspec (can be given more than once) to map the refs to remote-tracking branches, instead of the values of remote.*.fetch configuration variables for the remote repository",
                 // },
                 {
-                    name: ["-j", "jobs"],
+                    name: ["-j", "--jobs"],
                     args: {
                         name: 'n',
                     },

--- a/specs/git.js
+++ b/specs/git.js
@@ -746,6 +746,10 @@ var completionSpec = {
                     description: "Before fetching, remove any local tags that no longer exist on the remote if --prune is enabled",
                 },
                 {
+                    name: ["-n", "--no-tags"],
+                    description: "By default, tags that point at objects that are downloaded from the remote repository are fetched and stored locally. This option disables this automatic tag following",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -636,6 +636,11 @@ var completionSpec = {
             description: "Download objects and refs from another repository",
             options: [
                 {
+                    name: "--all",
+                    insertValue: "--all",
+                    description: "Fetch all remotes",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -693,6 +693,7 @@ var completionSpec = {
                     insertValue: "--negotiation-tip {cursor}",
                     args: {
                         name: 'commit|glob',
+                        generators: generators.commits,
                     },
                     description: "By default, Git will report, to the server, commits reachable from all local refs to find common commits in an attempt to reduce the size of the to-be-received packfile",
                 },

--- a/specs/git.js
+++ b/specs/git.js
@@ -831,6 +831,13 @@ var completionSpec = {
                     description: "Progress status is reported on the standard error stream by default when it is attached to a terminal, unless -q is specified.",
                 },
                 {
+                    name: ["-o", "--server-option"],
+                    args: {
+                        name: 'option',
+                    },
+                    description: "Transmit the given string to the server when communicating using protocol version 2. The given string must not contain a NUL or LF character. ",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -657,6 +657,14 @@ var completionSpec = {
                     description: "Limit fetching to the specified number of commits from the tip of each remote branch history",
                 },
                 {
+                    name: ["--deepen"],
+                    insertValue: "--deepen {cursor}",
+                    args: {
+                        name: 'depth',
+                    },
+                    description: "Similar to --depth, except it specifies the number of commits from the current shallow boundary instead of from the tip of each remote branch history",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -701,6 +701,14 @@ var completionSpec = {
                     description: "Show what would be done, without making any changes.",
                 },
                 {
+                    name: ["--write-fetch-head"],
+                    description: "Write the list of remote refs fetched in the FETCH_HEAD file directly under $GIT_DIR. This is the default",
+                },
+                {
+                    name: ["--no-write-fetch-head"],
+                    description: "tells Git not to write the file. ",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -773,6 +773,13 @@ var completionSpec = {
                     description: "When fetching refs listed on the command line, use the specified refspec (can be given more than once) to map the refs to remote-tracking branches, instead of the values of remote.*.fetch configuration variables for the remote repository",
                 },
                 {
+                    name: ["-j", "jobs"],
+                    args: {
+                        name: 'n',
+                    },
+                    description: "Number of parallel children to be used for all forms of fetching.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -784,6 +784,10 @@ var completionSpec = {
                     description: "Disable recursive fetching of submodules (this has the same effect as using the --recurse-submodules=no option).",
                 },
                 {
+                    name: ["--set-upstream"],
+                    description: "If the remote is fetched successfully, add upstream (tracking) reference, used by argument-less git-pull[1] and other commands.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -762,6 +762,17 @@ var completionSpec = {
                     description: "By default, tags that point at objects that are downloaded from the remote repository are fetched and stored locally. This option disables this automatic tag following",
                 },
                 {
+                    name: ["--recurse-submodules"],
+                    insertValue: "--recurse-submodules={cursor}",
+                    args: {
+                        name: 'mode',
+                        suggestions: [
+                            'yes', 'on-demand', 'no',
+                        ],
+                    },
+                    description: "When fetching refs listed on the command line, use the specified refspec (can be given more than once) to map the refs to remote-tracking branches, instead of the values of remote.*.fetch configuration variables for the remote repository",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -634,6 +634,22 @@ var completionSpec = {
         {
             name: "fetch",
             description: "Download objects and refs from another repository",
+            args: [
+                {
+                    name: "remote",
+                    isOptional: true,
+                    generators: generators.remotes
+                },
+                {
+                    name: "branch",
+                    isOptional: true,
+                    generators: generators.branches
+                },
+                {
+                    name: "refspec",
+                    isOptional: true,
+                },
+            ],
             options: [
                 {
                     name: "--all",
@@ -853,9 +869,6 @@ var completionSpec = {
                     name: ["-6", "--ipv6"],
                     description: "Use IPv6 addresses only, ignoring IPv4 addresses.",
                 },
-                {
-                    name: "origin", description: "copies all branches from the remote"
-                }
             ]
         },
         {

--- a/specs/git.js
+++ b/specs/git.js
@@ -722,6 +722,14 @@ var completionSpec = {
                     description: "Allow several <repository> and <group> arguments to be specified. No <refspec>s may be specified.",
                 },
                 {
+                    name: ["--auto-maintenance", "--auto-gc"],
+                    description: "Run git maintenance run --auto at the end to perform automatic repository maintenance if",
+                },
+                {
+                    name: ["--no-auto-maintenance", "--no-auto-gc"],
+                    description: "Don't run git maintenance run --auto at the end to perform automatic repository maintenance",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -714,6 +714,14 @@ var completionSpec = {
                     description: "This option overrides that check",
                 },
                 {
+                    name: ["-k", "--keep"],
+                    description: "Keep downloaded pack.",
+                },
+                {
+                    name: ["--multiple"],
+                    description: "Allow several <repository> and <group> arguments to be specified. No <refspec>s may be specified.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -796,6 +796,17 @@ var completionSpec = {
                     description: "Prepend <path> to paths printed in informative messages such as \”Fetching submodule foo\". This option is used internally when recursing over submodules.",
                 },
                 {
+                    name: ["--recurse-submodules-default"],
+                    insertValue: "--recurse-submodules-default={cursor}",
+                    args: {
+                        name: 'mode',
+                        suggestions: [
+                            'yes', 'on-demand',
+                        ],
+                    },
+                    description: "This option is used internally to temporarily provide a non-negative default value for the --recurse-submodules option",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -819,6 +819,10 @@ var completionSpec = {
                     description: "When given, and the repository to fetch from is handled by git fetch-pack, --exec=<upload-pack> is passed to the command to specify non-default path for the command run on the other end.",
                 },
                 {
+                    name: ["-q", "--quiet"],
+                    description: "Pass --quiet to git-fetch-pack and silence any other internally used git commands. Progress is not reported to the standard error stream.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -846,6 +846,14 @@ var completionSpec = {
                     description: "By default, git checks if a branch is force-updated during fetch. Pass --no-show-forced-updates or set fetch.showForcedUpdates to false to skip this check for performance reasons.",
                 },
                 {
+                    name: ["-4", "--ipv4"],
+                    description: "Use IPv4 addresses only, ignoring IPv6 addresses.",
+                },
+                {
+                    name: ["-6", "--ipv6"],
+                    description: "Use IPv6 addresses only, ignoring IPv4 addresses.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -807,6 +807,10 @@ var completionSpec = {
                     description: "This option is used internally to temporarily provide a non-negative default value for the --recurse-submodules option",
                 },
                 {
+                    name: ["-u", "--update-head-ok"],
+                    description: "By default git fetch refuses to update the head which corresponds to the current branch. This flag disables the check. This is purely for the internal use for git pull to communicate with git fetch, and unless you are implementing your own Porcelain you are not supposed to use it.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -685,6 +685,18 @@ var completionSpec = {
                     description: "If the source repository is shallow, fetch as much as possible so that the current repository has the same history as the source repository",
                 },
                 {
+                    name: ["--update-shallow"],
+                    description: "By default when fetching from a shallow repository, git fetch refuses refs that require updating .git/shallow",
+                },
+                {
+                    name: ["--negotiation-tip"],
+                    insertValue: "--negotiation-tip {cursor}",
+                    args: {
+                        name: 'commit|glob',
+                    },
+                    description: "By default, Git will report, to the server, commits reachable from all local refs to find common commits in an attempt to reduce the size of the to-be-received packfile",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -649,6 +649,14 @@ var completionSpec = {
                     description: "Use an atomic transaction to update local refs. Either all refs are updated, or on error, no refs are updated.",
                 },
                 {
+                    name: ["--depth"],
+                    insertValue: "--depth {cursor}",
+                    args: {
+                        name: 'depth',
+                    },
+                    description: "Limit fetching to the specified number of commits from the tip of each remote branch history",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -645,6 +645,10 @@ var completionSpec = {
                     description: "Append ref names and object names of fetched refs to the existing contents of .git/FETCH_HEAD",
                 },
                 {
+                    name: ["--atomic"],
+                    description: "Use an atomic transaction to update local refs. Either all refs are updated, or on error, no refs are updated.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -780,6 +780,10 @@ var completionSpec = {
                     description: "Number of parallel children to be used for all forms of fetching.",
                 },
                 {
+                    name: ["--no-recurse-submodules"],
+                    description: "Disable recursive fetching of submodules (this has the same effect as using the --recurse-submodules=no option).",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -823,6 +823,10 @@ var completionSpec = {
                     description: "Pass --quiet to git-fetch-pack and silence any other internally used git commands. Progress is not reported to the standard error stream.",
                 },
                 {
+                    name: ["-v", "--verbose"],
+                    description: "Be verbose.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -842,6 +842,10 @@ var completionSpec = {
                     description: "By default, git checks if a branch is force-updated during fetch. This can be disabled through fetch.showForcedUpdates, but the --show-forced-updates option guarantees this check occurs",
                 },
                 {
+                    name: ["--no-show-forced-updates"],
+                    description: "By default, git checks if a branch is force-updated during fetch. Pass --no-show-forced-updates or set fetch.showForcedUpdates to false to skip this check for performance reasons.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -665,6 +665,14 @@ var completionSpec = {
                     description: "Similar to --depth, except it specifies the number of commits from the current shallow boundary instead of from the tip of each remote branch history",
                 },
                 {
+                    name: ["--shallow-since"],
+                    insertValue: "--shallow-since {cursor}",
+                    args: {
+                        name: 'date',
+                    },
+                    description: "Deepen or shorten the history of a shallow repository to include all reachable commits after <date>",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -738,6 +738,14 @@ var completionSpec = {
                     description: "Don't write a commit-graph after fetching. This overrides the config setting fetch.writeCommitGraph",
                 },
                 {
+                    name: ["-p", "--prune"],
+                    description: "Before fetching, remove any remote-tracking references that no longer exist on the remote",
+                },
+                {
+                    name: ["-P", "--prune-tags"],
+                    description: "Before fetching, remove any local tags that no longer exist on the remote if --prune is enabled",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -730,6 +730,14 @@ var completionSpec = {
                     description: "Don't run git maintenance run --auto at the end to perform automatic repository maintenance",
                 },
                 {
+                    name: ["--write-commit-graph"],
+                    description: "Write a commit-graph after fetching. This overrides the config setting fetch.writeCommitGraph",
+                },
+                {
+                    name: ["--no-write-commit-graph"],
+                    description: "Don't write a commit-graph after fetching. This overrides the config setting fetch.writeCommitGraph",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -706,7 +706,11 @@ var completionSpec = {
                 },
                 {
                     name: ["--no-write-fetch-head"],
-                    description: "tells Git not to write the file. ",
+                    description: "tells Git not to write the file",
+                },
+                {
+                    name: ["-f", "--force"],
+                    description: "This option overrides that check",
                 },
                 {
                     name: "origin", description: "copies all branches from the remote"

--- a/specs/git.js
+++ b/specs/git.js
@@ -788,6 +788,14 @@ var completionSpec = {
                     description: "If the remote is fetched successfully, add upstream (tracking) reference, used by argument-less git-pull[1] and other commands.",
                 },
                 {
+                    name: ["--submodule-prefix"],
+                    insertValue: "--submodule-prefix {cursor}",
+                    args: {
+                        name: 'path',
+                    },
+                    description: "Prepend <path> to paths printed in informative messages such as \”Fetching submodule foo\". This option is used internally when recursing over submodules.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -827,6 +827,10 @@ var completionSpec = {
                     description: "Be verbose.",
                 },
                 {
+                    name: ["--progress"],
+                    description: "Progress status is reported on the standard error stream by default when it is attached to a terminal, unless -q is specified.",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -777,17 +777,18 @@ var completionSpec = {
                     name: ["-t", "--tags"],
                     description: "By default, tags that point at objects that are downloaded from the remote repository are fetched and stored locally. This option disables this automatic tag following",
                 },
-                {
-                    name: ["--recurse-submodules"],
-                    insertValue: "--recurse-submodules={cursor}",
-                    args: {
-                        name: 'mode',
-                        suggestions: [
-                            'yes', 'on-demand', 'no',
-                        ],
-                    },
-                    description: "When fetching refs listed on the command line, use the specified refspec (can be given more than once) to map the refs to remote-tracking branches, instead of the values of remote.*.fetch configuration variables for the remote repository",
-                },
+                // TODO: fig needs to accept '=' as delimiter for args/options
+                // {
+                //     name: ["--recurse-submodules"],
+                //     insertValue: "--recurse-submodules={cursor}",
+                //     args: {
+                //         name: 'mode',
+                //         suggestions: [
+                //             'yes', 'on-demand', 'no',
+                //         ],
+                //     },
+                //     description: "When fetching refs listed on the command line, use the specified refspec (can be given more than once) to map the refs to remote-tracking branches, instead of the values of remote.*.fetch configuration variables for the remote repository",
+                // },
                 {
                     name: ["-j", "jobs"],
                     args: {
@@ -811,17 +812,18 @@ var completionSpec = {
                     },
                     description: "Prepend <path> to paths printed in informative messages such as \”Fetching submodule foo\". This option is used internally when recursing over submodules.",
                 },
-                {
-                    name: ["--recurse-submodules-default"],
-                    insertValue: "--recurse-submodules-default={cursor}",
-                    args: {
-                        name: 'mode',
-                        suggestions: [
-                            'yes', 'on-demand',
-                        ],
-                    },
-                    description: "This option is used internally to temporarily provide a non-negative default value for the --recurse-submodules option",
-                },
+                // TODO: fig needs to accept '=' as delimiter for args/options
+                // {
+                //     name: ["--recurse-submodules-default"],
+                //     insertValue: "--recurse-submodules-default={cursor}",
+                //     args: {
+                //         name: 'mode',
+                //         suggestions: [
+                //             'yes', 'on-demand',
+                //         ],
+                //     },
+                //     description: "This option is used internally to temporarily provide a non-negative default value for the --recurse-submodules option",
+                // },
                 {
                     name: ["-u", "--update-head-ok"],
                     description: "By default git fetch refuses to update the head which corresponds to the current branch. This flag disables the check. This is purely for the internal use for git pull to communicate with git fetch, and unless you are implementing your own Porcelain you are not supposed to use it.",

--- a/specs/git.js
+++ b/specs/git.js
@@ -641,6 +641,10 @@ var completionSpec = {
                     description: "Fetch all remotes",
                 },
                 {
+                    name: ["-a", "--append"],
+                    description: "Append ref names and object names of fetched refs to the existing contents of .git/FETCH_HEAD",
+                },
+                {
                     name: "origin", description: "copies all branches from the remote"
                 }
             ]

--- a/specs/git.js
+++ b/specs/git.js
@@ -634,12 +634,11 @@ var completionSpec = {
         {
             name: "fetch",
             description: "Download objects and refs from another repository",
-            options:
-                [
-                    {
-                        name: "origin", description: "copies all branches from the remote"
-                    }
-                ]
+            options: [
+                {
+                    name: "origin", description: "copies all branches from the remote"
+                }
+            ]
         },
         {
             name: "stash",


### PR DESCRIPTION
This adds all options and args for the `git fetch` command.

The options `--recurse-submodules` and `--recurse-submodules-default` are currently not active, because the delimiter `=` is currently not working