### PR TITLE
[ECHO] Add echo spec

### DIFF
--- a/dev/echo.ts
+++ b/dev/echo.ts
@@ -1,0 +1,16 @@
+export const completion: Fig.Spec = {
+  name: "echo",
+  description: "Write arguments to the standard output",
+  args: {
+    name: "operands",
+    description:
+      "Write any specified operands, separated by single blank characters and followed by a newline character, to the standard output",
+    variadic: true,
+  },
+  options: [
+    {
+      name: "-n",
+      description: "Do not print the trailing newline character",
+    },
+  ],
+};


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
No completion spec for `echo`

**What is the new behavior (if this is a feature change)?**
Add a (very very small) completion spec for `echo`

**Additional info:**