### PR TITLE
feat: add 'compose' to docker spec

### DIFF
--- a/dev/docker.ts
+++ b/dev/docker.ts
@@ -1959,6 +1959,11 @@ export const completionSpec: Fig.Spec = {
       // TODO Subcommands
     },
     {
+      name: "compose",
+      description: "Contains most of docker-compose features and flags",
+      // TODO Subcommands
+    },
+    {
       name: "container",
       description: "Manage containers",
     },

--- a/dev/docker.ts
+++ b/dev/docker.ts
@@ -1961,7 +1961,7 @@ export const completionSpec: Fig.Spec = {
     {
       name: "compose",
       description: "Contains most of docker-compose features and flags",
-      // TODO Subcommands
+      loadSpec: "docker-compose",
     },
     {
       name: "container",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature
**What is the current behavior? (You can also link to an open issue here)**
No 'compose' subcommand for 'docker' command
**What is the new behavior (if this is a feature change)?**
Add 'compose' subcommand to 'docker' command. No options/arguments were added due to a lack of familiarity with the most common options for this subcommand.
**Additional info:**
- [Docker compose docs](https://docs.docker.com/compose/cli-command/)
- Fulfills #245 