### PR TITLE
[EXPO] Add new subcommands

### DIFF
--- a/dev/expo.ts
+++ b/dev/expo.ts
@@ -1,7 +1,76 @@
+const runOptions: Fig.Option[] = [
+  {
+    name: "--no-bundler",
+    description: "Skip starting the Metro bundler",
+  },
+  {
+    name: ["-d", "--device"],
+    description: "Device name to build the app on",
+    args: {
+      name: "device",
+    },
+  },
+  {
+    name: ["-p", "--port"],
+    description: "Port to start the Metro bundler on",
+    args: {
+      name: "port",
+    },
+  },
+  {
+    name: "--config",
+    description: "Use app.config.js to switch config files instead",
+    icon: "fig://icon?type=alert",
+    args: {
+      name: "config",
+      template: "filepaths",
+    },
+  },
+];
+
 export const completionSpec: Fig.Spec = {
   name: "expo",
   description: "",
   subcommands: [
+    {
+      name: "run:android",
+      description: "Run the android app binary locally",
+      icon: "fig://icon?type=android",
+      options: [
+        ...runOptions,
+        {
+          name: "--variant",
+          description: "(Android) build variant",
+          args: {
+            name: "variant",
+          },
+        },
+      ],
+    },
+    {
+      name: "run:ios",
+      description: "Run the ios app binary locally",
+      icon: "fig://icon?type=apple",
+      options: [
+        ...runOptions,
+        {
+          name: "--scheme",
+          description: "Scheme to build",
+          args: {
+            name: "scheme",
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--configuration",
+          description: "Xcode configuration to use",
+          args: {
+            name: "configuration",
+            suggestions: ["Debug", "Release"],
+          },
+        },
+      ],
+    },
     {
       name: "build:android",
       description: "",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
The new subcommand `run:ios` and `run:android` does not exist

**What is the new behavior (if this is a feature change)?**
Added those new subcommands

**Additional info:**
Blog-post of the expo CLI update:
https://blog.expo.io/introducing-expo-run-commands-835ae8da4813

Preview:
![Screenshot 2021-06-02 at 09 16 30](https://user-images.githubusercontent.com/43268759/120440114-8d149300-c383-11eb-9824-393205f46a2e.png)
