### PR TITLE
[GIT] Add file to possible list of arguments for diff

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -165,6 +165,10 @@ const gitGenerators: Record<string, Fig.Generator> = {
       });
     },
   },
+  getStagedFiles: {
+    script: "git diff --name-only --cached",
+    splitOn: "\n",
+  },
   getUnstagedFiles: {
     script: "git diff --name-only",
     splitOn: "\n",
@@ -1269,10 +1273,14 @@ export const completionSpec: Fig.Spec = {
         },
       ],
       args: {
-        name: "commit",
+        name: "file|commit",
         isOptional: true,
         suggestions: [{ name: "HEAD" }],
-        generators: [gitGenerators.commits, gitGenerators.getUnstagedFiles],
+        generators: [
+          gitGenerators.commits,
+          gitGenerators.getUnstagedFiles,
+          gitGenerators.getStagedFiles,
+        ],
       },
     },
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

I guess this is a feature. Here are the changes:

1. Add a generator for getting staged files using `git diff --name-only --cached`, check [here](https://stackoverflow.com/a/33610683).
2. Adds `file` as an option to the first argument of `git diff`.

**What is the current behavior? (You can also link to an open issue here)**
resolves #235 - previously only commits and unstaged files were being displayed.

**What is the new behavior (if this is a feature change)?**

<img width="533" alt="Screen Shot 2021-05-27 at 8 21 02 AM" src="https://user-images.githubusercontent.com/38927082/119852856-863dda00-bec4-11eb-9f5e-695c7e17c12c.png">

<img width="498" alt="Screen Shot 2021-05-27 at 8 21 11 AM" src="https://user-images.githubusercontent.com/38927082/119852869-88a03400-bec4-11eb-87c7-bf5a51d63f3c.png">


**Additional info:**
