### PR TITLE
feat(kubectl): get generator for resources

### DIFF
--- a/specs/kubectl.js
+++ b/specs/kubectl.js
@@ -3587,6 +3587,13 @@ var completionSpec = {
         {
             name: "get",
             description: "Display one or many resources",
+            args: {
+                name: 'Resource',
+                generator: {
+                    script: "kubectl api-resources -o name",
+                    splitOn: "\n"
+                }
+            },
             options: [
                 {
                     name: [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature
**What is the current behavior? (You can also link to an open issue here)**
No arguments for `get`
**What is the new behavior (if this is a feature change)?**
Generator to get the resources using `kubectl api-resources -o name`
**Additional info:**