### PR TITLE
[git] Prioritize current branch

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -61,6 +61,7 @@ const postProcessBranches: Fig.Generator["postProcess"] = (out) => {
         return {
           name: elm.replace("*", "").trim(),
           description: "current branch",
+          priority: 100,
           icon: "⭐️",
         };
       } else if (parts[0] === "+") {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
The current branch is distinct by a ⭐️  icon, but can be anywhere in the suggestions

**What is the new behavior (if this is a feature change)?**
Adds a priority of `100` to the current branch so it will always stay at the top

**Additional info:**
Very useful in this case:
![Screenshot 2021-07-23 at 09 21 22](https://user-images.githubusercontent.com/43268759/126749495-cc53709a-c1e1-4ced-8667-f9eed7639932.png)