### PR TITLE
[CUT] Add spec for cut

### DIFF
--- a/dev/cut.ts
+++ b/dev/cut.ts
@@ -1,0 +1,76 @@
+export const completionSpec: Fig.Spec = {
+  name: "cut",
+  description: "cut out selected portions of each line of a file",
+  args: {
+    template: "filepaths",
+    isOptional: true,
+    variadic: true,
+  },
+  subcommands: [
+    {
+      name: ["-b"],
+      description: "byte positions as a comma or - separated list of numbers",
+      args: [
+        {
+          name: "list",
+          description: "specifies byte positions",
+        },
+        {
+          name: "-n",
+          description: "do not split multi-byte characters",
+          isOptional: true,
+        },
+        {
+          name: "file",
+          template: "filepaths",
+          isOptional: true,
+          variadic: true,
+        },
+      ],
+    },
+    {
+      name: ["-c"],
+      description: "column positions as a comma or - separated list of numbers",
+      args: [
+        {
+          name: "list",
+          description: "specifies column positions",
+        },
+        {
+          name: "file",
+          template: "filepaths",
+          isOptional: true,
+          variadic: true,
+        },
+      ],
+    },
+    {
+      name: ["-f"],
+      description: "field positions as a comma or - separated list of numbers",
+      args: [
+        {
+          name: "list",
+          description: "specifies column positions",
+        },
+        {
+          name: "-d",
+          description:
+            "use delim as the field delimiter character instead of the tab character.",
+          isOptional: true,
+        },
+        {
+          name: "-s",
+          description:
+            "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
+          isOptional: true,
+        },
+        {
+          name: "file",
+          template: "filepaths",
+          isOptional: true,
+          variadic: true,
+        },
+      ],
+    },
+  ],
+};

--- a/dev/cut.ts
+++ b/dev/cut.ts
@@ -20,12 +20,6 @@ export const completionSpec: Fig.Spec = {
           description: "do not split multi-byte characters",
           isOptional: true,
         },
-        {
-          name: "file",
-          template: "filepaths",
-          isOptional: true,
-          variadic: true,
-        },
       ],
     },
     {
@@ -36,16 +30,10 @@ export const completionSpec: Fig.Spec = {
           name: "list",
           description: "specifies column positions",
         },
-        {
-          name: "file",
-          template: "filepaths",
-          isOptional: true,
-          variadic: true,
-        },
       ],
     },
     {
-      name: ["-f"],
+      name: "-f",
       description: "field positions as a comma or - separated list of numbers",
       args: [
         {
@@ -63,12 +51,6 @@ export const completionSpec: Fig.Spec = {
           description:
             "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
           isOptional: true,
-        },
-        {
-          name: "file",
-          template: "filepaths",
-          isOptional: true,
-          variadic: true,
         },
       ],
     },

--- a/dev/cut.ts
+++ b/dev/cut.ts
@@ -6,9 +6,9 @@ export const completionSpec: Fig.Spec = {
     isOptional: true,
     variadic: true,
   },
-  subcommands: [
+  options: [
     {
-      name: ["-b"],
+      name: "-b",
       description: "byte positions as a comma or - separated list of numbers",
       args: [
         {
@@ -29,7 +29,7 @@ export const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["-c"],
+      name: "-c",
       description: "column positions as a comma or - separated list of numbers",
       args: [
         {

--- a/dev/cut.ts
+++ b/dev/cut.ts
@@ -15,11 +15,6 @@ export const completionSpec: Fig.Spec = {
           name: "list",
           description: "specifies byte positions",
         },
-        {
-          name: "-n",
-          description: "do not split multi-byte characters",
-          isOptional: true,
-        },
       ],
     },
     {
@@ -40,19 +35,28 @@ export const completionSpec: Fig.Spec = {
           name: "list",
           description: "specifies column positions",
         },
+      ],
+    },
+    {
+      name: "-n",
+      description: "do not split multi-byte characters",
+    },
+    {
+      name: "-d",
+      description:
+        "use delim as the field delimiter character instead of the tab character.",
+      args: [
         {
-          name: "-d",
-          description:
-            "use delim as the field delimiter character instead of the tab character.",
-          isOptional: true,
-        },
-        {
-          name: "-s",
-          description:
-            "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
+          name: "delim",
+          description: "field deliminator to use instead of the tab character",
           isOptional: true,
         },
       ],
+    },
+    {
+      name: "-s",
+      description:
+        "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
     },
   ],
 };

--- a/specs/cut.js
+++ b/specs/cut.js
@@ -6,42 +6,42 @@ var completionSpec = {
         isOptional: true,
         variadic: true,
     },
-    subcommands: [
+    options: [
         {
-            name: ["-b"],
+            name: "-b",
             description: "byte positions as a comma or - separated list of numbers",
             args: [
                 {
                     name: "list",
-                    description: "specifies byte positions"
-                },
-                {
-                    name: "file",
-                    template: "filepaths",
-                    isOptional: true,
-                    variadic: true,
+                    description: "specifies byte positions",
                 },
                 {
                     name: "-n",
                     description: "do not split multi-byte characters",
                     isOptional: true,
                 },
+                {
+                    name: "file",
+                    template: "filepaths",
+                    isOptional: true,
+                    variadic: true,
+                },
             ],
         },
         {
-            name: ["-c"],
+            name: "-c",
             description: "column positions as a comma or - separated list of numbers",
             args: [
                 {
                     name: "list",
-                    description: "specifies column positions"
+                    description: "specifies column positions",
                 },
                 {
                     name: "file",
                     template: "filepaths",
                     isOptional: true,
                     variadic: true,
-                }
+                },
             ],
         },
         {
@@ -50,7 +50,7 @@ var completionSpec = {
             args: [
                 {
                     name: "list",
-                    description: "specifies column positions"
+                    description: "specifies column positions",
                 },
                 {
                     name: "-d",
@@ -58,15 +58,15 @@ var completionSpec = {
                     isOptional: true,
                 },
                 {
+                    name: "-s",
+                    description: "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
+                    isOptional: true,
+                },
+                {
                     name: "file",
                     template: "filepaths",
                     isOptional: true,
                     variadic: true,
-                },
-                {
-                    name: "-s",
-                    description: "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
-                    isOptional: true,
                 },
             ],
         },

--- a/specs/cut.js
+++ b/specs/cut.js
@@ -15,11 +15,6 @@ var completionSpec = {
                     name: "list",
                     description: "specifies byte positions",
                 },
-                {
-                    name: "-n",
-                    description: "do not split multi-byte characters",
-                    isOptional: true,
-                },
             ],
         },
         {
@@ -40,17 +35,26 @@ var completionSpec = {
                     name: "list",
                     description: "specifies column positions",
                 },
-                {
-                    name: "-d",
-                    description: "use delim as the field delimiter character instead of the tab character.",
-                    isOptional: true,
-                },
-                {
-                    name: "-s",
-                    description: "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
-                    isOptional: true,
-                },
             ],
+        },
+        {
+            name: "-n",
+            description: "do not split multi-byte characters",
+        },
+        {
+            name: "-d",
+            description: "use delim as the field delimiter character instead of the tab character.",
+            args: [
+                {
+                    name: "delim",
+                    description: "field deliminator to use instead of the tab character",
+                    isOptional: true,
+                }
+            ],
+        },
+        {
+            name: "-s",
+            description: "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
         },
     ],
 };

--- a/specs/cut.js
+++ b/specs/cut.js
@@ -1,0 +1,75 @@
+var completionSpec = {
+    name: "cut",
+    description: "cut out selected portions of each line of a file",
+    args: {
+        template: "filepaths",
+        isOptional: true,
+        variadic: true,
+    },
+    subcommands: [
+        {
+            name: ["-b"],
+            description: "byte positions as a comma or - separated list of numbers",
+            args: [
+                {
+                    name: "list",
+                    description: "specifies byte positions"
+                },
+                {
+                    name: "file",
+                    template: "filepaths",
+                    isOptional: true,
+                    variadic: true,
+                },
+                {
+                    name: "-n",
+                    description: "do not split multi-byte characters",
+                    isOptional: true,
+                },
+            ],
+        },
+        {
+            name: ["-c"],
+            description: "column positions as a comma or - separated list of numbers",
+            args: [
+                {
+                    name: "list",
+                    description: "specifies column positions"
+                },
+                {
+                    name: "file",
+                    template: "filepaths",
+                    isOptional: true,
+                    variadic: true,
+                }
+            ],
+        },
+        {
+            name: ["-f"],
+            description: "field positions as a comma or - separated list of numbers",
+            args: [
+                {
+                    name: "list",
+                    description: "specifies column positions"
+                },
+                {
+                    name: "-d",
+                    description: "use delim as the field delimiter character instead of the tab character.",
+                    isOptional: true,
+                },
+                {
+                    name: "file",
+                    template: "filepaths",
+                    isOptional: true,
+                    variadic: true,
+                },
+                {
+                    name: "-s",
+                    description: "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
+                    isOptional: true,
+                },
+            ],
+        },
+    ],
+};
+

--- a/specs/cut.js
+++ b/specs/cut.js
@@ -20,12 +20,6 @@ var completionSpec = {
                     description: "do not split multi-byte characters",
                     isOptional: true,
                 },
-                {
-                    name: "file",
-                    template: "filepaths",
-                    isOptional: true,
-                    variadic: true,
-                },
             ],
         },
         {
@@ -36,16 +30,10 @@ var completionSpec = {
                     name: "list",
                     description: "specifies column positions",
                 },
-                {
-                    name: "file",
-                    template: "filepaths",
-                    isOptional: true,
-                    variadic: true,
-                },
             ],
         },
         {
-            name: ["-f"],
+            name: "-f",
             description: "field positions as a comma or - separated list of numbers",
             args: [
                 {
@@ -61,12 +49,6 @@ var completionSpec = {
                     name: "-s",
                     description: "suppress lines with no field delimiter characters.  unless specified, lines with no delimiters are passed through unmodified.",
                     isOptional: true,
-                },
-                {
-                    name: "file",
-                    template: "filepaths",
-                    isOptional: true,
-                    variadic: true,
                 },
             ],
         },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds specs for the cut command
**What is the current behavior? (You can also link to an open issue here)**
No specs exist for the cut command
**What is the new behavior (if this is a feature change)?**
cut command autocompletion is enabled
**Additional info:**
<img width="413" alt="Screenshot 2021-05-05 at 1 23 59 PM" src="https://user-images.githubusercontent.com/811817/117112474-bb17af00-ada6-11eb-9ac6-3c6e0bc2268f.png">
