### PR TITLE
Create parser directives object under subcommand

### DIFF
--- a/dev/go.ts
+++ b/dev/go.ts
@@ -231,7 +231,9 @@ const packagesArg: Fig.Arg = {
 export const completionSpec: Fig.Spec = {
   name: "go",
   description: "Go is a tool for managing Go source code.",
-  posixNoncompliantFlags: true,
+  parserDirectives: {
+    posixNoncompliantFlags: true,
+  },
   subcommands: [
     {
       name: "bug",

--- a/dev/quickmail.ts
+++ b/dev/quickmail.ts
@@ -15,7 +15,9 @@ const bodyTempalates: Fig.Generator = {
 export const completionSpec: Fig.Spec = {
   name: "quickmail",
   description: "quickmail is a terminal-based solution to send mails",
-  posixNoncompliantFlags: true,
+  parserDirectives: {
+    posixNoncompliantFlags: true,
+  },
   options: [
     {
       name: ["-v", "--version"],

--- a/dev/terraform.ts
+++ b/dev/terraform.ts
@@ -411,6 +411,8 @@ export const completionSpec: Fig.Spec = {
   name: "terraform",
   description: "Terraform CLI",
   options: globalOptions,
-  posixNoncompliantFlags: true,
+  parserDirectives: {
+    posixNoncompliantFlags: true,
+  },
   subcommands: [...mainCommands, ...otherCommands, ...extraCommands],
 };

--- a/schemas/fig.d.ts
+++ b/schemas/fig.d.ts
@@ -26,16 +26,7 @@ declare namespace Fig {
   // both set to void by default
   export type StringOrFunction<T = void, R = void> = string | Function<T, R>;
 
-  export interface Spec extends Subcommand {
-    /**
-     * This flag allows options to have multiple characters
-     * even if they only have one hyphen
-     *
-     * @example
-     * -longflag
-     */
-    posixNoncompliantFlags?: boolean;
-  }
+  export type Spec = Subcommand;
 
   // Execute shell command function inside generators
   export type ExecuteShellCommandFunction = (
@@ -193,7 +184,16 @@ declare namespace Fig {
       executeShellCommand?: ExecuteShellCommandFunction
     ) => Promise<Spec>;
 
-    // Function<string[], Promise<Spec>>;
+    parserDirectives?: {
+      /**
+       * This flag allows options to have multiple characters
+       * even if they only have one hyphen
+       *
+       * @example
+       * -longflag
+       */
+      posixNoncompliantFlags?: boolean;
+    };
   }
 
   export interface Option extends BaseSuggestion {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Increases flexibility of parser option on a subcommand level. Eventually parser directives will group all information specific to how our internal parser should reconcile a user's buffer in the command line with a given completion spec (or subcommand of a completion spec)

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**

This is a breaking change for the 3 completion specs currently using the `posixNoncompliantFlags` option.