### PR TITLE
[BREW] Add autoremove command

### DIFF
--- a/dev/brew.ts
+++ b/dev/brew.ts
@@ -336,6 +336,18 @@ export const completionSpec: Fig.Spec = {
         },
       ],
     },
+    {
+      name: "autoremove",
+      description:
+        "Uninstall formulae that were only installed as a dependency of another formula and are now no longer needed.",
+      options: [
+        {
+          name: ["-n", "--dry-run"],
+          description:
+            "List what would be uninstalled, but do not actually uninstall anything.",
+        },
+      ],
+    },
   ],
   options: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature.

**What is the current behavior? (You can also link to an open issue here)**
Autocomplete is missing the `brew autoremove` command.

**What is the new behavior (if this is a feature change)?**
1. Add `autoremove` command

**Additional info:**
Brew docs about the `autoremove` command: https://docs.brew.sh/Manpage#autoremove---dry-run