### PR TITLE
[AWS] [ACM] add generators

### DIFF
--- a/dev/aws/acm.ts
+++ b/dev/aws/acm.ts
@@ -1,3 +1,180 @@
+const postPrecessGenerator = (
+  out: string,
+  parentKey: string,
+  childKey = ""
+): Fig.Suggestion[] => {
+  try {
+    const list = JSON.parse(out)[parentKey];
+
+    if (!Array.isArray(list)) {
+      return [
+        {
+          name: list[childKey],
+          icon: "fig://icon?type=aws",
+        },
+      ];
+    }
+
+    return list.map((elm) => {
+      const name = (childKey ? elm[childKey] : elm) as string;
+      return {
+        name,
+        icon: "fig://icon?type=aws",
+      };
+    });
+  } catch (e) {
+    console.log(e);
+  }
+  return [];
+};
+
+const _prefixFile = "file://";
+const _prefixBlob = "fileb://";
+
+const appendFolderPath = (tokens: string[], prefix: string): string => {
+  const baseLSCommand = "\\ls -1ApL ";
+  let whatHasUserTyped = tokens[tokens.length - 1];
+
+  if (!whatHasUserTyped.startsWith(prefix)) {
+    return `echo '${prefix}'`;
+  }
+  whatHasUserTyped = whatHasUserTyped.slice(prefix.length);
+
+  let folderPath = "";
+  const lastSlashIndex = whatHasUserTyped.lastIndexOf("/");
+
+  if (lastSlashIndex > -1) {
+    if (whatHasUserTyped.startsWith("/") && lastSlashIndex === 0) {
+      folderPath = "/";
+    } else {
+      folderPath = whatHasUserTyped.slice(0, lastSlashIndex + 1);
+    }
+  }
+
+  return baseLSCommand + folderPath;
+};
+
+const postProcessFiles = (out: string, prefix: string): Fig.Suggestion[] => {
+  if (out.trim() === prefix) {
+    return [
+      {
+        name: prefix,
+        insertValue: prefix,
+      },
+    ];
+  }
+  const sortFnStrings = (a, b) => {
+    return a.localeCompare(b);
+  };
+
+  const alphabeticalSortFilesAndFolders = (arr) => {
+    const dotsArr = [];
+    const otherArr = [];
+
+    arr.map((elm) => {
+      if (elm.toLowerCase() == ".ds_store") return;
+      if (elm.slice(0, 1) === ".") dotsArr.push(elm);
+      else otherArr.push(elm);
+    });
+
+    return [
+      ...otherArr.sort(sortFnStrings),
+      "../",
+      ...dotsArr.sort(sortFnStrings),
+    ];
+  };
+
+  const tempArr = alphabeticalSortFilesAndFolders(out.split("\n"));
+
+  const finalArr = [];
+  tempArr.forEach((item) => {
+    if (!(item === "" || item === null || item === undefined)) {
+      const outputType = item.slice(-1) === "/" ? "folder" : "file";
+
+      finalArr.push({
+        type: outputType,
+        name: item,
+        insertValue: item,
+      });
+    }
+  });
+
+  return finalArr;
+};
+
+const triggerPrefix = (
+  newToken: string,
+  oldToken: string,
+  prefix: string
+): boolean => {
+  if (!newToken.startsWith(prefix)) {
+    if (!oldToken) return false;
+
+    return oldToken.startsWith(prefix);
+  }
+
+  return newToken.lastIndexOf("/") !== oldToken.lastIndexOf("/");
+};
+
+const filterWithPrefix = (token: string, prefix: string): string => {
+  if (!token.startsWith(prefix)) return token;
+  return token.slice(token.lastIndexOf("/") + 1);
+};
+
+const generators: Record<string, Fig.Generator> = {
+  listFiles: {
+    script: (tokens) => {
+      return appendFolderPath(tokens, _prefixFile);
+    },
+    postProcess: (out) => {
+      return postProcessFiles(out, _prefixFile);
+    },
+
+    trigger: (newToken, oldToken) => {
+      return triggerPrefix(newToken, oldToken, _prefixFile);
+    },
+
+    filterTerm: (token) => {
+      return filterWithPrefix(token, _prefixFile);
+    },
+  },
+
+  listBlobs: {
+    script: (tokens) => {
+      return appendFolderPath(tokens, _prefixBlob);
+    },
+    postProcess: (out) => {
+      return postProcessFiles(out, _prefixBlob);
+    },
+
+    trigger: (newToken, oldToken) => {
+      return triggerPrefix(newToken, oldToken, _prefixBlob);
+    },
+
+    filterTerm: (token) => {
+      return filterWithPrefix(token, _prefixBlob);
+    },
+  },
+
+  listCertificates: {
+    script: "aws acm list-certificates",
+    postProcess: (out) => {
+      return postPrecessGenerator(
+        out,
+        "CertificateSummaryList",
+        "CertificateArn"
+      );
+    },
+  },
+
+  listCertificateAuthorities: {
+    script: "aws acm-pca list-certificate-authorities",
+    postProcess: (out) => {
+      return postPrecessGenerator(out, "CertificateAuthorities", "Arn");
+    },
+  },
+};
+
 export const completionSpec: Fig.Spec = {
   name: "acm",
   description:
@@ -14,6 +191,7 @@ export const completionSpec: Fig.Spec = {
             "String that contains the ARN of the ACM certificate to which the tag is to be applied. This must be of the form:  arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012  For more information about ARNs, see Amazon Resource Names (ARNs).",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -22,6 +200,8 @@ export const completionSpec: Fig.Spec = {
             "The key-value pair that defines the tag. The tag value is optional.",
           args: {
             name: "list",
+            variadic: true,
+            description: "Key=string,Value=string",
           },
         },
         {
@@ -30,6 +210,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -54,6 +235,7 @@ export const completionSpec: Fig.Spec = {
             "String that contains the ARN of the ACM certificate to be deleted. This must be of the form:  arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012  For more information about ARNs, see Amazon Resource Names (ARNs).",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -62,6 +244,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -86,6 +269,7 @@ export const completionSpec: Fig.Spec = {
             "The Amazon Resource Name (ARN) of the ACM certificate. The ARN must have the following form:  arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012  For more information about ARNs, see Amazon Resource Names (ARNs).",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -94,6 +278,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -118,6 +303,7 @@ export const completionSpec: Fig.Spec = {
             "An Amazon Resource Name (ARN) of the issued certificate. This must be of the form:  arn:aws:acm:region:account:certificate/12345678-1234-1234-1234-123456789012",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -126,6 +312,7 @@ export const completionSpec: Fig.Spec = {
             "Passphrase to associate with the encrypted exported private key. If you want to later decrypt the private key, you must have the passphrase. You can use the following OpenSSL command to decrypt a private key:   openssl rsa -in encrypted_key.pem -out decrypted_key.pem",
           args: {
             name: "blob",
+            generators: generators.listBlobs,
           },
         },
         {
@@ -134,6 +321,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -158,6 +346,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -182,6 +371,7 @@ export const completionSpec: Fig.Spec = {
             "String that contains a certificate ARN in the following format:  arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012  For more information about ARNs, see Amazon Resource Names (ARNs).",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -190,6 +380,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -214,6 +405,7 @@ export const completionSpec: Fig.Spec = {
             "The Amazon Resource Name (ARN) of an imported certificate to replace. To import a new certificate, omit this field.",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -221,6 +413,7 @@ export const completionSpec: Fig.Spec = {
           description: "The certificate to import.",
           args: {
             name: "blob",
+            generators: generators.listBlobs,
           },
         },
         {
@@ -229,6 +422,7 @@ export const completionSpec: Fig.Spec = {
             "The private key that matches the public key in the certificate.",
           args: {
             name: "blob",
+            generators: generators.listBlobs,
           },
         },
         {
@@ -236,6 +430,7 @@ export const completionSpec: Fig.Spec = {
           description: "The PEM encoded certificate chain.",
           args: {
             name: "blob",
+            generators: generators.listBlobs,
           },
         },
         {
@@ -244,6 +439,8 @@ export const completionSpec: Fig.Spec = {
             "One or more resource tags to associate with the imported certificate.  Note: You cannot apply tags when reimporting a certificate.",
           args: {
             name: "list",
+            variadic: true,
+            description: "Key=string,Value=string",
           },
         },
         {
@@ -252,6 +449,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -275,6 +473,16 @@ export const completionSpec: Fig.Spec = {
           description: "Filter the certificate list by status value.",
           args: {
             name: "list",
+            variadic: true,
+            suggestions: [
+              "PENDING_VALIDATION",
+              "ISSUED",
+              "INACTIVE",
+              "EXPIRED",
+              "VALIDATION_TIMED_OUT",
+              "REVOKED",
+              "FAILED",
+            ],
           },
         },
         {
@@ -283,6 +491,8 @@ export const completionSpec: Fig.Spec = {
             "Filter the certificate list. For more information, see the Filters structure.",
           args: {
             name: "structure",
+            description:
+              "extendedKeyUsage=string,string,keyUsage=string,string,keyTypes=string,string",
           },
         },
         {
@@ -307,6 +517,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -347,6 +558,7 @@ export const completionSpec: Fig.Spec = {
             "String that contains the ARN of the ACM certificate for which you want to list the tags. This must have the following form:  arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012  For more information about ARNs, see Amazon Resource Names (ARNs).",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -355,6 +567,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -379,6 +592,7 @@ export const completionSpec: Fig.Spec = {
             "Specifies expiration events associated with an account.",
           args: {
             name: "structure",
+            description: "DaysBeforeExpiry=integer",
           },
         },
         {
@@ -395,6 +609,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -419,6 +634,7 @@ export const completionSpec: Fig.Spec = {
             "String that contains the ARN of the ACM Certificate with one or more tags that you want to remove. This must be of the form:  arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012  For more information about ARNs, see Amazon Resource Names (ARNs).",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -426,6 +642,8 @@ export const completionSpec: Fig.Spec = {
           description: "The key-value pair that defines the tag to remove.",
           args: {
             name: "list",
+            variadic: true,
+            description: "Key=string,Value=string",
           },
         },
         {
@@ -434,6 +652,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -458,6 +677,7 @@ export const completionSpec: Fig.Spec = {
             "String that contains the ARN of the ACM certificate to be renewed. This must be of the form:  arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012  For more information about ARNs, see Amazon Resource Names (ARNs).",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -466,6 +686,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -498,6 +719,7 @@ export const completionSpec: Fig.Spec = {
             "The method you want to use if you are requesting a public certificate to validate that you own or control domain. You can validate with DNS or validate with email. We recommend that you use DNS validation.",
           args: {
             name: "string",
+            suggestions: ["EMAIL", "DNS"],
           },
         },
         {
@@ -506,6 +728,7 @@ export const completionSpec: Fig.Spec = {
             "Additional FQDNs to be included in the Subject Alternative Name extension of the ACM certificate. For example, add the name www.example.net to a certificate for which the DomainName field is www.example.com if users can reach your site by using either name. The maximum number of domain names that you can add to an ACM certificate is 100. However, the initial quota is 10 domain names. If you need more than 10 names, you must request a quota increase. For more information, see Quotas.  The maximum length of a SAN DNS name is 253 octets. The name is made up of multiple labels separated by periods. No label can be longer than 63 octets. Consider the following examples:     (63 octets).(63 octets).(63 octets).(61 octets) is legal because the total length is 253 octets (63+1+63+1+63+1+61) and no label exceeds 63 octets.    (64 octets).(63 octets).(63 octets).(61 octets) is not legal because the total length exceeds 253 octets (64+1+63+1+63+1+61) and the first label exceeds 63 octets.    (63 octets).(63 octets).(63 octets).(62 octets) is not legal because the total length of the DNS name (63+1+63+1+63+1+62) exceeds 253 octets.",
           args: {
             name: "list",
+            variadic: true,
           },
         },
         {
@@ -522,6 +745,8 @@ export const completionSpec: Fig.Spec = {
             "The domain name that you want ACM to use to send you emails so that you can validate domain ownership.",
           args: {
             name: "list",
+            variadic: true,
+            description: "DomainName=string,ValidationDomain=string",
           },
         },
         {
@@ -530,6 +755,7 @@ export const completionSpec: Fig.Spec = {
             "Currently, you can use this parameter to specify whether to add the certificate to a certificate transparency log. Certificate transparency makes it possible to detect SSL/TLS certificates that have been mistakenly or maliciously issued. Certificates that have not been logged typically produce an error message in a browser. For more information, see Opting Out of Certificate Transparency Logging.",
           args: {
             name: "structure",
+            description: "CertificateTransparencyLoggingPreference=string",
           },
         },
         {
@@ -538,6 +764,7 @@ export const completionSpec: Fig.Spec = {
             "The Amazon Resource Name (ARN) of the private certificate authority (CA) that will be used to issue the certificate. If you do not provide an ARN and you are trying to request a private certificate, ACM will attempt to issue a public certificate. For more information about private CAs, see the AWS Certificate Manager Private Certificate Authority (PCA) user guide. The ARN must have the following form:   arn:aws:acm-pca:region:account:certificate-authority/12345678-1234-1234-1234-123456789012",
           args: {
             name: "string",
+            generators: generators.listCertificateAuthorities,
           },
         },
         {
@@ -546,6 +773,8 @@ export const completionSpec: Fig.Spec = {
             "One or more resource tags to associate with the certificate.",
           args: {
             name: "list",
+            variadic: true,
+            description: "Key=string,Value=string",
           },
         },
         {
@@ -554,6 +783,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -578,6 +808,7 @@ export const completionSpec: Fig.Spec = {
             "String that contains the ARN of the requested certificate. The certificate ARN is generated and returned by the RequestCertificate action as soon as the request is made. By default, using this parameter causes email to be sent to all top-level domains you specified in the certificate request. The ARN must be of the form:   arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -602,6 +833,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -626,6 +858,7 @@ export const completionSpec: Fig.Spec = {
             "ARN of the requested certificate to update. This must be of the form:  arn:aws:acm:us-east-1:account:certificate/12345678-1234-1234-1234-123456789012",
           args: {
             name: "string",
+            generators: generators.listCertificates,
           },
         },
         {
@@ -634,6 +867,7 @@ export const completionSpec: Fig.Spec = {
             "Use to update the options for your certificate. Currently, you can specify whether to add your certificate to a transparency log. Certificate transparency makes it possible to detect SSL/TLS certificates that have been mistakenly or maliciously issued. Certificates that have not been logged typically produce an error message in a browser.",
           args: {
             name: "structure",
+            description: "CertificateTransparencyLoggingPreference=string",
           },
         },
         {
@@ -642,6 +876,7 @@ export const completionSpec: Fig.Spec = {
             "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
           args: {
             name: "string",
+            generators: generators.listFiles,
           },
         },
         {
@@ -671,6 +906,7 @@ export const completionSpec: Fig.Spec = {
                 "The Amazon Resource Name (ARN) of the ACM certificate. The ARN must have the following form:  arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012  For more information about ARNs, see Amazon Resource Names (ARNs).",
               args: {
                 name: "string",
+                generators: generators.listCertificates,
               },
             },
             {
@@ -679,6 +915,7 @@ export const completionSpec: Fig.Spec = {
                 "Performs service operation based on the JSON string provided. The JSON string follows the format provided by ``--generate-cli-skeleton``. If other arguments are provided on the command line, the CLI values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally.",
               args: {
                 name: "string",
+                generators: generators.listFiles,
               },
             },
             {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**

- [x] add-tags-to-certificate
- [x] delete-certificate
- [x] describe-certificate
- [x] export-certificate
- [x] get-account-configuration
- [x] get-certificate
- [x] import-certificate
- [x] list-certificates
- [x] list-tags-for-certificate
- [x] put-account-configuration
- [x] remove-tags-from-certificate
- [x] renew-certificate
- [x] request-certificate
- [x] resend-validation-email
- [x] update-certificate-options
- [x] wait