### PR TITLE
[hub] as wrapper for git

### DIFF
--- a/dev/hub.ts
+++ b/dev/hub.ts
@@ -1,0 +1,5 @@
+import git from "../dev/git";
+
+const completionSpec: Fig.Spec = git;
+
+export default completionSpec;

--- a/dev/hub.ts
+++ b/dev/hub.ts
@@ -1,5 +1,1 @@
-import git from "../dev/git";
-
-const completionSpec: Fig.Spec = git;
-
-export default completionSpec;
+export { default as Hub } from "./git";


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature

What is the current behavior? (You can also link to an open issue here)
Many people use Github's hub CLI tool as a wrapper and alias for git. When typing git, they expect autocompletions but don't get anything due to Fig reading the command as 'hub' and seeing no applicable spec.

What is the new behavior (if this is a feature change)?
hub gives the same exact suggestions as git. There are additional features that hub provides but I have not added them in.

Additional info:
Per hub's README: "Some hub features feel best when it's aliased as git. This is not dangerous; your normal git commands will all work. hub merely adds some sugar."

There shouldn't be any issues using the git completion spec with hub.