### PR TITLE
feat: add `deprecated` flag to `BaseSuggestion` type

### DIFF
--- a/dev/docker-compose.ts
+++ b/dev/docker-compose.ts
@@ -200,14 +200,18 @@ const completionSpec: Fig.Spec = {
     },
     {
       args: {
-        name: "(never|always|auto)",
+        name: "print",
+        suggestions: ["never", "always", "auto"],
       },
-      description: "Control when to print ANSI control characters",
+      description: "Control when to print ANSI control characters.",
       name: ["--ansi"],
     },
     {
-      description: "Do not print ANSI control characters (DEPRECATED)",
+      description: "Do not print ANSI control characters.",
       name: ["--no-ansi"],
+      deprecated: {
+        alternative: "docker-compose --ansi never",
+      },
     },
     {
       description: "Print version and exit",

--- a/dev/docker/compose-pull.ts
+++ b/dev/docker/compose-pull.ts
@@ -20,8 +20,10 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["--parallel"],
-      description:
-        "Deprecated, pull multiple images in parallel (enabled by default).",
+      description: "Pull multiple images in parallel.",
+      deprecated: {
+        message: "Enabled by default.",
+      },
     },
     {
       name: ["--no-parallel"],

--- a/dev/gcloud/ai-platform.ts
+++ b/dev/gcloud/ai-platform.ts
@@ -908,7 +908,11 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--async",
                   description:
-                    "(DEPRECATED) Display information about the operation in progress without waiting for the operation to complete. Enabled by default and can be omitted; use `--stream-logs` to run synchronously.",
+                    "Display information about the operation in progress without waiting for the operation to complete.",
+                  deprecated: {
+                    message:
+                      "Enabled by default, use `--stream-logs` to run synchronously.",
+                  },
                 },
                 {
                   name: "--billing-project",

--- a/dev/gcloud/app.ts
+++ b/dev/gcloud/app.ts
@@ -2624,8 +2624,8 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "gen-repo-info-file",
-      description: "[DEPRECATED] Saves repository information in a file.",
-
+      description: "Saves repository information in a file.",
+      deprecated: true,
       options: [
         {
           name: "--account",
@@ -2719,7 +2719,10 @@ const completionSpec: Fig.Spec = {
         {
           name: "--output-file",
           description:
-            '(Deprecated; use --output-directory instead.) Specifies the full name of the output file to contain a single source context.  The file name must be "source-context.json" in order to work with cloud diagnostic tools.',
+            'Specifies the full name of the output file to contain a single source context.  The file name must be "source-context.json" in order to work with cloud diagnostic tools.',
+          deprecated: {
+            alternative: "`--output-directory` flag.",
+          },
           args: {
             name: "OUTPUT_FILE",
             description: "string",

--- a/dev/gcloud/auth.ts
+++ b/dev/gcloud/auth.ts
@@ -336,7 +336,11 @@ const completionSpec: Fig.Spec = {
             {
               name: "--add-quota-project",
               description:
-                "(DEPRECATED) Read the project from the context of the gcloud command-line tool and write it to application default credentials as the quota project. It is the default behavior.\n+\nThe --add-quota-project flag is deprecated. Enabled by default, use *--no-add-quota-project* to disable.",
+                "Read the project from the context of the gcloud command-line tool and write it to application default credentials as the quota project. It is the default behavior.",
+              deprecated: {
+                message:
+                  "Enabled by default, use --no-add-quota-project* to disable.",
+              },
             },
             {
               name: "--billing-project",

--- a/dev/gcloud/ml-engine.ts
+++ b/dev/gcloud/ml-engine.ts
@@ -908,7 +908,11 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--async",
                   description:
-                    "(DEPRECATED) Display information about the operation in progress without waiting for the operation to complete. Enabled by default and can be omitted; use `--stream-logs` to run synchronously.",
+                    "Display information about the operation in progress without waiting for the operation to complete.",
+                  deprecated: {
+                    message:
+                      "Enabled by default, use `--stream-logs` to run synchronously.",
+                  },
                 },
                 {
                   name: "--billing-project",

--- a/dev/gcloud/services.ts
+++ b/dev/gcloud/services.ts
@@ -552,8 +552,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--full",
-              description:
-                "(DEPRECATED) This flag is deprecated.\n+\nThis flag is deprecated.",
+              deprecated: true,
               args: {
                 name: "FULL",
                 description: "int",

--- a/dev/gcloud/sql.ts
+++ b/dev/gcloud/sql.ts
@@ -4233,7 +4233,11 @@ const completionSpec: Fig.Spec = {
             {
               name: "--gce-zone",
               description:
-                "(DEPRECATED) Preferred Compute Engine zone (e.g. us-central1-a, us-central1-b, etc.).\n+\nFlag `--gce-zone` is deprecated and will be removed by release 255.0.0. Use `--zone` instead.",
+                "Preferred Compute Engine zone (e.g. us-central1-a, us-central1-b, etc.).",
+              deprecated: {
+                alternative: "Use the `--zone` flag.",
+                message: "It will be removed by release 255.0.0.",
+              },
               args: {
                 name: "GCE_ZONE",
                 description: "string",
@@ -4789,8 +4793,8 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "export",
-          description:
-            "*(DEPRECATED)*  Exports data from a Cloud SQL instance.",
+          description: "Exports data from a Cloud SQL instance.",
+          deprecated: true,
 
           options: [
             {
@@ -5108,7 +5112,8 @@ const completionSpec: Fig.Spec = {
         {
           name: "import",
           description:
-            "*(DEPRECATED)*  Imports data into a Cloud SQL instance from Google Cloud Storage.",
+            "Imports data into a Cloud SQL instance from Google Cloud Storage.",
+          deprecated: true,
 
           options: [
             {
@@ -5677,7 +5682,11 @@ const completionSpec: Fig.Spec = {
             {
               name: "--gce-zone",
               description:
-                "(DEPRECATED) Preferred Compute Engine zone (e.g. us-central1-a, us-central1-b, etc.). WARNING: Instance may be restarted.\n+\nFlag `--gce-zone` is deprecated and will be removed by release 255.0.0. Use `--zone` instead.",
+                "Preferred Compute Engine zone (e.g. us-central1-a, us-central1-b, etc.). WARNING: Instance may be restarted.",
+              deprecated: {
+                alternative: "Use the `--zone` flag.",
+                message: "It will be removed by release 255.0.0.",
+              },
               args: {
                 name: "GCE_ZONE",
                 description: "string",
@@ -8359,13 +8368,13 @@ const completionSpec: Fig.Spec = {
     {
       name: "ssl-certs",
       description:
-        "*(DEPRECATED)*  Provide commands for managing SSL certificates of Cloud SQL instances.",
+        "Provide commands for managing SSL certificates of Cloud SQL instances.",
+      deprecated: true,
       subcommands: [
         {
           name: "create",
-          description:
-            "*(DEPRECATED)*  Creates an SSL certificate for a Cloud SQL instance.",
-
+          description: "Creates an SSL certificate for a Cloud SQL instance.",
+          deprecated: true,
           options: [
             {
               name: "--account",
@@ -8521,8 +8530,8 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "delete",
-          description:
-            "*(DEPRECATED)*  Deletes an SSL certificate for a Cloud SQL instance.",
+          description: "Deletes an SSL certificate for a Cloud SQL instance.",
+          deprecated: true,
 
           options: [
             {
@@ -8679,8 +8688,8 @@ const completionSpec: Fig.Spec = {
         {
           name: "describe",
           description:
-            "*(DEPRECATED)*  Retrieves information about an SSL cert for a Cloud SQL instance.",
-
+            "Retrieves information about an SSL cert for a Cloud SQL instance.",
+          deprecated: true,
           options: [
             {
               name: "--account",
@@ -8830,9 +8839,8 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "list",
-          description:
-            "*(DEPRECATED)*  Lists all SSL certs for a Cloud SQL instance.",
-
+          description: "Lists all SSL certs for a Cloud SQL instance.",
+          deprecated: true,
           options: [
             {
               name: "--account",

--- a/schemas/fig.d.ts
+++ b/schemas/fig.d.ts
@@ -105,6 +105,30 @@ declare namespace Fig {
      * The "-" suggestion is hidden in the `cd` spec. You will only see it if you type cd -
      */
     hidden?: boolean;
+
+    /**
+     *
+     * Specifies whether a suggestion is deprecated.
+     * It is possible to optionally specify a deprecation message and an alternative command to run.
+     *
+     * `deprecated: true` and `deprecated: { }` will just display the option as deprecated.
+     *
+     */
+    deprecated?:
+      | boolean
+      | {
+          /**
+           * Provide an alternative to the deprecated command.
+           *
+           * @example
+           * alternative: 'npm install'
+           */
+          alternative?: string;
+          /**
+           * Provide a warning or additional info about the deprecation.
+           */
+          message?: string;
+        };
   }
 
   export interface Suggestion extends BaseSuggestion {


### PR DESCRIPTION
It introduces a new `deprecated` flag to `BaseSuggestion`. 
I have added some examples to clarify the use case.