### PR TITLE
[INTERNAL] feat: update no-empty-array-values rule

### DIFF
--- a/scripts/eslint-plugin-fig-linter/rules/no-empty-array-values.js
+++ b/scripts/eslint-plugin-fig-linter/rules/no-empty-array-values.js
@@ -6,11 +6,17 @@ module.exports = {
   create: function (context) {
     return {
       Property(node) {
-        if (
-          node.key.name === "options" ||
-          node.key.name === "subcommands" ||
-          node.key.name === "args"
-        ) {
+        const keyName = node.key.name;
+        if (["options", "subcommands", "args"].includes(keyName)) {
+          // This rule should not be applied to subcommands and
+          // options on the root object
+          if (
+            node.parent.parent.parent.parent.type ===
+              "ExportNamedDeclaration" &&
+            keyName !== "args"
+          )
+            return;
+
           if (node.value && node.value.type === "ArrayExpression") {
             if (node.value.elements.length === 0) {
               context.report({

--- a/scripts/eslint-plugin-fig-linter/rules/no-empty-array-values.js
+++ b/scripts/eslint-plugin-fig-linter/rules/no-empty-array-values.js
@@ -11,6 +11,10 @@ module.exports = {
           // This rule should not be applied to subcommands and
           // options on the root object
           if (
+            node.parent &&
+            node.parent.parent &&
+            node.parent.parent.parent &&
+            node.parent.parent.parent.parent &&
             node.parent.parent.parent.parent.type ===
               "ExportNamedDeclaration" &&
             keyName !== "args"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
The eslint rule disallows empty `options` and `subcommands` arrays at the root command

**What is the new behavior (if this is a feature change)?**
Those are now allowed and don't cause an error

**Additional info:**