### PR TITLE
[AWS] Add --secret-id generator to secret manager

### DIFF
--- a/dev/aws/secretsmanager.ts
+++ b/dev/aws/secretsmanager.ts
@@ -8,7 +8,7 @@ const generators: Record<string, Fig.Generator> = {
         const { SecretList = [] } = JSON.parse(out);
         return SecretList.map((item) => ({
           name: item.Name,
-          type: "option",
+          isDangerous: true,
         }));
       } catch (error) {
         console.error(error);
@@ -189,7 +189,6 @@ export const completionSpec: Fig.Spec = {
       name: "delete-secret",
       description:
         "Deletes an entire secret and all of the versions. You can optionally include a recovery window during which you can restore the secret. If you don't specify a recovery window value, the operation defaults to 30 days. Secrets Manager attaches a DeletionDate stamp to the secret that specifies the end of the recovery window. At the end of the recovery window, Secrets Manager deletes the secret permanently. At any time before recovery window ends, you can use RestoreSecret to remove the DeletionDate and cancel the deletion of the secret. You cannot access the encrypted secret information in any secret scheduled for deletion. If you need to access that information, you must cancel the deletion with RestoreSecret and then retrieve the information.    There is no explicit operation to delete a version of a secret. Instead, remove all staging labels from the VersionStage field of a version. That marks the version as deprecated and allows Secrets Manager to delete it as needed. Versions without any staging labels do not show up in ListSecretVersionIds unless you specify IncludeDeprecated.   The permanent secret deletion at the end of the waiting period is performed as a background task with low priority. There is no guarantee of a specific time after the recovery window for the actual delete operation to occur.     Minimum permissions  To run this command, you must have the following permissions:   secretsmanager:DeleteSecret    Related operations    To create a secret, use CreateSecret.   To cancel deletion of a version of a secret before the recovery window has expired, use RestoreSecret.",
-      isDangerous: true,
       options: [
         {
           name: "--secret-id",

--- a/dev/aws/secretsmanager.ts
+++ b/dev/aws/secretsmanager.ts
@@ -1,3 +1,23 @@
+const generators: Record<string, Fig.Generator> = {
+  secretIdsGenerator: {
+    // --page-size does not affect the number of items returned,
+    // just chunks request so it won't timeout
+    script: "aws secretsmanager list-secrets --sort-order asc --page-size 100",
+    postProcess: function (out) {
+      try {
+        const { SecretList = [] } = JSON.parse(out);
+        return SecretList.map((item) => ({
+          name: item.Name,
+          type: "option",
+        }));
+      } catch (error) {
+        console.error(error);
+      }
+      return [];
+    },
+  },
+};
+
 export const completionSpec: Fig.Spec = {
   name: "secretsmanager",
   description:
@@ -169,12 +189,14 @@ export const completionSpec: Fig.Spec = {
       name: "delete-secret",
       description:
         "Deletes an entire secret and all of the versions. You can optionally include a recovery window during which you can restore the secret. If you don't specify a recovery window value, the operation defaults to 30 days. Secrets Manager attaches a DeletionDate stamp to the secret that specifies the end of the recovery window. At the end of the recovery window, Secrets Manager deletes the secret permanently. At any time before recovery window ends, you can use RestoreSecret to remove the DeletionDate and cancel the deletion of the secret. You cannot access the encrypted secret information in any secret scheduled for deletion. If you need to access that information, you must cancel the deletion with RestoreSecret and then retrieve the information.    There is no explicit operation to delete a version of a secret. Instead, remove all staging labels from the VersionStage field of a version. That marks the version as deprecated and allows Secrets Manager to delete it as needed. Versions without any staging labels do not show up in ListSecretVersionIds unless you specify IncludeDeprecated.   The permanent secret deletion at the end of the waiting period is performed as a background task with low priority. There is no guarantee of a specific time after the recovery window for the actual delete operation to occur.     Minimum permissions  To run this command, you must have the following permissions:   secretsmanager:DeleteSecret    Related operations    To create a secret, use CreateSecret.   To cancel deletion of a version of a secret before the recovery window has expired, use RestoreSecret.",
+      isDangerous: true,
       options: [
         {
           name: "--secret-id",
           description:
             "Specifies the secret to delete. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.  If you specify an ARN, we generally recommend that you specify a complete ARN. You can specify a partial ARN too\u2014for example, if you don\u2019t include the final hyphen and six random characters that Secrets Manager adds at the end of the ARN when you created the secret. A partial ARN match can work as long as it uniquely matches only one secret. However, if your secret has a name that ends in a hyphen followed by six characters (before Secrets Manager adds the hyphen and six characters to the ARN) and you try to use that as a partial ARN, then those characters cause Secrets Manager to assume that you\u2019re specifying a complete ARN. This confusion can cause unexpected results. To avoid this situation, we recommend that you don\u2019t create secret names ending with a hyphen followed by six characters. If you specify an incomplete ARN without the random suffix, and instead provide the 'friendly name', you must not include the random suffix. If you do include the random suffix added by Secrets Manager, you receive either a ResourceNotFoundException or an AccessDeniedException error, depending on your permissions.",
           args: {
+            generators: generators.secretIdsGenerator,
             name: "string",
           },
         },

--- a/specs/aws/secretsmanager.js
+++ b/specs/aws/secretsmanager.js
@@ -1,3 +1,23 @@
+var generators = {
+    secretIdsGenerator: {
+        // --page-size does not affect the number of items returned,
+        // just chunks request so it won't timeout
+        script: "aws secretsmanager list-secrets --sort-order asc --page-size 100",
+        postProcess: function (out) {
+            try {
+                var _a = JSON.parse(out).SecretList, SecretList = _a === void 0 ? [] : _a;
+                return SecretList.map(function (item) { return ({
+                    name: item.Name,
+                    type: "option",
+                }); });
+            }
+            catch (error) {
+                console.error(error);
+            }
+            return [];
+        },
+    },
+};
 var completionSpec = {
     name: "secretsmanager",
     description: "AWS Secrets Manager API Reference AWS Secrets Manager provides a service to enable you to store, manage, and retrieve, secrets. This guide provides descriptions of the Secrets Manager API. For more information about using this service, see the AWS Secrets Manager User Guide.  API Version  This version of the Secrets Manager API Reference documents the Secrets Manager API version 2017-10-17.  As an alternative to using the API, you can use one of the AWS SDKs, which consist of libraries and sample code for various programming languages and platforms such as Java, Ruby, .NET, iOS, and Android. The SDKs provide a convenient way to create programmatic access to AWS Secrets Manager. For example, the SDKs provide cryptographically signing requests, managing errors, and retrying requests automatically. For more information about the AWS SDKs, including downloading and installing them, see Tools for Amazon Web Services.  We recommend you use the AWS SDKs to make programmatic API calls to Secrets Manager. However, you also can use the Secrets Manager HTTP Query API to make direct calls to the Secrets Manager web service. To learn more about the Secrets Manager HTTP Query API, see Making Query Requests in the AWS Secrets Manager User Guide.  Secrets Manager API supports GET and POST requests for all actions, and doesn't require you to use GET for some actions and POST for others. However, GET requests are subject to the limitation size of a URL. Therefore, for operations that require larger sizes, use a POST request.  Support and Feedback for AWS Secrets Manager  We welcome your feedback. Send your comments to awssecretsmanager-feedback@amazon.com, or post your feedback and questions in the AWS Secrets Manager Discussion Forum. For more information about the AWS Discussion Forums, see Forums Help.  How examples are presented  The JSON that AWS Secrets Manager expects as your request parameters and the service returns as a response to HTTP query requests contain single, long strings without line breaks or white space formatting. The JSON shown in the examples displays the code formatted with both line breaks and white space to improve readability. When example input parameters can also cause long strings extending beyond the screen, you can insert line breaks to enhance readability. You should always submit the input as a single JSON text string.  Logging API Requests  AWS Secrets Manager supports AWS CloudTrail, a service that records AWS API calls for your AWS account and delivers log files to an Amazon S3 bucket. By using information that's collected by AWS CloudTrail, you can determine the requests successfully made to Secrets Manager, who made the request, when it was made, and so on. For more about AWS Secrets Manager and support for AWS CloudTrail, see Logging AWS Secrets Manager Events with AWS CloudTrail in the AWS Secrets Manager User Guide. To learn more about CloudTrail, including enabling it and find your log files, see the AWS CloudTrail User Guide.",
@@ -146,11 +166,13 @@ var completionSpec = {
         {
             name: "delete-secret",
             description: "Deletes an entire secret and all of the versions. You can optionally include a recovery window during which you can restore the secret. If you don't specify a recovery window value, the operation defaults to 30 days. Secrets Manager attaches a DeletionDate stamp to the secret that specifies the end of the recovery window. At the end of the recovery window, Secrets Manager deletes the secret permanently. At any time before recovery window ends, you can use RestoreSecret to remove the DeletionDate and cancel the deletion of the secret. You cannot access the encrypted secret information in any secret scheduled for deletion. If you need to access that information, you must cancel the deletion with RestoreSecret and then retrieve the information.    There is no explicit operation to delete a version of a secret. Instead, remove all staging labels from the VersionStage field of a version. That marks the version as deprecated and allows Secrets Manager to delete it as needed. Versions without any staging labels do not show up in ListSecretVersionIds unless you specify IncludeDeprecated.   The permanent secret deletion at the end of the waiting period is performed as a background task with low priority. There is no guarantee of a specific time after the recovery window for the actual delete operation to occur.     Minimum permissions  To run this command, you must have the following permissions:   secretsmanager:DeleteSecret    Related operations    To create a secret, use CreateSecret.   To cancel deletion of a version of a secret before the recovery window has expired, use RestoreSecret.",
+            isDangerous: true,
             options: [
                 {
                     name: "--secret-id",
                     description: "Specifies the secret to delete. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.  If you specify an ARN, we generally recommend that you specify a complete ARN. You can specify a partial ARN too\u2014for example, if you don\u2019t include the final hyphen and six random characters that Secrets Manager adds at the end of the ARN when you created the secret. A partial ARN match can work as long as it uniquely matches only one secret. However, if your secret has a name that ends in a hyphen followed by six characters (before Secrets Manager adds the hyphen and six characters to the ARN) and you try to use that as a partial ARN, then those characters cause Secrets Manager to assume that you\u2019re specifying a complete ARN. This confusion can cause unexpected results. To avoid this situation, we recommend that you don\u2019t create secret names ending with a hyphen followed by six characters. If you specify an incomplete ARN without the random suffix, and instead provide the 'friendly name', you must not include the random suffix. If you do include the random suffix added by Secrets Manager, you receive either a ResourceNotFoundException or an AccessDeniedException error, depending on your permissions.",
                     args: {
+                        generators: generators.secretIdsGenerator,
                         name: "string",
                     },
                 },

--- a/specs/aws/secretsmanager.js
+++ b/specs/aws/secretsmanager.js
@@ -8,7 +8,7 @@ var generators = {
                 var _a = JSON.parse(out).SecretList, SecretList = _a === void 0 ? [] : _a;
                 return SecretList.map(function (item) { return ({
                     name: item.Name,
-                    type: "option",
+                    isDangerous: true,
                 }); });
             }
             catch (error) {
@@ -166,7 +166,6 @@ var completionSpec = {
         {
             name: "delete-secret",
             description: "Deletes an entire secret and all of the versions. You can optionally include a recovery window during which you can restore the secret. If you don't specify a recovery window value, the operation defaults to 30 days. Secrets Manager attaches a DeletionDate stamp to the secret that specifies the end of the recovery window. At the end of the recovery window, Secrets Manager deletes the secret permanently. At any time before recovery window ends, you can use RestoreSecret to remove the DeletionDate and cancel the deletion of the secret. You cannot access the encrypted secret information in any secret scheduled for deletion. If you need to access that information, you must cancel the deletion with RestoreSecret and then retrieve the information.    There is no explicit operation to delete a version of a secret. Instead, remove all staging labels from the VersionStage field of a version. That marks the version as deprecated and allows Secrets Manager to delete it as needed. Versions without any staging labels do not show up in ListSecretVersionIds unless you specify IncludeDeprecated.   The permanent secret deletion at the end of the waiting period is performed as a background task with low priority. There is no guarantee of a specific time after the recovery window for the actual delete operation to occur.     Minimum permissions  To run this command, you must have the following permissions:   secretsmanager:DeleteSecret    Related operations    To create a secret, use CreateSecret.   To cancel deletion of a version of a secret before the recovery window has expired, use RestoreSecret.",
-            isDangerous: true,
             options: [
                 {
                     name: "--secret-id",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Add generator to suggest value for AWS Secret Manager's --secret-id flag

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**
Autocomplete lists available secrets for AWS Secret Manager's --secret-id flag

**Additional info:**