### PR TITLE
git[checkout]: show tags in checkout suggestions

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -57,6 +57,10 @@ const postProcessBranches: Fig.Generator["postProcess"] = (out) => {
     const parts = elm.match(/\S+/g);
     if (parts.length > 1) {
       if (parts[0] === "*") {
+        // We are in a detached HEAD state
+        if (elm.includes("HEAD detached")) {
+          return {};
+        }
         // Current branch.
         return {
           name: elm.replace("*", "").trim(),
@@ -206,7 +210,12 @@ const gitGenerators: Record<string, Fig.Generator> = {
 
   tags: {
     script: "git tag --list",
-    splitOn: "\n",
+    postProcess: function (output) {
+      return output.split("\n").map((tag) => ({
+        name: tag,
+        icon: "🏷️",
+      }));
+    },
   },
 
   // Files for staging
@@ -3966,10 +3975,11 @@ export const completionSpec: Fig.Spec = {
       args: [
         {
           name: "branch or file",
-          description: "branch, file or commit to switch to",
+          description: "branch, file, tag or commit to switch to",
           isOptional: true,
           generators: [
             gitGenerators.remoteLocalBranches,
+            gitGenerators.tags,
             { template: "filepaths" },
           ],
           suggestions: [
@@ -4978,7 +4988,7 @@ export const completionSpec: Fig.Spec = {
       args: [
         {
           name: "branch name",
-          description: "branch or commit to switch to",
+          description: "branch, commit, or tag to switch to",
           generators: gitGenerators.localBranches,
           suggestions: [
             {

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -4988,7 +4988,7 @@ export const completionSpec: Fig.Spec = {
       args: [
         {
           name: "branch name",
-          description: "branch, commit, or tag to switch to",
+          description: "branch or commit to switch to",
           generators: gitGenerators.localBranches,
           suggestions: [
             {

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -3975,7 +3975,7 @@ export const completionSpec: Fig.Spec = {
       ],
       args: [
         {
-          name: "branch or file",
+          name: "branch, file, tag or commit",
           description: "branch, file, tag or commit to switch to",
           isOptional: true,
           generators: [

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -78,6 +78,7 @@ const postProcessBranches: Fig.Generator["postProcess"] = (out) => {
       name,
       description: "branch",
       icon: "fig://icon?type=git",
+      priority: 75,
     };
   });
 };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
git checkout will list branches, files, and commits to checkout but not tags.

**What is the new behavior (if this is a feature change)?**
Tags will be listed in the suggestions for git checkout.

**Additional info:**
The current branch is normally given top priority with a star icon. However, if we are in a detached HEAD state after checking out a tag, I don't think we want to suggest the current branch. It would just show (detached HEAD state) and isn't actionable suggestion.

Re:https://github.com/withfig/autocomplete/issues/403