### PR TITLE
[FIG] feat: allow nesting of specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
     "scripts": {
         "dev": "source scripts/dev.sh",
         "test": "tsc --noEmit && echo 'All specs passed validation. You are ready to push!'",
-        "copy": "func() { cp \"$(pwd)\"/specs/${1}.js ~/.fig/autocomplete/; }; func",
-        "copy:all": "cp \"$(pwd)\"/specs/*.js ~/.fig/autocomplete/",
+        "copy": "func() { mkdir -p ~/.fig/autocomplete/$(dirname ${1}.js); cp \"$(pwd)\"/specs/${1}.js ~/.fig/autocomplete/${1}.js; }; func",
+        "copy:all": "rsync -a --include '*/' --include '*.js' --exclude '*' $(pwd)/specs/ ~/.fig/autocomplete/",
         "create-boilerplate": "./scripts/create-boilerplate.sh",
         "build": "ts-node-script scripts/compiler.ts",
-        "lint": "eslint '*/*.ts'",
+        "lint": "eslint '**/*.ts'",
         "lint:fix": "npm run lint -- --fix",
         "prepare": "husky install"
     },

--- a/scripts/create-boilerplate.sh
+++ b/scripts/create-boilerplate.sh
@@ -7,10 +7,17 @@ echo
 
 read -e -p "What's the name of the CLI tool you want to create an autocomplete spec for: " USER_INPUT_CLI_TOOL
 
+# Must put file path in quotes in case either variable has spaces
+FILEPATH="$(pwd)/dev/$USER_INPUT_CLI_TOOL.ts"
+
+# The actual name of the spec
+SPEC_NAME="$(basename $USER_INPUT_CLI_TOOL)"
+
+# If it's a nested path make sure the directory exists
+mkdir -p "$(dirname $FILEPATH)"
 
 # Check if the given file exists
-# Must put file path in quotes in case either variable has spaces
-if [[ -f "$(pwd)/dev/$USER_INPUT_CLI_TOOL.ts" ]]; then
+if [[ -f "$FILEPATH" ]]; then
   echo
   echo "$(tput setaf 1)This completion spec already exists$(tput sgr0)"
   echo
@@ -25,11 +32,11 @@ else
   ## Using quotes around EOF will remove expansions
     # https://superuser.com/questions/1436906/need-to-expand-a-variable-in-a-heredoc-that-is-in-quotes
   cat <<EOF >> "$(pwd)/dev/$USER_INPUT_CLI_TOOL.ts"
-// To learn more about FIg's autocomplete standard visit: https://withfig.com/docs/autocomplete/building-a-spec#building-your-first-autocomplete-spec
+// To learn more about Fig's autocomplete standard visit: https://withfig.com/docs/autocomplete/building-a-spec#building-your-first-autocomplete-spec
 
 // The below is a dummy example for git. Make sure to change the file name!
 export const completion: Fig.Spec = {
-  name: "git",
+  name: "$SPEC_NAME",
   description: "The stupid content tracker",
   subcommands: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
It is not possible to nest files in the `dev/` folder (e.g. `dev/aws/s3.ts`)

**What is the new behavior (if this is a feature change)?**
It is possible to nest folders.

**Additional info:**
Updated eslint, typescript and also the `copy` and `copy:all` commands