### PR TITLE
Add "Fig Not Installed" Warning in Dev Script

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,6 +1,28 @@
 #!/bin/bash
 
 clear
+
+whichapp() {
+    local appNameOrBundleId=$1 isAppName=0 bundleId
+    # Determine whether an app *name* or *bundle ID* was specified.
+    [[ $appNameOrBundleId =~ \.[aA][pP][pP]$ || $appNameOrBundleId =~ ^[^.]+$ ]] && isAppName=1
+    if (( isAppName )); then
+        # Translate to a bundle ID first.
+        bundleId=$(osascript -e "id of application \"$appNameOrBundleId\"" 2>/dev/null) || 
+        { 
+            echo
+            echo "******"
+            echo "******"
+            echo "WARNING: Fig is not installed" 1>&2;
+            echo "******"
+            echo "******"
+            echo
+        }
+    fi
+}
+
+whichapp Fig
+
 echo 
 echo "Welcome to $(tput bold)$(tput setaf 5)Fig Dev Mode$(tput sgr0)";
 echo 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Dev Script Update
**What is the current behavior? (You can also link to an open issue here)**
#247 Dev Script doesn't include a warning about Fig not being installed
**What is the new behavior (if this is a feature change)?**
Adds warning!
**Additional info:**
In order to test  what happens when the app isn't installed, change line 24 from `whichapp Fig` to `whichapp blah`. 