### PR TITLE
[BREW] Add analytics subcommand

### DIFF
--- a/dev/brew.ts
+++ b/dev/brew.ts
@@ -235,6 +235,20 @@ export const completionSpec: Fig.Spec = {
         },
       ],
     },
+    {
+      name: "analytics",
+      description: "Manages analytics preferences",
+      subcommands: [
+        {
+          name: "on",
+          description: "Turns on analytics",
+        },
+        {
+          name: "off",
+          description: "Turns off analytics",
+        },
+      ],
+    },
   ],
   options: [
     {

--- a/specs/brew.js
+++ b/specs/brew.js
@@ -228,12 +228,10 @@ var completionSpec = {
             subcommands: [
                 {
                     name: "on",
-                    insertValue: "on",
                     description: "Turns on analytics",
                 },
                 {
                     name: "off",
-                    insertValue: "off",
                     description: "Turns off analytics",
                 },
             ],

--- a/specs/brew.js
+++ b/specs/brew.js
@@ -222,6 +222,22 @@ var completionSpec = {
                 },
             ],
         },
+        {
+            name: "analytics",
+            description: "Manages analytics preferences",
+            subcommands: [
+                {
+                    name: "on",
+                    insertValue: "on",
+                    description: "Turns on analytics",
+                },
+                {
+                    name: "off",
+                    insertValue: "off",
+                    description: "Turns off analytics",
+                },
+            ],
+        },
     ],
     options: [
         {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

I added the `brew analytics <on|off>` command to Fig autocomplete specs. People like to turn the analytics off for privacy reasons.

**What is the current behavior? (You can also link to an open issue here)**

Fig `brew` autocomplete does not list this subcommand.

**What is the new behavior (if this is a feature change)?**

Fig will show the autocomplete for the following:

- `brew analytics`
- `brew analytics on`
- `brew analytics off`

**Additional info:**

N/A