### PR TITLE
Add Laravel artisan spec

### DIFF
--- a/dev/php.ts
+++ b/dev/php.ts
@@ -5,67 +5,28 @@ export const completion: Fig.Spec = {
   name: "php",
   description: "Run the PHP interpreter",
   generateSpec: async (context, executeShellCommand) => {
-    if (true)
-      return {
-        name: "php",
-        subcommands: [{ name: "artisan", loadSpec: "php/artisan" }],
-      };
+    const subcommands = [];
+
+    if ((await executeShellCommand("ls -1 artisan")) === "artisan") {
+      subcommands.push({ name: "artisan", loadSpec: "php/artisan" });
+    }
+
+    return {
+      name: "php",
+      subcommands,
+      args: {
+        generators: {
+          template: "filepaths",
+          filterTemplateSuggestions: function (suggestions) {
+            return suggestions.filter((suggestion) => {
+              return (
+                // suggestion.name.endsWith(".php") ||
+                suggestion.name.indexOf(".") === -1
+              );
+            });
+          },
+        },
+      },
+    };
   },
-  subcommands: [{ name: "test1" }, { name: "test2" }],
-
-  // args: {
-  //   generators: {
-  //     template: "filepaths",
-  //     filterTemplateSuggestions: function (suggestions) {
-  //       return suggestions.filter((suggestion) => {
-  //         return (
-  //           // suggestion.name.endsWith(".php") ||
-  //           suggestion.name.indexOf(".") === -1
-  //         );
-  //       });
-  //     },
-  //   },
-  // },
 };
-
-// var completionSpec = {
-//   name: "php",
-//   description: "Run the PHP interpreter",
-
-//   },
-//   subcommands: [
-//     {
-//       name: "artisan",
-//       description: "",
-//       options: [],
-//       args: [
-//         {
-//           generators: {
-//             script: "php artisan list --format=json",
-//             postProcess: function (out) {
-//               if (out.trim() == "") {
-//                 return [];
-//               }
-//               try {
-//                 const commands = JSON.parse(out);
-
-//                 const artisanCommands = [];
-
-//                 commands.commands.map((command) => {
-//                   artisanCommands.push({
-//                     name: command.name,
-//                     description: command.description,
-//                     icon: "https://web.tinkerwell.app/img/laravel.3cab6a56.png",
-//                   });
-//                 });
-
-//                 return artisanCommands;
-//               } catch (e) {}
-//               return [];
-//             },
-//           },
-//         },
-//       ],
-//     },
-//   ],
-// };

--- a/dev/php/artisan.ts
+++ b/dev/php/artisan.ts
@@ -1,37 +1,51 @@
 export const completion: Fig.Spec = {
   name: "artisan",
-  description: "The stupid content tracker",
+  description: "Laravel Artisan Command",
   generateSpec: async (context, executeShellCommand) => {
-    if (true)
-      return {
-        name: "artisan",
-        subcommands: [{ name: "abc" }, { name: "def" }],
-      };
+    var out = await executeShellCommand("php artisan list --format=json");
+    const subcommands = [];
+
+    try {
+      const commandDefinition = JSON.parse(out);
+
+      commandDefinition.commands.map((command) => {
+        subcommands.push({
+          name: command.name,
+          description: command.description,
+          icon: "https://web.tinkerwell.app/img/laravel.3cab6a56.png",
+
+          args: Object.keys(command.definition.arguments).map((argumentKey) => {
+            const argument = command.definition.arguments[argumentKey];
+
+            return {
+              name: argument.name,
+              description: argument.description,
+              isOptional: !argument.is_required,
+            };
+          }),
+          options: Object.keys(command.definition.options).map((optionKey) => {
+            const option = command.definition.options[optionKey];
+            const names = [option.name];
+
+            if (option.shortcut !== "") {
+              names.push(option.shortcut);
+            }
+
+            return {
+              name: names,
+              description: option.description,
+            };
+          }),
+        });
+      });
+    } catch (err) {
+      //
+    }
+
+    return {
+      name: "artisan",
+      debounce: true,
+      subcommands,
+    };
   },
-
-  // subcommands: [
-  //   {
-  //     name: "checkout",
-  //     description: "Switch branches or restore working tree files",
-
-  //     // If a subcommand or option takes an argument, you must include the args prop, even if it's an empty object (like below)
-  //     // If you want to build custom suggestions for arguments check out: https://withfig.com/docs/autocomplete/building-a-spec#making-advanced-suggestions
-  //     args: {},
-  //     options: [
-  //       {
-  //         name: ["-b"],
-  //         description: "create and checkout a new branch",
-  //         args: {
-  //           name: "branch",
-  //         },
-  //       },
-  //     ],
-  //   },
-  // ],
-  // options: [
-  //   {
-  //     name: ["-v", "--version"],
-  //     description: "View your current git version",
-  //   },
-  // ],
 };

--- a/specs/php.js
+++ b/specs/php.js
@@ -40,65 +40,34 @@ var completionSpec = {
     name: "php",
     description: "Run the PHP interpreter",
     generateSpec: function (context, executeShellCommand) { return __awaiter(void 0, void 0, void 0, function () {
+        var subcommands;
         return __generator(this, function (_a) {
-            if (true)
-                return [2 /*return*/, {
-                        name: "php",
-                        subcommands: [{ name: "artisan", loadSpec: "php/artisan" }],
-                    }];
-            return [2 /*return*/];
+            switch (_a.label) {
+                case 0:
+                    subcommands = [];
+                    return [4 /*yield*/, executeShellCommand("ls -1 artisan")];
+                case 1:
+                    if ((_a.sent()) === 'artisan') {
+                        subcommands.push({ name: "artisan", loadSpec: "php/artisan" });
+                    }
+                    return [2 /*return*/, {
+                            name: "php",
+                            subcommands: subcommands,
+                            args: {
+                                generators: {
+                                    template: "filepaths",
+                                    filterTemplateSuggestions: function (suggestions) {
+                                        return suggestions.filter(function (suggestion) {
+                                            return (
+                                            // suggestion.name.endsWith(".php") ||
+                                            suggestion.name.indexOf(".") === -1);
+                                        });
+                                    },
+                                },
+                            },
+                        }];
+            }
         });
     }); },
-    subcommands: [{ name: "test1" }, { name: "test2" }],
-    // args: {
-    //   generators: {
-    //     template: "filepaths",
-    //     filterTemplateSuggestions: function (suggestions) {
-    //       return suggestions.filter((suggestion) => {
-    //         return (
-    //           // suggestion.name.endsWith(".php") ||
-    //           suggestion.name.indexOf(".") === -1
-    //         );
-    //       });
-    //     },
-    //   },
-    // },
 };
 
-// var completionSpec = {
-//   name: "php",
-//   description: "Run the PHP interpreter",
-//   },
-//   subcommands: [
-//     {
-//       name: "artisan",
-//       description: "",
-//       options: [],
-//       args: [
-//         {
-//           generators: {
-//             script: "php artisan list --format=json",
-//             postProcess: function (out) {
-//               if (out.trim() == "") {
-//                 return [];
-//               }
-//               try {
-//                 const commands = JSON.parse(out);
-//                 const artisanCommands = [];
-//                 commands.commands.map((command) => {
-//                   artisanCommands.push({
-//                     name: command.name,
-//                     description: command.description,
-//                     icon: "https://web.tinkerwell.app/img/laravel.3cab6a56.png",
-//                   });
-//                 });
-//                 return artisanCommands;
-//               } catch (e) {}
-//               return [];
-//             },
-//           },
-//         },
-//       ],
-//     },
-//   ],
-// };

--- a/specs/php/artisan.js
+++ b/specs/php/artisan.js
@@ -36,40 +36,54 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 var completionSpec = {
     name: "artisan",
-    description: "The stupid content tracker",
+    description: "Laravel Artisan Command",
     generateSpec: function (context, executeShellCommand) { return __awaiter(void 0, void 0, void 0, function () {
+        var out, subcommands, commandDefinition;
         return __generator(this, function (_a) {
-            if (true)
-                return [2 /*return*/, {
-                        name: "artisan",
-                        subcommands: [{ name: "abc" }, { name: "def" }],
-                    }];
-            return [2 /*return*/];
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, executeShellCommand("php artisan list --format=json")];
+                case 1:
+                    out = _a.sent();
+                    subcommands = [];
+                    try {
+                        commandDefinition = JSON.parse(out);
+                        commandDefinition.commands.map(function (command) {
+                            subcommands.push({
+                                name: command.name,
+                                description: command.description,
+                                icon: 'https://web.tinkerwell.app/img/laravel.3cab6a56.png',
+                                args: Object.keys(command.definition.arguments).map(function (argumentKey) {
+                                    var argument = command.definition.arguments[argumentKey];
+                                    return {
+                                        name: argument.name,
+                                        description: argument.description,
+                                        isOptional: !argument.is_required
+                                    };
+                                }),
+                                options: Object.keys(command.definition.options).map(function (optionKey) {
+                                    var option = command.definition.options[optionKey];
+                                    var names = [option.name];
+                                    if (option.shortcut !== '') {
+                                        names.push(option.shortcut);
+                                    }
+                                    return {
+                                        name: names,
+                                        description: option.description,
+                                    };
+                                })
+                            });
+                        });
+                    }
+                    catch (err) {
+                        //
+                    }
+                    return [2 /*return*/, {
+                            name: "artisan",
+                            debounce: true,
+                            subcommands: subcommands,
+                        }];
+            }
         });
     }); },
-    // subcommands: [
-    //   {
-    //     name: "checkout",
-    //     description: "Switch branches or restore working tree files",
-    //     // If a subcommand or option takes an argument, you must include the args prop, even if it's an empty object (like below)
-    //     // If you want to build custom suggestions for arguments check out: https://withfig.com/docs/autocomplete/building-a-spec#making-advanced-suggestions
-    //     args: {},
-    //     options: [
-    //       {
-    //         name: ["-b"],
-    //         description: "create and checkout a new branch",
-    //         args: {
-    //           name: "branch",
-    //         },
-    //       },
-    //     ],
-    //   },
-    // ],
-    // options: [
-    //   {
-    //     name: ["-v", "--version"],
-    //     description: "View your current git version",
-    //   },
-    // ],
 };
 


### PR DESCRIPTION
This PR adds a new Laravel artisan spec, that automatically parses all available Laravel commands, arguments, and options.

This spec only gets included when an `artisan` file exists in the current working directory.