### PR TITLE
feat: update `tailwindcss` spec

### DIFF
--- a/dev/tailwindcss.ts
+++ b/dev/tailwindcss.ts
@@ -1,17 +1,64 @@
+const commonOptions: Fig.Option[] = [
+  {
+    name: ["--help", "-h"],
+    description: "Display usage information.",
+  },
+];
+
+const buildOptions: Fig.Option[] = [
+  {
+    name: ["-i", "--input"],
+    description: "Specify input file.",
+    args: { name: "input file", template: "filepaths" },
+  },
+  {
+    name: ["-o", "--output"],
+    description: "Specify output file.",
+    args: { name: "output file", template: "filepaths" },
+  },
+  {
+    name: ["-c", "--config"],
+    description: "Specify config file to use.",
+    args: { name: "config file", template: "filepaths" },
+  },
+  {
+    name: "--postcss",
+    description: "Load custom PostCSS configuration.",
+    args: {
+      name: "postcss config file",
+      template: "filepaths",
+      isOptional: true,
+    },
+  },
+  {
+    name: "--purge",
+    description: "Content paths to use for removing unused classes.",
+  },
+  {
+    name: ["--watch", "-w"],
+    description: "Watch for changes and rebuild as needed.",
+  },
+  {
+    name: "--jit",
+    description: "Build using JIT mode.",
+  },
+  {
+    name: ["--minify", "-m"],
+    description: "Minify the output.",
+  },
+  {
+    name: "--no-autoprefixer",
+    description: "Disable autoprefixer.",
+  },
+  ...commonOptions,
+];
+
 export const completionSpec: Fig.Spec = {
   name: "tailwindcss",
   description: "tailwindcss CLI tools",
   icon: "https://tailwindcss.com/favicon-32x32.png",
-  options: [{ name: "--help", description: "Show help." }],
+  options: buildOptions,
   subcommands: [
-    {
-      name: "help",
-      description: "More information about the command.",
-      args: {
-        name: "command",
-        suggestions: ["init", "build"],
-      },
-    },
     {
       name: "init",
       description: "Creates Tailwind config file. Default: tailwind.config.js.",
@@ -21,38 +68,24 @@ export const completionSpec: Fig.Spec = {
       },
       options: [
         {
-          name: "-p",
-          description: "Generate also a PostCSS config file.",
+          name: "--jit",
+          description: "Initialize for JIT mode",
         },
         {
-          name: "--full",
-          description: "Generate a complete configuration file.",
+          name: ["-p", "--postcss"],
+          description: "Initialize a 'postcss.config.js' file.",
         },
+        {
+          name: ["-f", "--full"],
+          description: "Initialize a full 'tailwind.config.js' file",
+        },
+        ...commonOptions,
       ],
     },
     {
       name: "build",
       description: "Build CSS file.",
-      args: {
-        description: "Tailwind CSS file to compile.",
-        template: "filepaths",
-      },
-      options: [
-        {
-          name: ["-o", "--output"],
-          description: "Specify output file.",
-          args: { name: "output file", template: "filepaths" },
-        },
-        {
-          name: ["-c", "--config"],
-          description: "Specify config file to use.",
-          args: { name: "config file", template: "filepaths" },
-        },
-        {
-          name: "--no-autoprefixer",
-          description: "Don't add vendor prefixes using autoprefixer.",
-        },
-      ],
+      options: buildOptions,
     },
   ],
 };


### PR DESCRIPTION
Update `tailwindcss` cli spec to the latest version according to https://github.com/tailwindlabs/tailwindcss/blob/8da840f2a3df2df6b4159d5c849a99536f2b8989/src/cli.js#L125-L164 and to the docs.

