### PR TITLE
feat: add posixNoncompliantFlags to Spec

### DIFF
--- a/schemas/fig.d.ts
+++ b/schemas/fig.d.ts
@@ -27,7 +27,16 @@ declare namespace Fig {
   // both set to void by default
   export type StringOrFunction<T = void, R = void> = string | Function<T, R>;
 
-  export type Spec = Subcommand;
+  export interface Spec extends Subcommand {
+    /**
+     * This flag allows options to have multiple characters
+     * even though they only have one hyphen
+     *
+     * @example
+     * -mod
+     */
+    posixNoncompliantFlags?: boolean;
+  }
 
   // Execute shell command function inside generators
   export type ExecuteShellCommandFunction = (param: String) => Promise<String>;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update

**What is the current behavior? (You can also link to an open issue here)**

The `posixNoncompliantFlags` property does not exist on the `Spec` type

**What is the new behavior (if this is a feature change)?**
The `posixNoncompliantFlags` exists as a property on `Spec`

**Additional info:**