### PR TITLE
[ELECTRON] Add electron spec

### DIFF
--- a/dev/electron.ts
+++ b/dev/electron.ts
@@ -1,0 +1,32 @@
+export const completion: Fig.Spec = {
+  name: "electron",
+  description:
+    "Build cross platform desktop apps with JavaScript, HTML and CSS",
+  args: {
+    name: "path",
+    description: "A path to an electron app",
+    template: ["filepaths", "folders"],
+  },
+  options: [
+    {
+      name: ["-i", "--interactive"],
+      description: "Open a REPL to the main process",
+    },
+    {
+      name: ["-r", "--require"],
+      description: "Module to preload",
+      args: {
+        name: "module",
+        template: "filepaths",
+      },
+    },
+    {
+      name: ["-v", "--version"],
+      description: "Print the version",
+    },
+    {
+      name: ["-a", "--abi"],
+      description: "Print the Node ABI version",
+    },
+  ],
+};

--- a/dev/yarn.ts
+++ b/dev/yarn.ts
@@ -127,7 +127,7 @@ export const completionSpec: Fig.Spec = {
       await executeShellCommand(script as string)
     ).map(({ name }) => name as string);
 
-    const cli = ["vue", "nuxt", "expo", "jest", "next"];
+    const cli = ["vue", "nuxt", "expo", "jest", "next", "electron"];
     const subcommands = packages
       .filter((name) => cli.includes(name))
       .map((name) => ({


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
No completion spec for `electron`

**What is the new behavior (if this is a feature change)?**
Add a completion spec for `electron`

**Additional info:**
Also add it to `yarn` spec, to get completion like this:
![Screenshot 2021-06-05 at 10 37 14](https://user-images.githubusercontent.com/43268759/120885560-001f4300-c5ea-11eb-9299-55f0b0b457be.png)
