### PR TITLE
Additions to Cargo's autocompletion

### DIFF
--- a/dev/cargo.ts
+++ b/dev/cargo.ts
@@ -23,7 +23,7 @@ const completionSpec: Fig.Spec = {
           description: "alias for workspace",
         },
         {
-          name: ["--release"],
+          name: "--release",
           description: "build in release mode, with optimizations",
         },
         {
@@ -42,7 +42,7 @@ const completionSpec: Fig.Spec = {
           description: "output usage info",
         },
         {
-          name: ["--release"],
+          name: "--release",
           description: "build in release mode, with optimizations",
         },
       ],
@@ -77,7 +77,7 @@ const completionSpec: Fig.Spec = {
           description: "output usage info",
         },
         {
-          name: ["--release"],
+          name: "--release",
           description: "test in release mode, with optimizations",
         },
       ],

--- a/dev/cargo.ts
+++ b/dev/cargo.ts
@@ -3,7 +3,7 @@ const completionSpec: Fig.Spec = {
   description: "CLI Interface for Cargo",
   subcommands: [
     {
-      name: "build",
+      name: ["build", "b"],
       description: "compile local package and dependencies",
       options: [
         {
@@ -23,6 +23,10 @@ const completionSpec: Fig.Spec = {
           description: "alias for workspace",
         },
         {
+          name: ["--release"],
+          description: "build in release mode, with optimizations",
+        },
+        {
           name: ["-j, --jobs"],
           description: "number of CPUS",
           insertValue: "-j {cursor}",
@@ -30,12 +34,16 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: "run",
+      name: ["run", "r"],
       description: "Run a binary or example of the local package",
       options: [
         {
           name: ["-h", "--help"],
           description: "output usage info",
+        },
+        {
+          name: ["--release"],
+          description: "build in release mode, with optimizations",
         },
       ],
     },
@@ -59,6 +67,16 @@ const completionSpec: Fig.Spec = {
       args: {
         template: "filepaths",
       },
+    },
+    {
+      name: ["test", "t"],
+      description: "run tests",
+      options: [
+        {
+          name: ["-h", "--h"],
+          description: "output usage info",
+        },
+      ],
     },
     {
       name: "rustc",

--- a/dev/cargo.ts
+++ b/dev/cargo.ts
@@ -76,6 +76,10 @@ const completionSpec: Fig.Spec = {
           name: ["-h", "--h"],
           description: "output usage info",
         },
+        {
+          name: ["--release"],
+          description: "test in release mode, with optimizations",
+        },
       ],
     },
     {


### PR DESCRIPTION
This change adds features to the cargo autocompletion.

Currently autocomplete for `build` and `run` offers a number number of build modes, but not the `--release` mode. Fig also currently requires the full names `build`, `run`, and `test` is currently not a candidate for autocompletion.

This PR adds a cursory completion for `test`, single letter forms for `build`, `run`, and `test` (`b`, `r`, and `t` respectively), along with the `--release` flag for build and run.