### PR TITLE
feat: add specs folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 .env
 .idea/
 .vscode
+specs


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
Contributors need to check in their newly created `.js` files in as well

**What is the new behavior (if this is a feature change)?**
New PRs only have to include the `.ts` file

**Additional info:**
The files are still in git for compatibility with old versions of Fig