### PR TITLE
Fix search path in brew install subcommand generator

### DIFF
--- a/dev/brew.ts
+++ b/dev/brew.ts
@@ -55,7 +55,7 @@ export const completionSpec: Fig.Spec = {
         description: "Formula or cask to install",
         generators: {
           script:
-            "ls -1 /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks",
+            "HBPATH=$(brew --repository); ls -1 $HBPATH/Library/Taps/homebrew/homebrew-core/Formula $HBPATH/Library/Taps/homebrew/homebrew-cask/Casks",
           postProcess: function (out) {
             return out.split("\n").map((formula) => {
               return {

--- a/specs/brew.js
+++ b/specs/brew.js
@@ -51,7 +51,7 @@ var completionSpec = {
                 name: "formula",
                 description: "Formula or cask to install",
                 generators: {
-                    script: "ls -1 /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks",
+                    script: "HBPATH=$(brew --repository); ls -1 $HBPATH/Library/Taps/homebrew/homebrew-core/Formula $HBPATH/Library/Taps/homebrew/homebrew-cask/Casks",
                     postProcess: function (out) {
                         return out.split("\n").map(function (formula) {
                             return {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix
**What is the current behavior? (You can also link to an open issue here)**
Search path for formulas and casks in brew install subcommand generator is wrong for homebrew installations in new M1 macs. On M1 macs homebrew installs in /opt/homebrew while on Intel macs is in /usr/local/Homebrew 
**What is the new behavior (if this is a feature change)?**
By using the command "brew --repository", the right homebrew installation path can be used for any mac.
**Additional info:**