### PR TITLE
[AWS] [Cloudwatch] add generators

### DIFF
--- a/dev/aws/cloudwatch.ts
+++ b/dev/aws/cloudwatch.ts
@@ -168,10 +168,7 @@ const postPrecessGenerator = (
           icon: "fig://icon?type=aws",
         };
       })
-      .filter(
-        (value, index, self) =>
-          self.map((x) => x.name).indexOf(value.name) === index
-      );
+      .filter(uniqueNames);
   } catch (e) {
     console.log(e);
   }
@@ -220,10 +217,7 @@ const listCustomGenerator = async (
           icon: "fig://icon?type=aws",
         };
       })
-      .filter(
-        (value, index, self) =>
-          self.map((x) => x.name).indexOf(value.name) === index
-      );
+      .filter(uniqueNames);
   } catch (e) {
     console.log(e);
   }
@@ -262,10 +256,7 @@ const listDimensionTypes = async (
         });
       })
       .flat()
-      .filter(
-        (value, index, self) =>
-          self.map((x) => x.name).indexOf(value.name) === index
-      );
+      .filter(uniqueNames);
   } catch (e) {
     console.log(e);
   }
@@ -382,6 +373,9 @@ const postProcessFiles = (out: string, prefix: string): Fig.Suggestion[] => {
 
   return finalArr;
 };
+
+const uniqueNames = (value, index, self) =>
+  self.map((x) => x.name).indexOf(value.name) === index;
 
 const triggerPrefix = (
   newToken: string,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**

- [x] delete-alarms
- [x] delete-anomaly-detector
- [x] delete-dashboards
- [x] delete-insight-rules
- [x] delete-metric-stream
- [x] describe-alarm-history
- [x] describe-alarms
- [x] describe-alarms-for-metric
- [x] describe-anomaly-detectors
- [x] describe-insight-rules
- [x] disable-alarm-actions
- [x] disable-insight-rules
- [x] enable-alarm-actions
- [x] enable-insight-rules
- [x] get-dashboard
- [x] get-insight-rule-report
- [x] get-metric-data
- [x] get-metric-statistics
- [x] get-metric-stream
- [x] get-metric-widget-image
- [x] list-dashboards
- [x] list-metric-streams
- [x] list-metrics
- [x] list-tags-for-resource
- [x] put-anomaly-detector
- [x] put-composite-alarm
- [x] put-dashboard
- [x] put-insight-rule
- [x] put-metric-alarm
- [x] put-metric-data
- [x] put-metric-stream
- [x] set-alarm-state
- [x] start-metric-streams
- [x] stop-metric-streams
- [x] tag-resource
- [x] untag-resource
- [x] wait