### PR TITLE
[YARN] Add --latest flag to upgrade-interactive

### DIFF
--- a/dev/yarn.ts
+++ b/dev/yarn.ts
@@ -961,6 +961,12 @@ export const completionSpec: Fig.Spec = {
     {
       name: "upgrade-interactive",
       description: "Upgrades packages in interactive mode",
+      options: [
+        {
+          name: ["--latest"],
+          description: "Use the version tagged latest in the registry",
+        },
+      ],
     },
     {
       name: "version",

--- a/dev/yarn.ts
+++ b/dev/yarn.ts
@@ -963,7 +963,7 @@ export const completionSpec: Fig.Spec = {
       description: "Upgrades packages in interactive mode",
       options: [
         {
-          name: ["--latest"],
+          name: "--latest",
           description: "Use the version tagged latest in the registry",
         },
       ],


### PR DESCRIPTION
**What kind of change does this PR introduce? ** feature

**What is the current behavior?**  No flag auto-completion to yarn upgrade-interactive

**What is the new behavior (if this is a feature change)?**  Add --latest flag to yarn upgrade-interactive command

**Additional info:** Haven't tested it. See https://classic.yarnpkg.com/en/docs/cli/upgrade-interactive/#toc-yarn-upgrade-interactive command documentation