### PR TITLE
git: use --no-optional-locks with background status cmd

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -86,7 +86,7 @@ const postProcessBranches: Fig.Generator["postProcess"] = (out) => {
 const gitGenerators: Record<string, Fig.Generator> = {
   // Commit history
   commits: {
-    script: "git log --oneline",
+    script: "git --no-optional-locks log --oneline",
     postProcess: function (out) {
       const output = filterMessages(out);
 
@@ -106,7 +106,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
 
   // user aliases
   aliases: {
-    script: "git config --get-regexp '^alias' |cut -d. -f2",
+    script: "git --no-optional-locks config --get-regexp '^alias' |cut -d. -f2",
     postProcess: function (out) {
       return out.split("\n").map((aliasLine) => {
         const splitted = aliasLine.match(/^(\S+)\s(.*)/);
@@ -118,7 +118,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
   // Saved stashes
   // TODO: maybe only print names of stashes
   stashes: {
-    script: "git stash list",
+    script: "git --no-optional-locks stash list",
     postProcess: function (out) {
       const output = filterMessages(out);
 
@@ -143,7 +143,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
   // https://mirrors.edge.kernel.org/pub/software/scm/git/docs/#_identifier_terminology
 
   treeish: {
-    script: "git diff --cached --name-only",
+    script: "git --no-optional-locks diff --cached --name-only",
     postProcess: function (out) {
       const output = filterMessages(out);
 
@@ -164,17 +164,17 @@ const gitGenerators: Record<string, Fig.Generator> = {
 
   // All branches
   remoteLocalBranches: {
-    script: "git branch -a --no-color",
+    script: "git --no-optional-locks branch -a --no-color",
     postProcess: postProcessBranches,
   },
 
   localBranches: {
-    script: "git branch --no-color",
+    script: "git --no-optional-locks branch --no-color",
     postProcess: postProcessBranches,
   },
 
   remotes: {
-    script: "git remote -v",
+    script: "git --no-optional-locks remote -v",
     postProcess: function (out) {
       const remoteURLs = out.split("\n").reduce((dict, line) => {
         const pair = line.split("\t");
@@ -210,7 +210,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
   },
 
   tags: {
-    script: "git tag --list",
+    script: "git --no-optional-locks tag --list",
     postProcess: function (output) {
       return output.split("\n").map((tag) => ({
         name: tag,
@@ -316,7 +316,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
   },
 
   getUnstagedFiles: {
-    script: "git diff --name-only",
+    script: "git --no-optional-locks diff --name-only",
     splitOn: "\n",
   },
 

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -500,6 +500,10 @@ export const completionSpec: Fig.Spec = {
       description: "Do not use replacement refs",
     },
     {
+      name: "--no-optional-locks",
+      description: "Do not perform optional operations that require locks",
+    },
+    {
       name: "--bare",
       description: "Treat the repository as a bare repository",
     },

--- a/dev/git.ts
+++ b/dev/git.ts
@@ -221,7 +221,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
 
   // Files for staging
   files_for_staging: {
-    script: "git status --short",
+    script: "git --no-optional-locks status --short",
     postProcess: (out, context) => {
       const output = filterMessages(out);
 
@@ -230,7 +230,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
       }
 
       const files = output.split("\n").map((file) => {
-        // From "git status --short"
+        // From "git --no-optional-locks status --short"
         // M  dev/github.ts // test file that was added
         //  M dev/kubectl.ts // test file that was not added
         // A  test2.txt // new added and tracked file
@@ -310,7 +310,8 @@ const gitGenerators: Record<string, Fig.Generator> = {
   },
 
   getStagedFiles: {
-    script: "git status --short | sed -ne '/^M /p' -e '/A /p'",
+    script:
+      "git --no-optional-locks status --short | sed -ne '/^M /p' -e '/A /p'",
     postProcess: postProcessTrackedFiles,
   },
 
@@ -322,9 +323,9 @@ const gitGenerators: Record<string, Fig.Generator> = {
   getChangedTrackedFiles: {
     script: function (context) {
       if (context.includes("--staged") || context.includes("--cached")) {
-        return `git status --short | sed -ne '/^M /p' -e '/A /p'`;
+        return `git --no-optional-locks status --short | sed -ne '/^M /p' -e '/A /p'`;
       } else {
-        return `git status --short | sed -ne '/M /p' -e '/A /p'`;
+        return `git --no-optional-locks status --short | sed -ne '/M /p' -e '/A /p'`;
       }
     },
     postProcess: postProcessTrackedFiles,


### PR DESCRIPTION
This PR adds in the --no-optional-locks flag everywhere git status is run as a background command.
A index.lock file will not be created when status is run so user git commands will not be blocked from running.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
Background `git status` commands create an index.lock file which can interfere with user commands if the repo is large enough. The .lock file is still in place while Fig is generating completions and blocks the user from exec their own command.

**What is the new behavior (if this is a feature change)?**
Skip creating the .lock file when we run git status.

**Additional info:**
See explanation: https://git-scm.com/docs/git-status#_background_refresh
Re: https://github.com/withfig/fig/discussions/296