### PR TITLE
[FIG]: fix typo in schema

### DIFF
--- a/schemas/fig.d.ts
+++ b/schemas/fig.d.ts
@@ -87,7 +87,7 @@ declare namespace Fig {
      * If you want your suggestions to always be at the top order regardless of whether they have been selected before or not, rank them 76 or above
      * If you want your suggestions to always be at the bottom regardless of whether they have been selected before or not, rank them 49 or below
      */
-    prioritiy?: number;
+    priority?: number;
     /**
      * Specifies whether a suggestion should be hidden from results. Fig will only show it if the user types the exact same thing as the name
      *


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
The property `priority` is misspelled in our schema `fig.d.ts`file

**What is the new behavior (if this is a feature change)?**
The typo is fixed
**Additional info:**