### PR TITLE
Kubectl - Context & rollout generators

### DIFF
--- a/dev/kubectl.ts
+++ b/dev/kubectl.ts
@@ -1662,6 +1662,9 @@ export const completionSpec: Fig.Spec = {
         {
           name: "deployment",
           description: "Create a deployment with the specified name.",
+          args: {
+            name: "NAME",
+          },
           options: [
             {
               name: ["--allow-missing-template-keys"],

--- a/dev/kubectl.ts
+++ b/dev/kubectl.ts
@@ -938,7 +938,16 @@ export const completionSpec: Fig.Spec = {
       name: "config",
       description:
         'Modify kubeconfig files using subcommands like "kubectl config set current-context my-context"',
-      options: [],
+      options: [
+        {
+          name: "--kubeconfig",
+          insertValue: "--kubeconfig=",
+          args: {
+            name: "path",
+            template: "filepaths",
+          },
+        },
+      ],
       subcommands: [
         {
           name: "current-context",

--- a/dev/kubectl.ts
+++ b/dev/kubectl.ts
@@ -41,6 +41,13 @@ const sharedArgs = {
       splitOn: "\n",
     },
   },
+  listDeployments: {
+    name: "Deployments",
+    generators: {
+      script: "kubectl get deployments.apps -o name",
+      splitOn: "\n",
+    },
+  },
 };
 
 export const completionSpec: Fig.Spec = {
@@ -3735,6 +3742,7 @@ export const completionSpec: Fig.Spec = {
         {
           name: "history",
           description: "View previous rollout revisions and configurations.",
+          args: sharedArgs.listDeployments,
           options: [
             {
               name: ["--allow-missing-template-keys"],
@@ -3784,6 +3792,7 @@ export const completionSpec: Fig.Spec = {
         {
           name: "pause",
           description: "Mark the provided resource as paused",
+          args: sharedArgs.listDeployments,
           options: [
             {
               name: ["--allow-missing-template-keys"],
@@ -3913,6 +3922,7 @@ export const completionSpec: Fig.Spec = {
         {
           name: "status",
           description: "Show the status of the rollout.",
+          args: sharedArgs.listDeployments,
           options: [
             {
               name: ["-f", "--filename"],
@@ -3947,6 +3957,51 @@ export const completionSpec: Fig.Spec = {
             {
               name: ["-w", "--watch"],
               description: "Watch the status of the rollout until it's done.",
+              args: {},
+            },
+          ],
+          subcommands: [],
+        },
+        {
+          name: "undo",
+          description: "Rollback to a previous rollout.",
+          args: sharedArgs.listDeployments,
+          options: [
+            {
+              name: ["--to_revision=revision"],
+              insertValue: "--to_revision=",
+              args: {},
+            },
+            {
+              name: "--dry-run=strategy",
+              insertValue: "--dry-run=",
+              args: {
+                name: "Strategy",
+                suggestions: ["none", "client", "server"],
+              },
+            },
+            {
+              name: ["-f", "--filename"],
+              description:
+                "Filename, directory, or URL to files identifying the resource to get from a server.",
+              args: {},
+            },
+            {
+              name: ["-k", "--kustomize"],
+              description:
+                "Process the kustomization directory. This flag can't be used together with -f or -R.",
+              args: {},
+            },
+            {
+              name: ["-R", "--recursive"],
+              description:
+                "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.",
+              args: {},
+            },
+            {
+              name: ["--timeout"],
+              description:
+                "The length of time to wait before ending watch, zero means never. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).",
               args: {},
             },
           ],

--- a/dev/kubectl.ts
+++ b/dev/kubectl.ts
@@ -25,6 +25,22 @@ const sharedArgs = {
       splitOn: "\n",
     },
   },
+  listKubeConfContexts: {
+    name: "Context",
+    generators: {
+      script: function (context) {
+        console.log(context);
+        if (context.includes("--kubeconfig")) {
+          const index = context.indexOf("--kubeconfig");
+          return `kubectl config --kubeconfig=${
+            context[index + 1]
+          } get-contexts -o name`;
+        }
+        return "kubectl config get-contexts -o name";
+      },
+      splitOn: "\n",
+    },
+  },
 };
 
 export const completionSpec: Fig.Spec = {
@@ -1013,11 +1029,33 @@ export const completionSpec: Fig.Spec = {
         {
           name: "set-context",
           description: "Sets a context entry in kubeconfig",
+          args: sharedArgs.listKubeConfContexts,
           options: [
             {
               name: ["--current"],
               description: "Modify the current context",
               args: {},
+            },
+            {
+              name: ["--cluster=cluster_nickname"],
+              insertValue: "--cluster=",
+              args: {
+                name: "cluster_nickname",
+              },
+            },
+            {
+              name: ["--user=user_nickname"],
+              insertValue: "--user=",
+              args: {
+                name: "user_nickname",
+              },
+            },
+            {
+              name: ["--namespace=namespace"],
+              insertValue: "--namespace=",
+              args: {
+                name: "namespace",
+              },
             },
           ],
           subcommands: [],
@@ -1092,6 +1130,24 @@ export const completionSpec: Fig.Spec = {
             },
           ],
           subcommands: [],
+        },
+        {
+          name: "unset",
+          description: "Unsets an individual value in a kubeconfig file",
+          subcommands: [],
+        },
+        {
+          name: "use-context",
+          description: "Sets the current-context in a kubeconfig file",
+          args: sharedArgs.listKubeConfContexts,
+          options: [],
+          subcommands: [],
+        },
+        {
+          name: "view",
+          description:
+            "Display merged kubeconfig settings or a specified kubeconfig file",
+          options: [],
         },
       ],
     },

--- a/dev/kubectl.ts
+++ b/dev/kubectl.ts
@@ -1,28 +1,29 @@
 // TODO: Handle if not connected to a k8s cluster
-const resourcesArg = {
-  name: "Resource Type",
-  generators: {
-    script: "kubectl api-resources -o name",
-    splitOn: "\n",
-  },
-};
 
-const runningPodsArg = {
-  name: "Running Pods",
-  generators: {
-    script: "kubectl get pods --field-selector=status.phase=Running -o name",
-    splitOn: "\n",
-  },
-};
-
-const resourceSuggestionsFromResourceType = {
-  name: "Resource",
-  generators: {
-    script: function (context) {
-      const resourceType = context[context.length - 2];
-      return `kubectl get ${resourceType} -o custom-columns=:.metadata.name`;
+const sharedArgs = {
+  resourcesArg: {
+    name: "Resource Type",
+    generators: {
+      script: "kubectl api-resources -o name",
+      splitOn: "\n",
     },
-    splitOn: "\n",
+  },
+  runningPodsArg: {
+    name: "Running Pods",
+    generators: {
+      script: "kubectl get pods --field-selector=status.phase=Running -o name",
+      splitOn: "\n",
+    },
+  },
+  resourceSuggestionsFromResourceType: {
+    name: "Resource",
+    generators: {
+      script: function (context) {
+        const resourceType = context[context.length - 2];
+        return `kubectl get ${resourceType} -o custom-columns=:.metadata.name`;
+      },
+      splitOn: "\n",
+    },
   },
 };
 
@@ -102,7 +103,7 @@ export const completionSpec: Fig.Spec = {
       name: "annotate",
       description: "Update the annotations on one or more resources",
       args: [
-        resourcesArg,
+        sharedArgs.resourcesArg,
         {
           name: "KEY=VAL",
           variadic: true,
@@ -501,7 +502,7 @@ export const completionSpec: Fig.Spec = {
       name: "attach",
       description:
         "Attach to a process that is already running inside an existing container.",
-      args: runningPodsArg,
+      args: sharedArgs.runningPodsArg,
       options: [
         {
           name: ["-c", "--container"],
@@ -2642,7 +2643,10 @@ export const completionSpec: Fig.Spec = {
     {
       name: "describe",
       description: "Show details of a specific resource or group of resources",
-      args: [resourcesArg, resourceSuggestionsFromResourceType],
+      args: [
+        sharedArgs.resourcesArg,
+        sharedArgs.resourceSuggestionsFromResourceType,
+      ],
       options: [
         {
           name: ["-A", "--all-namespaces"],
@@ -2864,7 +2868,7 @@ export const completionSpec: Fig.Spec = {
     {
       name: "exec",
       description: "Execute a command in a container.",
-      args: runningPodsArg,
+      args: sharedArgs.runningPodsArg,
       options: [
         {
           name: ["-c", "--container"],
@@ -2899,7 +2903,7 @@ export const completionSpec: Fig.Spec = {
     {
       name: "explain",
       description: "List the fields for supported resources",
-      args: resourcesArg,
+      args: sharedArgs.resourcesArg,
       options: [
         {
           name: ["--api-version"],
@@ -3055,7 +3059,7 @@ export const completionSpec: Fig.Spec = {
     {
       name: "get",
       description: "Display one or many resources",
-      args: resourcesArg,
+      args: sharedArgs.resourcesArg,
       options: [
         {
           name: ["-A", "--all-namespaces"],

--- a/specs/kubectl.js
+++ b/specs/kubectl.js
@@ -38,6 +38,13 @@ var sharedArgs = {
             splitOn: "\n",
         },
     },
+    listDeployments: {
+        name: "Deployments",
+        generators: {
+            script: "kubectl get deployments.apps -o name",
+            splitOn: "\n",
+        },
+    },
 };
 var completionSpec = {
     name: "kubectl",
@@ -3255,6 +3262,7 @@ var completionSpec = {
                 {
                     name: "history",
                     description: "View previous rollout revisions and configurations.",
+                    args: sharedArgs.listDeployments,
                     options: [
                         {
                             name: ["--allow-missing-template-keys"],
@@ -3297,6 +3305,7 @@ var completionSpec = {
                 {
                     name: "pause",
                     description: "Mark the provided resource as paused",
+                    args: sharedArgs.listDeployments,
                     options: [
                         {
                             name: ["--allow-missing-template-keys"],
@@ -3408,6 +3417,7 @@ var completionSpec = {
                 {
                     name: "status",
                     description: "Show the status of the rollout.",
+                    args: sharedArgs.listDeployments,
                     options: [
                         {
                             name: ["-f", "--filename"],
@@ -3437,6 +3447,47 @@ var completionSpec = {
                         {
                             name: ["-w", "--watch"],
                             description: "Watch the status of the rollout until it's done.",
+                            args: {},
+                        },
+                    ],
+                    subcommands: [],
+                },
+                {
+                    name: "undo",
+                    description: "Rollback to a previous rollout.",
+                    args: sharedArgs.listDeployments,
+                    options: [
+                        {
+                            name: ["--to_revision=revision"],
+                            insertValue: "--to_revision=",
+                            args: {},
+                        },
+                        {
+                            name: "--dry-run=strategy",
+                            insertValue: "--dry-run=",
+                            args: {
+                                name: "Strategy",
+                                suggestions: ["none", "client", "server"],
+                            },
+                        },
+                        {
+                            name: ["-f", "--filename"],
+                            description: "Filename, directory, or URL to files identifying the resource to get from a server.",
+                            args: {},
+                        },
+                        {
+                            name: ["-k", "--kustomize"],
+                            description: "Process the kustomization directory. This flag can't be used together with -f or -R.",
+                            args: {},
+                        },
+                        {
+                            name: ["-R", "--recursive"],
+                            description: "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.",
+                            args: {},
+                        },
+                        {
+                            name: ["--timeout"],
+                            description: "The length of time to wait before ending watch, zero means never. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).",
                             args: {},
                         },
                     ],

--- a/specs/kubectl.js
+++ b/specs/kubectl.js
@@ -24,6 +24,20 @@ var sharedArgs = {
             splitOn: "\n",
         },
     },
+    listKubeConfContexts: {
+        name: "Context",
+        generators: {
+            script: function (context) {
+                console.log(context);
+                if (context.includes("--kubeconfig")) {
+                    var index = context.indexOf("--kubeconfig");
+                    return "kubectl config --kubeconfig=" + context[index + 1] + " get-contexts -o name";
+                }
+                return "kubectl config get-contexts -o name";
+            },
+            splitOn: "\n",
+        },
+    },
 };
 var completionSpec = {
     name: "kubectl",
@@ -892,11 +906,33 @@ var completionSpec = {
                 {
                     name: "set-context",
                     description: "Sets a context entry in kubeconfig",
+                    args: sharedArgs.listKubeConfContexts,
                     options: [
                         {
                             name: ["--current"],
                             description: "Modify the current context",
                             args: {},
+                        },
+                        {
+                            name: ["--cluster=cluster_nickname"],
+                            insertValue: "--cluster=",
+                            args: {
+                                name: "cluster_nickname",
+                            },
+                        },
+                        {
+                            name: ["--user=user_nickname"],
+                            insertValue: "--user=",
+                            args: {
+                                name: "user_nickname",
+                            },
+                        },
+                        {
+                            name: ["--namespace=namespace"],
+                            insertValue: "--namespace=",
+                            args: {
+                                name: "namespace",
+                            },
                         },
                     ],
                     subcommands: [],
@@ -964,6 +1000,23 @@ var completionSpec = {
                         },
                     ],
                     subcommands: [],
+                },
+                {
+                    name: "unset",
+                    description: "Unsets an individual value in a kubeconfig file",
+                    subcommands: [],
+                },
+                {
+                    name: "use-context",
+                    description: "Sets the current-context in a kubeconfig file",
+                    args: sharedArgs.listKubeConfContexts,
+                    options: [],
+                    subcommands: [],
+                },
+                {
+                    name: "view",
+                    description: "Display merged kubeconfig settings or a specified kubeconfig file",
+                    options: [],
                 },
             ],
         },

--- a/specs/kubectl.js
+++ b/specs/kubectl.js
@@ -1,26 +1,28 @@
 // TODO: Handle if not connected to a k8s cluster
-var resourcesArg = {
-    name: "Resource Type",
-    generators: {
-        script: "kubectl api-resources -o name",
-        splitOn: "\n",
-    },
-};
-var runningPodsArg = {
-    name: "Running Pods",
-    generators: {
-        script: "kubectl get pods --field-selector=status.phase=Running -o name",
-        splitOn: "\n",
-    },
-};
-var resourceSuggestionsFromResourceType = {
-    name: "Resource",
-    generators: {
-        script: function (context) {
-            var resourceType = context[context.length - 2];
-            return "kubectl get " + resourceType + " -o custom-columns=:.metadata.name";
+var sharedArgs = {
+    resourcesArg: {
+        name: "Resource Type",
+        generators: {
+            script: "kubectl api-resources -o name",
+            splitOn: "\n",
         },
-        splitOn: "\n",
+    },
+    runningPodsArg: {
+        name: "Running Pods",
+        generators: {
+            script: "kubectl get pods --field-selector=status.phase=Running -o name",
+            splitOn: "\n",
+        },
+    },
+    resourceSuggestionsFromResourceType: {
+        name: "Resource",
+        generators: {
+            script: function (context) {
+                var resourceType = context[context.length - 2];
+                return "kubectl get " + resourceType + " -o custom-columns=:.metadata.name";
+            },
+            splitOn: "\n",
+        },
     },
 };
 var completionSpec = {
@@ -95,7 +97,7 @@ var completionSpec = {
             name: "annotate",
             description: "Update the annotations on one or more resources",
             args: [
-                resourcesArg,
+                sharedArgs.resourcesArg,
                 {
                     name: "KEY=VAL",
                     variadic: true,
@@ -437,7 +439,7 @@ var completionSpec = {
         {
             name: "attach",
             description: "Attach to a process that is already running inside an existing container.",
-            args: runningPodsArg,
+            args: sharedArgs.runningPodsArg,
             options: [
                 {
                     name: ["-c", "--container"],
@@ -2299,7 +2301,10 @@ var completionSpec = {
         {
             name: "describe",
             description: "Show details of a specific resource or group of resources",
-            args: [resourcesArg, resourceSuggestionsFromResourceType],
+            args: [
+                sharedArgs.resourcesArg,
+                sharedArgs.resourceSuggestionsFromResourceType,
+            ],
             options: [
                 {
                     name: ["-A", "--all-namespaces"],
@@ -2493,7 +2498,7 @@ var completionSpec = {
         {
             name: "exec",
             description: "Execute a command in a container.",
-            args: runningPodsArg,
+            args: sharedArgs.runningPodsArg,
             options: [
                 {
                     name: ["-c", "--container"],
@@ -2526,7 +2531,7 @@ var completionSpec = {
         {
             name: "explain",
             description: "List the fields for supported resources",
-            args: resourcesArg,
+            args: sharedArgs.resourcesArg,
             options: [
                 {
                     name: ["--api-version"],
@@ -2661,7 +2666,7 @@ var completionSpec = {
         {
             name: "get",
             description: "Display one or many resources",
-            args: resourcesArg,
+            args: sharedArgs.resourcesArg,
             options: [
                 {
                     name: ["-A", "--all-namespaces"],
@@ -4086,7 +4091,7 @@ var completionSpec = {
                             args: {},
                         },
                         {
-                            name: ["--wanker"],
+                            name: ["--template"],
                             description: "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].",
                             args: {},
                         },

--- a/specs/kubectl.js
+++ b/specs/kubectl.js
@@ -1463,6 +1463,9 @@ var completionSpec = {
                 {
                     name: "deployment",
                     description: "Create a deployment with the specified name.",
+                    args: {
+                        name: "NAME",
+                    },
                     options: [
                         {
                             name: ["--allow-missing-template-keys"],

--- a/specs/kubectl.js
+++ b/specs/kubectl.js
@@ -819,7 +819,16 @@ var completionSpec = {
         {
             name: "config",
             description: 'Modify kubeconfig files using subcommands like "kubectl config set current-context my-context"',
-            options: [],
+            options: [
+                {
+                    name: "--kubeconfig",
+                    insertValue: "--kubeconfig=",
+                    args: {
+                        name: "path",
+                        template: "filepaths",
+                    },
+                },
+            ],
             subcommands: [
                 {
                     name: "current-context",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature
**What is the current behavior? (You can also link to an open issue here)**
No generators and missing args & options for `config` and `rollout` subcommands
**What is the new behavior (if this is a feature change)?**
- Adds missing args & opts for `config` and `rollout` subcommands
- Adds generators where appropriate for `config` and `rollout` subcommands
- Refactors all shared args into a `sharedArgs` const
**Additional info:**
![Screen Recording 2021-04-16 at 10 37 12](https://user-images.githubusercontent.com/3679064/115005641-f9a10480-9e9f-11eb-94fb-d86d81e5ee45.gif)
