### PR TITLE
Remove preceding '+' for branches checked out in another worktree

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -95,17 +95,21 @@ const gitGenerators: Record<string, Fig.Generator> = {
 
       return output.split("\n").map((elm) => {
         // current branch
-        if (elm.includes("*")) {
+        let name = elm.trim();
+        const parts = elm.match(/\S+/g);
+        if (parts.length > 1 && parts[0] == "*") {
           return {
             name: elm.replace("*", "").trim(),
             description: "current branch",
             icon: "⭐️",
             // priority: 100,
           };
+        } else if (parts.length > 1 && parts[0] == "+") {
+          name = elm.replace("+", "").trim();
         }
 
         return {
-          name: elm.trim(),
+          name,
           description: "branch",
           icon: "fig://icon?type=git",
         };

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -94,18 +94,18 @@ const gitGenerators: Record<string, Fig.Generator> = {
       }
 
       return output.split("\n").map((elm) => {
-        // current branch
         let name = elm.trim();
         const parts = elm.match(/\S+/g);
         if (parts.length > 1) {
           if (parts[0] == "*") {
+            // Current branch.
             return {
               name: elm.replace("*", "").trim(),
               description: "current branch",
               icon: "⭐️",
-              // priority: 100,
             };
           } else if (parts[0] == "+") {
+            // Branch checked out in another worktree.
             name = elm.replace("+", "").trim();
           }
         }

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -97,15 +97,17 @@ const gitGenerators: Record<string, Fig.Generator> = {
         // current branch
         let name = elm.trim();
         const parts = elm.match(/\S+/g);
-        if (parts.length > 1 && parts[0] == "*") {
-          return {
-            name: elm.replace("*", "").trim(),
-            description: "current branch",
-            icon: "⭐️",
-            // priority: 100,
-          };
-        } else if (parts.length > 1 && parts[0] == "+") {
-          name = elm.replace("+", "").trim();
+        if (parts.length > 1) {
+          if (parts[0] == "*") {
+            return {
+              name: elm.replace("*", "").trim(),
+              description: "current branch",
+              icon: "⭐️",
+              // priority: 100,
+            };
+          } else if (parts[0] == "+") {
+            name = elm.replace("+", "").trim();
+          }
         }
 
         return {


### PR DESCRIPTION
Bug fix for git cli. Current behavior when branch `other` is checked out in another worktree is to show `+ other` as a suggestion.

New behavior handles this case, suggesting `other` instead, while still handling branch names with the `+` character in them.

