### PR TITLE
[Docker] show container names rather than the IDs

### DIFF
--- a/dev/docker.ts
+++ b/dev/docker.ts
@@ -3,8 +3,8 @@ const postProcessDockerPs: Fig.Generator["postProcess"] = (out) => {
     try {
       const parsedJSON: Record<string, string> = JSON.parse(i);
       return {
-        name: parsedJSON.ID,
-        displayName: `${parsedJSON.ID} (${parsedJSON.Image})`,
+        name: parsedJSON.Names,
+        displayName: `${parsedJSON.Names} (${parsedJSON.Image})`,
         icon: "fig://icon?type=docker",
       };
     } catch (error) {


### PR DESCRIPTION
On input from issue https://github.com/withfig/autocomplete/issues/304 changed the Docker autocomplete generator to show container names rather than the IDs it currently shows.