### PR TITLE
Use consistent naming of exported spec

### DIFF
--- a/dev/adb.ts
+++ b/dev/adb.ts
@@ -148,7 +148,7 @@ const reverseConnectionSuggestions: Fig.Suggestion[] = [
   },
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "adb",
   description: "Android Debug Bridge",
   subcommands: [

--- a/dev/command.ts
+++ b/dev/command.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "command",
   description: "run a command!",
   args: {

--- a/dev/dbt.ts
+++ b/dev/dbt.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "dbt",
   description: "",
   subcommands: [

--- a/dev/echo.ts
+++ b/dev/echo.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "echo",
   description: "Write arguments to the standard output",
   args: {

--- a/dev/electron.ts
+++ b/dev/electron.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "electron",
   description:
     "Build cross platform desktop apps with JavaScript, HTML and CSS",

--- a/dev/exa.ts
+++ b/dev/exa.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "exa",
   description: "a modern replacement for ls",
   args: {

--- a/dev/example/git_push.ts
+++ b/dev/example/git_push.ts
@@ -19,7 +19,7 @@
 
 // <arg1> [arg2...] -> This is just one argument that is NOT optional and is variadic
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "git_push_example",
   description: "",
 

--- a/dev/example/trigger.ts
+++ b/dev/example/trigger.ts
@@ -137,7 +137,7 @@ var customArgument = {
   },
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "trigger_example",
   description: "",
   subcommands: [

--- a/dev/flutter.ts
+++ b/dev/flutter.ts
@@ -661,7 +661,7 @@ const run = [
 
 // spec
 
-const completionSpec = {
+export const completionSpec: Fig.Spec = {
   name: "flutter",
   description: "Run flutter command.",
   subcommands: [

--- a/dev/gatsby.ts
+++ b/dev/gatsby.ts
@@ -19,7 +19,7 @@ const sharedOptions: Fig.Option[] = [
   },
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "gatsby",
   description: "Gatsby CLI",
   subcommands: [

--- a/dev/heroku.ts
+++ b/dev/heroku.ts
@@ -15,7 +15,7 @@ const getAppGenerator: Fig.Generator = {
   },
 };
 
-export const spec: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "heroku",
   subcommands: [
     {

--- a/dev/lerna.ts
+++ b/dev/lerna.ts
@@ -258,7 +258,7 @@ const listSubCommand: Fig.Subcommand = {
   ],
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "lerna",
   description:
     "A tool for managing JavaScript projects with multiple packages.",

--- a/dev/mask.ts
+++ b/dev/mask.ts
@@ -2,7 +2,7 @@
 // var executeShellCommand: Fig.ExecuteShellCommandFunction;
 
 // The below is a dummy example for git. Make sure to change the file name!
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "mask",
   generateSpec: async (context, executeShellCommand) => {
     // See if use specified a maskfile location

--- a/dev/ng.ts
+++ b/dev/ng.ts
@@ -25,7 +25,7 @@ const projectsOption = {
     generators: projectsGenerator,
   },
 };
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "ng",
   description: "CLI interface for Angular",
   subcommands: [

--- a/dev/nuxt.ts
+++ b/dev/nuxt.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "nuxt",
   description: "",
   subcommands: [

--- a/dev/php.ts
+++ b/dev/php.ts
@@ -1,7 +1,7 @@
 // To learn more about Fig's autocomplete standard visit: https://fig.io/docs/autocomplete/building-a-spec#building-your-first-autocomplete-spec
 
 // The below is a dummy example for git. Make sure to change the file name!
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "php",
   description: "Run the PHP interpreter",
   generateSpec: async (context, executeShellCommand) => {

--- a/dev/php/artisan.ts
+++ b/dev/php/artisan.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "artisan",
   description: "Laravel Artisan Command",
   generateSpec: async (context, executeShellCommand) => {

--- a/dev/poetry.ts
+++ b/dev/poetry.ts
@@ -54,7 +54,7 @@ const globalOptions: Fig.Option[] = [
   noInteraction,
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "poetry",
   description: "Python package manager",
   subcommands: [

--- a/dev/python/http.server.ts
+++ b/dev/python/http.server.ts
@@ -1,6 +1,6 @@
 import { SIGUNUSED } from "node:constants";
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "http.server",
   description: "",
 

--- a/dev/rails.ts
+++ b/dev/rails.ts
@@ -608,7 +608,7 @@ const defaultCommands: Fig.Subcommand[] = [
   newCommand,
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "rails",
   description: "Ruby on Rails CLI",
   async generateSpec(_, executeShellCommand) {

--- a/dev/rclone.ts
+++ b/dev/rclone.ts
@@ -88,7 +88,7 @@ const checkFlags: Array<Fig.Option> = [
   },
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "rclone",
   description: "The Swiss army knife of cloud storage",
   subcommands: [

--- a/dev/serverless.ts
+++ b/dev/serverless.ts
@@ -172,7 +172,7 @@ const options: Record<string, Fig.Option> = {
   },
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "serverless",
   description: "zero-friction serverless development",
   options: [

--- a/dev/stripe.ts
+++ b/dev/stripe.ts
@@ -253,7 +253,7 @@ const sharedOptions: Fig.Option[] = [
   },
 ];
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "stripe",
   description: "CLI interface for Stripe.com",
   subcommands: [

--- a/dev/su.ts
+++ b/dev/su.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "su",
   description: "",
   subcommands: [],

--- a/dev/sudo.ts
+++ b/dev/sudo.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "sudo",
   description: "execute a command as the superuser or another user",
   options: [

--- a/dev/time.ts
+++ b/dev/time.ts
@@ -1,4 +1,4 @@
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "time",
   description: "time how long a commmand takes!",
   args: {

--- a/dev/tmux.ts
+++ b/dev/tmux.ts
@@ -47,7 +47,7 @@ const flagsOption: Fig.Option = {
   },
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "tmux",
   description: "A terminal multiplexer",
   subcommands: [

--- a/dev/volta.ts
+++ b/dev/volta.ts
@@ -18,7 +18,7 @@ const toolArgs: Fig.Arg = {
   name: "tool@version",
 };
 
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "volta",
   description: "The JavaScript Launcher",
   subcommands: [

--- a/dev/wp.ts
+++ b/dev/wp.ts
@@ -168,7 +168,7 @@ const global_parameter_quiet: Fig.Option = {
 };
 
 // The below is a dummy example for git. Make sure to change the file name!
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "wp",
   description: "WP-CLI is the command-line interface for WordPress.",
   subcommands: [

--- a/dev/wrangler.ts
+++ b/dev/wrangler.ts
@@ -26,7 +26,7 @@ const OPTION_VERBOSE: Fig.Option = {
 /* DOCS: 
 https://developers.cloudflare.com/workers/cli-wrangler/commands 
 */
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "wrangler",
   description: "Wrangler CLI for Cloudflare Workers",
   subcommands: [

--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -3,6 +3,6 @@ export const SOURCE_FOLDER_NAME = "dev";
 export const DESTINATION_FOLDER_NAME = "specs";
 
 export const getBoilerplateSpecContent = (specName: string) => `
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "${specName}"
 };`;

--- a/scripts/create-boilerplate.sh
+++ b/scripts/create-boilerplate.sh
@@ -32,7 +32,7 @@ else
   ## Using quotes around EOF will remove expansions
     # https://superuser.com/questions/1436906/need-to-expand-a-variable-in-a-heredoc-that-is-in-quotes
   cat <<EOF >> "$(pwd)/dev/$USER_INPUT_CLI_TOOL.ts"
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "$SPEC_NAME",
   description: "",
   subcommands: [],

--- a/scripts/create-example.sh
+++ b/scripts/create-example.sh
@@ -35,7 +35,7 @@ else
 // To learn more about Fig's autocomplete standard visit: https://fig.io/docs/autocomplete/building-a-spec#building-your-first-autocomplete-spec
 
 // The below is a dummy example for git. Make sure to change the file name!
-export const completion: Fig.Spec = {
+export const completionSpec: Fig.Spec = {
   name: "$SPEC_NAME",
   description: "The stupid content tracker",
   subcommands: [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Refactoring.

**What is the current behavior? (You can also link to an open issue here)**

Different files uses different names for the exported spec.

**What is the new behavior (if this is a feature change)?**

Change all files to use `export const completionSpec` (which is the documented version).