### PR TITLE
chore(eslint): add `no-missing-spec-export` rule

### DIFF
--- a/dev/adb.ts
+++ b/dev/adb.ts
@@ -148,7 +148,7 @@ const reverseConnectionSuggestions: Fig.Suggestion[] = [
   },
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "adb",
   description: "Android Debug Bridge",
   subcommands: [

--- a/dev/command.ts
+++ b/dev/command.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "command",
   description: "run a command!",
   args: {

--- a/dev/dbt.ts
+++ b/dev/dbt.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "dbt",
   description: "",
   subcommands: [

--- a/dev/echo.ts
+++ b/dev/echo.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "echo",
   description: "Write arguments to the standard output",
   args: {

--- a/dev/electron.ts
+++ b/dev/electron.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "electron",
   description:
     "Build cross platform desktop apps with JavaScript, HTML and CSS",

--- a/dev/exa.ts
+++ b/dev/exa.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "exa",
   description: "a modern replacement for ls",
   args: {

--- a/dev/example/git_push.ts
+++ b/dev/example/git_push.ts
@@ -19,7 +19,7 @@
 
 // <arg1> [arg2...] -> This is just one argument that is NOT optional and is variadic
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "git_push_example",
   description: "",
 

--- a/dev/example/trigger.ts
+++ b/dev/example/trigger.ts
@@ -137,7 +137,7 @@ var customArgument = {
   },
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "trigger_example",
   description: "",
   subcommands: [

--- a/dev/flutter.ts
+++ b/dev/flutter.ts
@@ -661,7 +661,7 @@ const run = [
 
 // spec
 
-const completionSpec = {
+export const completionSpec: Fig.Spec = {
   name: "flutter",
   description: "Run flutter command.",
   subcommands: [

--- a/dev/gatsby.ts
+++ b/dev/gatsby.ts
@@ -19,7 +19,7 @@ const sharedOptions: Fig.Option[] = [
   },
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "gatsby",
   description: "Gatsby CLI",
   subcommands: [

--- a/dev/heroku.ts
+++ b/dev/heroku.ts
@@ -15,7 +15,7 @@ const getAppGenerator: Fig.Generator = {
   },
 };
 
-export const spec: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "heroku",
   subcommands: [
     {

--- a/dev/lerna.ts
+++ b/dev/lerna.ts
@@ -258,7 +258,7 @@ const listSubCommand: Fig.Subcommand = {
   ],
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "lerna",
   description:
     "A tool for managing JavaScript projects with multiple packages.",

--- a/dev/mask.ts
+++ b/dev/mask.ts
@@ -2,7 +2,7 @@
 // var executeShellCommand: Fig.ExecuteShellCommandFunction;
 
 // The below is a dummy example for git. Make sure to change the file name!
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "mask",
   generateSpec: async (context, executeShellCommand) => {
     // See if use specified a maskfile location

--- a/dev/ng.ts
+++ b/dev/ng.ts
@@ -25,7 +25,7 @@ const projectsOption = {
     generators: projectsGenerator,
   },
 };
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "ng",
   description: "CLI interface for Angular",
   subcommands: [

--- a/dev/nuxt.ts
+++ b/dev/nuxt.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "nuxt",
   description: "",
   subcommands: [

--- a/dev/php.ts
+++ b/dev/php.ts
@@ -1,7 +1,7 @@
 // To learn more about Fig's autocomplete standard visit: https://fig.io/docs/autocomplete/building-a-spec#building-your-first-autocomplete-spec
 
 // The below is a dummy example for git. Make sure to change the file name!
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "php",
   description: "Run the PHP interpreter",
   generateSpec: async (context, executeShellCommand) => {

--- a/dev/php/artisan.ts
+++ b/dev/php/artisan.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "artisan",
   description: "Laravel Artisan Command",
   generateSpec: async (context, executeShellCommand) => {

--- a/dev/poetry.ts
+++ b/dev/poetry.ts
@@ -54,7 +54,7 @@ const globalOptions: Fig.Option[] = [
   noInteraction,
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "poetry",
   description: "Python package manager",
   subcommands: [

--- a/dev/python/http.server.ts
+++ b/dev/python/http.server.ts
@@ -1,6 +1,6 @@
 import { SIGUNUSED } from "node:constants";
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "http.server",
   description: "",
 

--- a/dev/rails.ts
+++ b/dev/rails.ts
@@ -608,7 +608,7 @@ const defaultCommands: Fig.Subcommand[] = [
   newCommand,
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "rails",
   description: "Ruby on Rails CLI",
   async generateSpec(_, executeShellCommand) {

--- a/dev/rclone.ts
+++ b/dev/rclone.ts
@@ -88,7 +88,7 @@ const checkFlags: Array<Fig.Option> = [
   },
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "rclone",
   description: "The Swiss army knife of cloud storage",
   subcommands: [

--- a/dev/serverless.ts
+++ b/dev/serverless.ts
@@ -172,7 +172,7 @@ const options: Record<string, Fig.Option> = {
   },
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "serverless",
   description: "zero-friction serverless development",
   options: [

--- a/dev/stripe.ts
+++ b/dev/stripe.ts
@@ -253,7 +253,7 @@ const sharedOptions: Fig.Option[] = [
   },
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "stripe",
   description: "CLI interface for Stripe.com",
   subcommands: [

--- a/dev/su.ts
+++ b/dev/su.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "su",
   description: "",
   subcommands: [],

--- a/dev/sudo.ts
+++ b/dev/sudo.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "sudo",
   description: "execute a command as the superuser or another user",
   options: [

--- a/dev/time.ts
+++ b/dev/time.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "time",
   description: "time how long a commmand takes!",
   args: {

--- a/dev/tmux.ts
+++ b/dev/tmux.ts
@@ -47,7 +47,7 @@ const flagsOption: Fig.Option = {
   },
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "tmux",
   description: "A terminal multiplexer",
   subcommands: [

--- a/dev/volta.ts
+++ b/dev/volta.ts
@@ -18,7 +18,7 @@ const toolArgs: Fig.Arg = {
   name: "tool@version",
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "volta",
   description: "The JavaScript Launcher",
   subcommands: [

--- a/dev/wrangler.ts
+++ b/dev/wrangler.ts
@@ -26,7 +26,7 @@ const OPTION_VERBOSE: Fig.Option = {
 /* DOCS: 
 https://developers.cloudflare.com/workers/cli-wrangler/commands 
 */
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "wrangler",
   description: "Wrangler CLI for Cloudflare Workers",
   subcommands: [

--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -3,6 +3,6 @@ export const SOURCE_FOLDER_NAME = "dev";
 export const DESTINATION_FOLDER_NAME = "specs";
 
 export const getBoilerplateSpecContent = (specName: string) => `
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "${specName}"
 };`;

--- a/scripts/eslint-plugin-fig-linter/index.js
+++ b/scripts/eslint-plugin-fig-linter/index.js
@@ -6,6 +6,7 @@ module.exports = {
     "no-invalid-name": require("./rules/no-invalid-name"),
     "no-empty-array-values": require("./rules/no-empty-array-values"),
     "no-useless-insertvalue": require("./rules/no-useless-insertvalue"),
+    "no-missing-spec-export": require("./rules/no-missing-spec-export"),
   },
   configs: {
     recommended: {
@@ -18,7 +19,16 @@ module.exports = {
         // TODO: Re-Enable Rule if we got a proper flag for that
         "fig-linter/no-invalid-option": "off",
         "fig-linter/no-invalid-name": "error",
+        "fig-linter/no-missing-spec-export": "off",
       },
+      overrides: [
+        {
+          files: "dev/**/*.ts",
+          rules: {
+            "fig-linter/no-missing-spec-export": "error",
+          },
+        },
+      ],
     },
   },
 };

--- a/scripts/eslint-plugin-fig-linter/rules/no-missing-spec-export.js
+++ b/scripts/eslint-plugin-fig-linter/rules/no-missing-spec-export.js
@@ -1,0 +1,79 @@
+const SPEC_NAME = "completionSpec";
+
+function isVariableDeclarator(node) {
+  return node.type === "VariableDeclarator";
+}
+
+function isCompletionSpecExport(node) {
+  if (isVariableDeclarator(node)) {
+    if (node.id.type === "Identifier" && node.id.name === SPEC_NAME) {
+      return true;
+    }
+  } /* ExportSpecifier */ else {
+    if (node.exported.name === SPEC_NAME) {
+      return true;
+    }
+  }
+  return false;
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    fixable: true,
+  },
+  create(context) {
+    let exports = [];
+
+    return {
+      "ExportNamedDeclaration > VariableDeclaration"(node) {
+        exports.push(...node.declarations /* VariableDeclarator */);
+      },
+      ExportSpecifier(node) {
+        exports.push(node);
+      },
+      "Program:exit"(node) {
+        switch (exports.length) {
+          case 0:
+            context.report({
+              node,
+              message:
+                "File must contain one `export const completionSpec: Fig.Spec` declaration.",
+            });
+            break;
+          case 1:
+            if (!isCompletionSpecExport(exports[0])) {
+              context.report({
+                node: isVariableDeclarator(exports[0])
+                  ? exports[0].id
+                  : exports[0].exported,
+                message:
+                  "The spec export of the file should be named `completionSpec`",
+                fix(fixer) {
+                  return isVariableDeclarator(exports[0])
+                    ? fixer.replaceTextRange(
+                        exports[0].id.range,
+                        `${SPEC_NAME}: Fig.Spec`
+                      )
+                    : fixer.insertTextAfter(
+                        exports[0].local,
+                        ` as ${SPEC_NAME}`
+                      );
+                },
+              });
+            }
+            break;
+          default:
+            // check if at least one of the exports is completionSpec
+            if (!exports.some((_export) => isCompletionSpecExport(_export))) {
+              context.report({
+                node,
+                message:
+                  "Exactly one of the exports of the file should be named `completionSpec`",
+              });
+            }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
In this PR we add an ESLint rule that ensure that each spec has a `completionSpec` export so that Typescript no longer has to transform the code assuming that the first export is the correct one.
In particular the ESLint rule groups all `NamedExports` in one `exports` array:
```js
export const foo = 100
export { bar, baz }
```
and then checks the number of exports of the file:
- if `0`: it raises an error asking the user to add a `completionSpec` export;
- if `1`: it checks if the export is correctly named fixing the export name otherwise;
- if `> 1`: checks if any export is named `completionSpec` and it raises an error if none was found.