### PR TITLE
fix: Double quotes in git staged files generator

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -178,7 +178,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
       });
 
       return items.map((item) => {
-        const file = item.file;
+        const file = item.file.replace(/^"|"$/g, "");
         let ext = "";
 
         try {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
#339

**What is the new behavior (if this is a feature change)?**
Removes double-quotes using a regex at the start and/or at the end of each line of `git status --short` output

![Screenshot 2021-07-03 at 11 54 31](https://user-images.githubusercontent.com/43268759/124350519-6e5d2280-dbf5-11eb-836a-8dbaa2e60931.png)


**Additional info:**