### PR TITLE
Add `gh clone` completions

### DIFF
--- a/specs/gh.js
+++ b/specs/gh.js
@@ -295,6 +295,128 @@ var completionSpec = {
             ]
         },
         { name: "release", description: "Manage GitHub releases" },
-        { name: "repo", description: "Create, clone, fork, and view repositories" },
+        {
+            name: "repo",
+            description: "Create, clone, fork, list, and view repositories",
+            subcommands: [
+                {
+                    name: "clone",
+                    description: "Clone a repository locally",
+                    args: {
+                        name: "string",
+                    },
+                    options: [
+                        { name: ["-h", "--help"], description: "Show help for command" },
+                    ],
+                },
+                {
+                    name: "create",
+                    description: "Create a new GitHub repository",
+                    args: {
+                        name: "string",
+                    },
+                    options: [
+                        { name: ["-h", "--help"], description: "Show help for command" },
+                        {
+                            name: ["-y", "--confirm"],
+                            description: "Skip the confirmation prompt",
+                        },
+                        {
+                            name: ["-d", "--description"],
+                            description: "Description of the repository",
+                            args: {
+                                name: "string",
+                            }
+                        },
+                        {
+                            name: ["-h", "--homepage"],
+                            description: "repository home page URL",
+                            args: {
+                                name: "string",
+                            },
+                        },
+                        { name: ["--public"], description: "make the repository public" },
+                        { name: ["--private"], description: "make the repository private" },
+                        {
+                            name: ["--internal"],
+                            description: "make the repository internal",
+                        },
+                        {
+                            name: ["--enable-issues"],
+                            description: "Enable issues in the new repository {true|false}",
+                        },
+                        {
+                            name: ["--enable-wiki"],
+                            description: "Enable wiki in the new repository {true|false}",
+                        },
+                    ],
+                },
+                {
+                    name: "fork",
+                    description: "Create a fork of a repository",
+                    args: {
+                        name: "string",
+                    },
+                    options: [
+                        { name: ["-h", "--help"], description: "Show help for command" },
+                        { name: ["--clone"], description: "Clone the fork {true|false}" },
+                        {
+                            name: ["--remote"],
+                            description: "Add remote for fork {true|false}",
+                        },
+                        {
+                            name: ["--remote-name"],
+                            description:
+                                "Specify a name for a fork\'s new remote. (default \"origin\")",
+                            args: {
+                                name: "string",
+                            },
+                        },
+                    ],
+                },
+                {
+                    name: "list",
+                    description: "List repositories owned by user or organization",
+                    args: {
+                        name: "string",
+                    },
+                    options: [
+                        { name: ["-h", "--help"], description: "Show help for command" },
+                        { name: ["--archived"], description: "Show only archived repositories" },
+                        { name: ["--fork"], description: "Show only forked repositories" },
+                        { name: ["-l", "--fork"], description: "Filter by primary coding language" },
+                        {
+                            name: ["-L", "--limit"],
+                            description: "Maximum number of repositories to list (default 30)",
+                            args: {
+                                name: "string"
+                            }
+                        },
+                        { name: ["--no-archived"], description: "Omit archived repositories" },
+                        { name: ["--private"], description: "Show only private repositories" },
+                        { name: ["--public"], description: "Show only public repositories" },
+                        { name: ["--source"], description: "Show only non-forks" },
+                    ],
+                },
+                {
+                    name: "view",
+                    description: "View a repository",
+                    args: {
+                        name: "string",
+                    },
+                    options: [
+                        { name: ["-h", "--help"], description: "Show help for command" },
+                        {
+                            name: ["-b", "--branch"],
+                            description: "View a specific branch of the repository",
+                            args: {
+                                name: "string",
+                            }
+                        },
+                        { name: ["-w", "--web"], description: "Open a repository in the browser" },
+                    ],
+                },
+            ],
+        },
     ]
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature: autocomplete spec for `gh clone` subcommands

**What is the current behavior? (You can also link to an open issue here)**
currently no `ch clone` subcommands have autocomplete spec

**What is the new behavior (if this is a feature change)?**
`gh clone` subcommands now autocomplete

**Additional info:**
Info taken from https://cli.github.com/manual/gh_repo_clone