### PR TITLE
feat: add `next` subcommand to `npx`

### DIFF
--- a/dev/npx.ts
+++ b/dev/npx.ts
@@ -7,6 +7,11 @@ export const completionSpec: Fig.Spec = {
       icon: "https://reactnative.dev/img/pwa/manifest-icon-512.png",
       loadSpec: "react-native",
     },
+    {
+      name: "next",
+      icon: "https://nextjs.org/static/favicon/favicon-16x16.png",
+      loadSpec: "next",
+    },
   ],
   options: [
     {


### PR DESCRIPTION
This PR adds the `next` also as a subcommand of `npx`. I don't think it is a common practice to have `next`, `babel`, `tailwind`, etc...installed globally. 
Instead many `npm` CLI tools are convenient to be run as `npx --no-install [package-name]` from the project dir.

I think the same applies to other `npm` commands.