### PR TITLE
[WIP] - Terraform Taint subcommand specs

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -2404,8 +2404,8 @@ export const completionSpec: Fig.Spec = {
         { name: ["-p", "--patch"], description: "select hunks interactively" },
       ],
       args: {
-        name: "branch or file",
-        description: "branch to switch to or file to restore",
+        name: "branch or commit",
+        description: "branch or commit to switch to",
         isOptional: true,
         generators: gitGenerators.branches,
         suggestions: [

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -2404,8 +2404,8 @@ export const completionSpec: Fig.Spec = {
         { name: ["-p", "--patch"], description: "select hunks interactively" },
       ],
       args: {
-        name: "branch",
-        description: "branch to switch to",
+        name: "branch or file",
+        description: "branch to switch to or file to restore",
         isOptional: true,
         generators: gitGenerators.branches,
         suggestions: [

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -2404,8 +2404,8 @@ export const completionSpec: Fig.Spec = {
         { name: ["-p", "--patch"], description: "select hunks interactively" },
       ],
       args: {
-        name: "branch or commit",
-        description: "branch or commit to switch to",
+        name: "branch",
+        description: "branch to switch to",
         isOptional: true,
         generators: gitGenerators.branches,
         suggestions: [

--- a/dev/terraform.ts
+++ b/dev/terraform.ts
@@ -1,0 +1,90 @@
+const addressList: Fig.Generator = {
+  script: "terraform state list",
+  postProcess: function (out) {
+    if (out.includes("No state file was found!") || out.includes("Error")) {
+      return [];
+    }
+    return out.split("\n").map((addresses) => {
+      return {
+        name: addresses.replace("* ", "").trim(),
+        icon: "fig://icon?type=terraform",
+        description: "workspace",
+      };
+    });
+  },
+};
+
+const globalOptions: Fig.Option[] = [
+  {
+    name: "-help",
+    description:
+      "Show this help output, or the help for a specified subcommand.",
+  },
+  {
+    name: "-chdir",
+    description:
+      "Switch to a different working directory before executing the given subcommand.",
+    insertValue: "-chdir=",
+    args: {
+      template: "filepaths",
+    },
+  },
+  {
+    name: "-version",
+    description: "Show the current Terraform version",
+  },
+];
+
+export const completionSpec: Fig.Spec = {
+  name: "terraform",
+  description: "Terraform CLI",
+  options: globalOptions,
+  posixNoncompliantFlags: true,
+  subcommands: [
+    {
+      name: "taint",
+      description:
+        "command informs Terraform that a particular object has become degraded or damaged.",
+      options: [
+        {
+          name: "-allow-missing",
+          description:
+            "If specified, the command will succeed (exit code 0) even if the resource is missing. The command might still return an error for other situations, such as if there is a problem reading or writing the state.",
+        },
+        {
+          name: "-lock",
+          insertValue: "-lock=",
+          description:
+            "Disables Terraform's default behavior of attempting to take a read/write lock on the state for the duration of the operation if set to false. Defaults to true.",
+          args: {
+            name: "true or false",
+            suggestions: ["true", "false"],
+          },
+        },
+        {
+          name: "-lock-timeout",
+          insertValue: "-lock-timeout=",
+          description:
+            "Unless locking is disabled with -lock=false, instructs Terraform to retry acquiring a lock for a period of time before returning an error. The duration syntax is a number followed by a time unit letter, such as 3s for three seconds.",
+          args: {
+            name: "seconds",
+          },
+        },
+        {
+          name: "-ignore-remote-version",
+          insertValue: "-ignore-remote-version",
+          description:
+            "When using the enhanced remote backend with Terraform Cloud, continue even if remote and local Terraform versions differ. This may result in an unusable Terraform Cloud workspace, and should be used with extreme caution.",
+          args: {
+            name: "seconds",
+          },
+        },
+        ...globalOptions,
+      ],
+      args: {
+        generators: addressList,
+        name: "address",
+      },
+    },
+  ],
+};

--- a/specs/git.js
+++ b/specs/git.js
@@ -2176,8 +2176,8 @@ var completionSpec = {
                 { name: ["-p", "--patch"], description: "select hunks interactively" },
             ],
             args: {
-                name: "branch or file",
-                description: "branch to switch to or file to restore",
+                name: "branch or commit",
+                description: "branch or commit to switch to",
                 isOptional: true,
                 generators: gitGenerators.branches,
                 suggestions: [

--- a/specs/git.js
+++ b/specs/git.js
@@ -2176,8 +2176,8 @@ var completionSpec = {
                 { name: ["-p", "--patch"], description: "select hunks interactively" },
             ],
             args: {
-                name: "branch",
-                description: "branch to switch to",
+                name: "branch or file",
+                description: "branch to switch to or file to restore",
                 isOptional: true,
                 generators: gitGenerators.branches,
                 suggestions: [

--- a/specs/terraform.js
+++ b/specs/terraform.js
@@ -1,0 +1,86 @@
+var __spreadArray = (this && this.__spreadArray) || function (to, from) {
+    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
+        to[j] = from[i];
+    return to;
+};
+var addressList = {
+    script: "terraform state list",
+    postProcess: function (out) {
+        if (out.includes("No state file was found!") || out.includes("Error")) {
+            return [];
+        }
+        return out.split("\n").map(function (addresses) {
+            return {
+                name: addresses.replace("* ", "").trim(),
+                icon: "fig://icon?type=terraform",
+                description: "workspace",
+            };
+        });
+    },
+};
+var globalOptions = [
+    {
+        name: "-help",
+        description: "Show this help output, or the help for a specified subcommand.",
+    },
+    {
+        name: "-chdir",
+        description: "Switch to a different working directory before executing the given subcommand.",
+        insertValue: "-chdir=",
+        args: {
+            template: "filepaths",
+        },
+    },
+    {
+        name: "-version",
+        description: "Show the current Terraform version",
+    },
+];
+var completionSpec = {
+    name: "terraform",
+    description: "Terraform CLI",
+    options: globalOptions,
+    posixNoncompliantFlags: true,
+    subcommands: [
+        {
+            name: "taint",
+            description: "command informs Terraform that a particular object has become degraded or damaged.",
+            options: __spreadArray([
+                {
+                    name: "-allow-missing",
+                    description: "If specified, the command will succeed (exit code 0) even if the resource is missing. The command might still return an error for other situations, such as if there is a problem reading or writing the state.",
+                },
+                {
+                    name: "-lock",
+                    insertValue: "-lock=",
+                    description: "Disables Terraform's default behavior of attempting to take a read/write lock on the state for the duration of the operation if set to false. Defaults to true.",
+                    args: {
+                        name: "true or false",
+                        suggestions: ["true", "false"],
+                    },
+                },
+                {
+                    name: "-lock-timeout",
+                    insertValue: "-lock-timeout=",
+                    description: "Unless locking is disabled with -lock=false, instructs Terraform to retry acquiring a lock for a period of time before returning an error. The duration syntax is a number followed by a time unit letter, such as 3s for three seconds.",
+                    args: {
+                        name: "seconds",
+                    },
+                },
+                {
+                    name: "-ignore-remote-version",
+                    insertValue: "-ignore-remote-version",
+                    description: "When using the enhanced remote backend with Terraform Cloud, continue even if remote and local Terraform versions differ. This may result in an unusable Terraform Cloud workspace, and should be used with extreme caution.",
+                    args: {
+                        name: "seconds",
+                    },
+                }
+            ], globalOptions),
+            args: {
+                generators: addressList,
+                name: "address",
+            },
+        },
+    ],
+};
+


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds the terraform taint command specs to fig
**What is the current behavior? (You can also link to an open issue here)**
Command doesn't exist in specs
**What is the new behavior (if this is a feature change)?**
Autocomplete is now enabled for terraform taint
**Additional info:**
<img width="400" alt="Screenshot 2021-05-08 at 12 35 47 AM" src="https://user-images.githubusercontent.com/811817/117497174-ba913b00-af95-11eb-9041-4b0f1ce815a0.png">
<img width="412" alt="Screenshot 2021-05-08 at 12 35 26 AM" src="https://user-images.githubusercontent.com/811817/117497177-bcf39500-af95-11eb-8350-095f017fb11d.png">
<img width="475" alt="Screenshot 2021-05-08 at 12 35 16 AM" src="https://user-images.githubusercontent.com/811817/117497181-be24c200-af95-11eb-92d1-285eb27fc020.png">
