### PR TITLE
[BREW] Add regenerate-uuid subcommand

### DIFF
--- a/dev/brew.ts
+++ b/dev/brew.ts
@@ -280,6 +280,10 @@ export const completionSpec: Fig.Spec = {
           name: "off",
           description: "Turns off analytics",
         },
+        {
+          name: "regenerate-uuid",
+          description: "Regenerate the UUID used for analytics",
+        },
       ],
     },
   ],


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature
**What is the current behavior? (You can also link to an open issue here)**
The subcommand `brew analytics regenerate-uuid` does not exist
**What is the new behavior (if this is a feature change)?**
Added subcommand

**Additional info:**
https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/analytics.rb#L47

Preview
![image](https://user-images.githubusercontent.com/37574822/120882157-c57cd100-c610-11eb-856c-5d751601030b.png)
