### PR TITLE
feat: add create-react-native-app spec

### DIFF
--- a/dev/create-react-native-app.ts
+++ b/dev/create-react-native-app.ts
@@ -1,0 +1,99 @@
+const ICONS = {
+  help:
+    "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/help.png",
+  version:
+    "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/info.png",
+  true:
+    "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/true.png",
+  false:
+    "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/false.png",
+  skip:
+    "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/skip.png",
+  path:
+    "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/path.png",
+  string:
+    "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/string.png",
+  template:
+    "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/export.png",
+  npm: "fig://icon?type=npm",
+};
+
+const boolArg: Fig.Arg = {
+  name: "boolean",
+  isOptional: true,
+  suggestions: [
+    {
+      name: "true",
+      icon: ICONS.true,
+    },
+    {
+      name: "false",
+      icon: ICONS.false,
+    },
+  ],
+};
+
+export const completionSpec: Fig.Spec = {
+  name: "create-react-native-app",
+  description: "Creates a new React Native project",
+  args: {
+    template: "folders",
+    name: "name",
+  },
+  options: [
+    // template
+    {
+      name: ["--template"],
+      description:
+        "The name of a template from expo/examples or URL to a GitHub repo that contains an example.",
+      args: {
+        name: "template",
+        isOptional: false,
+      },
+      icon: ICONS.template,
+    },
+    {
+      name: ["--template-path"],
+      description: "The path inside of a GitHub repo where the example lives.",
+      args: {
+        name: "name",
+        isOptional: false,
+      },
+      icon: ICONS.path,
+    },
+    // bool
+    {
+      name: ["--yes"],
+      description: "Use the default options for creating a project",
+      args: boolArg,
+      icon: ICONS.skip,
+    },
+    {
+      name: ["--no-install"],
+      description: "Skip installing npm packages or CocoaPods.",
+      args: boolArg,
+      icon: ICONS.skip,
+    },
+    {
+      name: ["--use-npm"],
+      description:
+        "Use npm to install dependencies. (default when Yarn is not installed)",
+      args: boolArg,
+      icon: ICONS.npm,
+    },
+
+    // Info
+    {
+      name: ["-h", "--help"],
+      description: "Output usage information",
+      icon: ICONS.help,
+      priority: 1,
+    },
+    {
+      name: ["-V", "--version"],
+      description: "Output the version number",
+      icon: ICONS.version,
+      priority: 1,
+    },
+  ],
+};

--- a/dev/create-react-native-app.ts
+++ b/dev/create-react-native-app.ts
@@ -51,6 +51,7 @@ export const completionSpec: Fig.Spec = {
         isOptional: false,
       },
       icon: ICONS.template,
+      priority: 76,
     },
     {
       name: ["--template-path"],
@@ -60,6 +61,7 @@ export const completionSpec: Fig.Spec = {
         isOptional: false,
       },
       icon: ICONS.path,
+      priority: 76,
     },
     // bool
     {
@@ -67,12 +69,14 @@ export const completionSpec: Fig.Spec = {
       description: "Use the default options for creating a project",
       args: boolArg,
       icon: ICONS.skip,
+      priority: 76,
     },
     {
       name: ["--no-install"],
       description: "Skip installing npm packages or CocoaPods.",
       args: boolArg,
       icon: ICONS.skip,
+      priority: 76,
     },
     {
       name: ["--use-npm"],
@@ -80,6 +84,7 @@ export const completionSpec: Fig.Spec = {
         "Use npm to install dependencies. (default when Yarn is not installed)",
       args: boolArg,
       icon: ICONS.npm,
+      priority: 76,
     },
 
     // Info

--- a/dev/npx.ts
+++ b/dev/npx.ts
@@ -1,5 +1,9 @@
 const suggestions: Fig.Suggestion[] = [
   {
+    name: "create-react-native-app",
+    icon: "https://reactnative.dev/img/pwa/manifest-icon-512.png",
+  },
+  {
     name: "react-native",
     icon: "https://reactnative.dev/img/pwa/manifest-icon-512.png",
   },

--- a/dev/pnpx.ts
+++ b/dev/pnpx.ts
@@ -3,6 +3,11 @@ export const completionSpec: Fig.Spec = {
   description: "Execute binaries from npm packages",
   subcommands: [
     {
+      name: "create-react-native-app",
+      icon: "https://reactnative.dev/img/pwa/manifest-icon-512.png",
+      loadSpec: "create-react-native-app",
+    },
+    {
       name: "react-native",
       icon: "https://reactnative.dev/img/pwa/manifest-icon-512.png",
       loadSpec: "react-native",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds support for `create-react-native-app`. Utilizes the icons added for https://github.com/withfig/autocomplete/pull/419 (I maintain both tools).