### PR TITLE
Add aliases generator for git completion

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -25,6 +25,17 @@ const gitGenerators: Record<string, Fig.Generator> = {
     },
   },
 
+  // user aliases
+  aliases: {
+    script: "git config --get-regexp '^alias' |cut -d. -f2",
+    postProcess: function (out) {
+      return out.split("\n").map((aliasLine) => {
+        const splitted = aliasLine.match(/^(\S+)\s(.*)/);
+        return { name: splitted[1], description: splitted[2] };
+      });
+    },
+  },
+
   // Saved stashes
   // TODO: maybe only print names of stashes
   stashes: {
@@ -202,6 +213,9 @@ const head = {
 export const completionSpec: Fig.Spec = {
   name: "git",
   description: "the stupid content tracker",
+  args: {
+    generators: gitGenerators.aliases,
+  },
   options: [
     {
       name: "--version",


### PR DESCRIPTION
This PR extends the existing `git` file to include an Argument generator which suggests git aliases (from config, not shell aliases).

Without this commands like `git st` become cumbersome with Fig as you have to <space> or <esc> away the menu to avoid the suggested vanilla command.