### PR TITLE
fix: [TMUX] session name flag '-s' should be in lowercase

### DIFF
--- a/dev/tmux.ts
+++ b/dev/tmux.ts
@@ -2115,9 +2115,9 @@ const completionSpec: Fig.Spec = {
   ],
   additionalSuggestions: [
     {
-      name: "new -S 'name'",
+      name: "new -s 'name'",
       description: "Create a new session shortcut",
-      insertValue: "new -S '{cursor}'",
+      insertValue: "new -s '{cursor}'",
       icon: "fig://template?color=2ecc71&badge=🔥",
       // type: "shortcut",
     },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
fig autocompletes this way:
`tmux new -S 'name'`
Which throws an error:
```sh
$ tmux new -S 'session1' 
tmux: unknown option -- S
```

**What is the new behavior (if this is a feature change)?**
```sh
$ tmux new -s 'session1' 
# Opens the session correctly.
```

**Additional info:**