### PR TITLE
feat: fix bugs in npm uninstall

### DIFF
--- a/dev/npm.ts
+++ b/dev/npm.ts
@@ -264,57 +264,12 @@ export const completionSpec: Fig.Spec = {
       description: "uninstall a package",
       args: [
         {
-          generators: {
-            script: "cat package.json",
-            postProcess: function (out) {
-              if (out.trim() === "") {
-                return [];
-              }
-              try {
-                const packageContent = JSON.parse(out);
-                const dependencies = packageContent["dependencies"];
-                if (dependencies) {
-                  const dps = Object.keys(dependencies);
-                  return dps.map((pkg) => {
-                    const scope = pkg.indexOf("/") + 1;
-                    if (scope !== -1) {
-                      pkg = pkg.substring(scope);
-                    }
-                    const version = pkg.indexOf("@");
-                    if (version !== -1) {
-                      pkg = pkg.substring(version);
-                    }
-                    return {
-                      name: pkg,
-                      icon: `fig://icon?type=file`,
-                      description: "dependency file",
-                    };
-                  });
-                }
-              } catch (e) {}
-              return [];
-            },
-          },
+          name: "package",
+          generators: dependenciesGenerator,
+          variadic: true,
         },
       ],
-      options: [
-        {
-          name: ["-S", "--save"],
-          description: " Package will be removed from your dependencies",
-        },
-        {
-          name: ["-D", "--save-dev"],
-          description: "Package will appear in your `devDependencies`",
-        },
-        {
-          name: ["-O", "--save-optional"],
-          description: "Package will appear in your `optionalDependencies`",
-        },
-        {
-          name: "--no-save",
-          description: "Prevents saving to `dependencies`",
-        },
-      ],
+      options: npmInstallOptions,
     },
     {
       name: "r",

--- a/dev/npm.ts
+++ b/dev/npm.ts
@@ -34,26 +34,20 @@ const dependenciesGenerator: Fig.Generator = {
       const packageContent = JSON.parse(out);
       const dependencies = packageContent["dependencies"];
       if (dependencies) {
-        const dps = Object.keys(dependencies);
-        return dps
+        return Object.keys(dependencies)
           .filter(function (pkg) {
-            let isListed = false;
-            for (let i = 3; i <= context.length; i++) {
-              if (pkg == context[i - 2]) {
-                isListed = true;
-              }
-            }
+            const isListed = context.some((current) => current === pkg);
             return !isListed;
           })
-          .map((pkg) => {
-            const scope = pkg.indexOf("/") + 1;
-            const version = pkg.indexOf("@");
+          .map((name) => {
+            const scope = name.indexOf("/") + 1;
+            const version = name.indexOf("@");
             const displayName =
-              (scope !== -1 ? pkg.substring(scope) : pkg) ||
-              (version !== -1 ? pkg.substring(version) : pkg);
+              (scope !== -1 ? name.substring(scope) : name) ||
+              (version !== -1 ? name.substring(version) : name);
             return {
-              name: pkg,
-              displayName: displayName,
+              name,
+              displayName,
               description: "dependency",
             };
           });
@@ -63,7 +57,7 @@ const dependenciesGenerator: Fig.Generator = {
   },
 };
 
-const npmInstallOptions = [
+const npmInstallOptions: Fig.Option[] = [
   {
     name: ["-S", "--save"],
     description: " Package will be removed from your dependencies",

--- a/dev/npm.ts
+++ b/dev/npm.ts
@@ -24,6 +24,64 @@ const searchGenerator: Fig.Generator = {
   // },
 };
 
+const dependenciesGenerator: Fig.Generator = {
+  script: "cat package.json",
+  postProcess: function (out, context) {
+    if (out.trim() === "") {
+      return [];
+    }
+    try {
+      const packageContent = JSON.parse(out);
+      const dependencies = packageContent["dependencies"];
+      if (dependencies) {
+        const dps = Object.keys(dependencies);
+        return dps
+          .filter(function (pkg) {
+            let isListed = false;
+            for (let i = 3; i <= context.length; i++) {
+              if (pkg == context[i - 2]) {
+                isListed = true;
+              }
+            }
+            return !isListed;
+          })
+          .map((pkg) => {
+            const scope = pkg.indexOf("/") + 1;
+            const version = pkg.indexOf("@");
+            const displayName =
+              (scope !== -1 ? pkg.substring(scope) : pkg) ||
+              (version !== -1 ? pkg.substring(version) : pkg);
+            return {
+              name: pkg,
+              displayName: displayName,
+              description: "dependency",
+            };
+          });
+      }
+    } catch (e) {}
+    return [];
+  },
+};
+
+const npmInstallOptions = [
+  {
+    name: ["-S", "--save"],
+    description: " Package will be removed from your dependencies",
+  },
+  {
+    name: ["-D", "--save-dev"],
+    description: "Package will appear in your `devDependencies`",
+  },
+  {
+    name: ["-O", "--save-optional"],
+    description: "Package will appear in your `optionalDependencies`",
+  },
+  {
+    name: "--no-save",
+    description: "Prevents saving to `dependencies`",
+  },
+];
+
 export const completionSpec: Fig.Spec = {
   name: "npm",
   description: "Node package manager",
@@ -265,61 +323,52 @@ export const completionSpec: Fig.Spec = {
       ],
     },
     {
+      name: "r",
+      description: "uninstall a package",
+      args: [
+        {
+          name: "package",
+          generators: dependenciesGenerator,
+          variadic: true,
+        },
+      ],
+      options: npmInstallOptions,
+    },
+    {
+      name: "rm",
+      description: "uninstall a package",
+      args: [
+        {
+          name: "package",
+          generators: dependenciesGenerator,
+          variadic: true,
+        },
+      ],
+      options: npmInstallOptions,
+    },
+    {
+      name: "remove",
+      description: "uninstall a package",
+      args: [
+        {
+          name: "package",
+          generators: dependenciesGenerator,
+          variadic: true,
+        },
+      ],
+      options: npmInstallOptions,
+    },
+    {
       name: "uninstall",
       description: "remove a package",
       args: [
         {
-          generators: {
-            script: "cat package.json",
-            postProcess: function (out) {
-              if (out.trim() === "") {
-                return [];
-              }
-              try {
-                const packageContent = JSON.parse(out);
-                const dependencies = packageContent["dependencies"];
-                if (dependencies) {
-                  const dps = Object.keys(dependencies);
-                  return dps.map((pkg) => {
-                    const scope = pkg.indexOf("/") + 1;
-                    if (scope !== -1) {
-                      pkg = pkg.substring(scope);
-                    }
-                    const version = pkg.indexOf("@");
-                    if (version !== -1) {
-                      pkg = pkg.substring(version);
-                    }
-                    return {
-                      name: pkg,
-                      icon: `fig://icon?type=file`,
-                      description: "dependency file",
-                    };
-                  });
-                }
-              } catch (e) {}
-              return [];
-            },
-          },
+          name: "package",
+          generators: dependenciesGenerator,
+          variadic: true,
         },
       ],
-      options: [
-        {
-          name: ["-S", "--save"],
-          description: " Package will be removed from your dependencies",
-        },
-        {
-          name: ["-D", "--save-dev"],
-          description: "Package will appear in your `devDependencies`",
-        },
-        {
-          name: ["-O", "--save-optional"],
-          description: "Package will appear in your `optionalDependencies`",
-        },
-        {
-          name: "--no-save",
-          description: "Prevents saving to `dependencies`",
-        },
-      ],
+      options: npmInstallOptions,
     },
     { name: "unpublish", description: "remove a package from the registry" },
     { name: "unstar", description: "unmark your package" },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
- Bug fixes

**What is the current behavior? (You can also link to an open issue here)**
- Various bugs

**What is the new behavior (if this is a feature change)?**
- Add aliases of npm uninstall
- Changed icon & description of npm uninstall to make more sense
- Made npm uninstall variatic to process multiple uninstalls
- Fixed bug with npm uninstall not working with packages including @, by using a displayName

**Additional info:**
- Addresses #390 and #391 
