### PR TITLE
Add editor.formatOnSave

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "editor.formatOnSave": true
 }


### PR DESCRIPTION
Pulling this out from https://github.com/withfig/autocomplete/pull/354/files#r667475392

IMO this setting improves the default Fig spec editing dev experience without requiring everyone to manually set this in their global user VSCode settings 🙌 


**What is the current behavior? (You can also link to an open issue here)**

When saving a Fig spec in VScode, prettier does not currently automatically run.

**What is the new behavior (if this is a feature change)?**

When saving a Fig spec in VSCode, prettier will automatically run.
