### PR TITLE
[YARN]: Load specs of cli that exists in current package

### DIFF
--- a/dev/yarn.ts
+++ b/dev/yarn.ts
@@ -121,6 +121,30 @@ const configList: Fig.Generator = {
 export const completionSpec: Fig.Spec = {
   name: "yarn",
   description: "Manage packages and run scripts",
+  generateSpec: async (context, executeShellCommand) => {
+    const { script, postProcess } = packageList;
+    const packages = postProcess(
+      await executeShellCommand(script as string)
+    ).map(({ name }) => name as string);
+
+    const cli = ["vue", "nuxt", "expo", "jest", "next"];
+    const subcommands: Fig.Subcommand[] = [];
+
+    packages
+      .filter((name) => cli.includes(name))
+      .forEach((name) => {
+        subcommands.push({
+          name,
+          loadSpec: name,
+          icon: "fig://icon?type=package",
+        });
+      });
+
+    return {
+      name: "yarn",
+      subcommands,
+    } as Fig.Spec;
+  },
   args: [
     {
       generators: getScriptsGenerator,

--- a/dev/yarn.ts
+++ b/dev/yarn.ts
@@ -121,7 +121,7 @@ const configList: Fig.Generator = {
 export const completionSpec: Fig.Spec = {
   name: "yarn",
   description: "Manage packages and run scripts",
-  generateSpec: async (context, executeShellCommand) => {
+  generateSpec: async (_context, executeShellCommand) => {
     const { script, postProcess } = packageList;
     const packages = postProcess(
       await executeShellCommand(script as string)

--- a/dev/yarn.ts
+++ b/dev/yarn.ts
@@ -128,17 +128,13 @@ export const completionSpec: Fig.Spec = {
     ).map(({ name }) => name as string);
 
     const cli = ["vue", "nuxt", "expo", "jest", "next"];
-    const subcommands: Fig.Subcommand[] = [];
-
-    packages
+    const subcommands = packages
       .filter((name) => cli.includes(name))
-      .forEach((name) => {
-        subcommands.push({
-          name,
-          loadSpec: name,
-          icon: "fig://icon?type=package",
-        });
-      });
+      .map((name) => ({
+        name,
+        loadSpec: name,
+        icon: "fig://icon?type=package",
+      }));
 
     return {
       name: "yarn",

--- a/specs/yarn.js
+++ b/specs/yarn.js
@@ -9,6 +9,42 @@ var __assign = (this && this.__assign) || function () {
     };
     return __assign.apply(this, arguments);
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 var __spreadArray = (this && this.__spreadArray) || function (to, from) {
     for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
         to[j] = from[i];
@@ -111,6 +147,37 @@ var configList = {
 var completionSpec = {
     name: "yarn",
     description: "Manage packages and run scripts",
+    generateSpec: function (context, executeShellCommand) { return __awaiter(void 0, void 0, void 0, function () {
+        var script, postProcess, packages, _a, cli, subcommands;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    script = packageList.script, postProcess = packageList.postProcess;
+                    _a = postProcess;
+                    return [4 /*yield*/, executeShellCommand(script)];
+                case 1:
+                    packages = _a.apply(void 0, [_b.sent()]).map(function (_a) {
+                        var name = _a.name;
+                        return name;
+                    });
+                    cli = ["vue", "nuxt", "expo", "jest", "next"];
+                    subcommands = [];
+                    packages
+                        .filter(function (name) { return cli.includes(name); })
+                        .forEach(function (name) {
+                        subcommands.push({
+                            name: name,
+                            loadSpec: name,
+                            icon: "fig://icon?type=package",
+                        });
+                    });
+                    return [2 /*return*/, {
+                            name: "yarn",
+                            subcommands: subcommands,
+                        }];
+            }
+        });
+    }); },
     args: [
         {
             generators: getScriptsGenerator,

--- a/specs/yarn.js
+++ b/specs/yarn.js
@@ -147,7 +147,7 @@ var configList = {
 var completionSpec = {
     name: "yarn",
     description: "Manage packages and run scripts",
-    generateSpec: function (context, executeShellCommand) { return __awaiter(void 0, void 0, void 0, function () {
+    generateSpec: function (_context, executeShellCommand) { return __awaiter(void 0, void 0, void 0, function () {
         var script, postProcess, packages, _a, cli, subcommands;
         return __generator(this, function (_b) {
             switch (_b.label) {
@@ -161,16 +161,13 @@ var completionSpec = {
                         return name;
                     });
                     cli = ["vue", "nuxt", "expo", "jest", "next"];
-                    subcommands = [];
-                    packages
+                    subcommands = packages
                         .filter(function (name) { return cli.includes(name); })
-                        .forEach(function (name) {
-                        subcommands.push({
-                            name: name,
-                            loadSpec: name,
-                            icon: "fig://icon?type=package",
-                        });
-                    });
+                        .map(function (name) { return ({
+                        name: name,
+                        loadSpec: name,
+                        icon: "fig://icon?type=package",
+                    }); });
                     return [2 /*return*/, {
                             name: "yarn",
                             subcommands: subcommands,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This PR adds a new feature to the `yarn` spec

**What is the current behavior? (You can also link to an open issue here)**
Currently, if you want to run a cli from yarn using `yarn <cli> ...`, you won't get any completion

**What is the new behavior (if this is a feature change)?**
Fig loads the specs of the cli that are in the current `package.json` and provide completion for them

**Additional info:**
Example:
The `next` package exists in the current `package.json`, so the spec for it will be loaded.
![Screenshot 2021-05-01 at 11 31 10](https://user-images.githubusercontent.com/43268759/116778184-bbdfd680-aa70-11eb-80b2-59cd5baae23e.png)
![Screenshot 2021-05-01 at 11 32 03](https://user-images.githubusercontent.com/43268759/116778216-db76ff00-aa70-11eb-8e6a-ed82fa99349c.png)