### PR TITLE
[GIT] Add commit to `checkout` name and description 

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -2404,8 +2404,8 @@ export const completionSpec: Fig.Spec = {
         { name: ["-p", "--patch"], description: "select hunks interactively" },
       ],
       args: {
-        name: "branch or file",
-        description: "branch to switch to or file to restore",
+        name: "branch or commit",
+        description: "branch or commit to switch to",
         isOptional: true,
         generators: gitGenerators.branches,
         suggestions: [

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -2404,8 +2404,8 @@ export const completionSpec: Fig.Spec = {
         { name: ["-p", "--patch"], description: "select hunks interactively" },
       ],
       args: {
-        name: "branch",
-        description: "branch to switch to",
+        name: "branch or file",
+        description: "branch to switch to or file to restore",
         isOptional: true,
         generators: gitGenerators.branches,
         suggestions: [

--- a/specs/git.js
+++ b/specs/git.js
@@ -2176,8 +2176,8 @@ var completionSpec = {
                 { name: ["-p", "--patch"], description: "select hunks interactively" },
             ],
             args: {
-                name: "branch or file",
-                description: "branch to switch to or file to restore",
+                name: "branch or commit",
+                description: "branch or commit to switch to",
                 isOptional: true,
                 generators: gitGenerators.branches,
                 suggestions: [

--- a/specs/git.js
+++ b/specs/git.js
@@ -2176,8 +2176,8 @@ var completionSpec = {
                 { name: ["-p", "--patch"], description: "select hunks interactively" },
             ],
             args: {
-                name: "branch",
-                description: "branch to switch to",
+                name: "branch or file",
+                description: "branch to switch to or file to restore",
                 isOptional: true,
                 generators: gitGenerators.branches,
                 suggestions: [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
FIX - git checkout command can be used to restore files from the working tree and checkout branches
**What is the current behavior? (You can also link to an open issue here)**
Current autocompletion only documents the branch
**What is the new behavior (if this is a feature change)?**
Added description to talk about the file checkout too
**Additional info:**