### PR TITLE
Completed lsd spec

### DIFF
--- a/dev/lsd.ts
+++ b/dev/lsd.ts
@@ -1,6 +1,6 @@
 const completionSpec: Fig.Spec = {
   name: "lsd",
-  description: "as ls command with a lot of pretty colors and some other stuff",
+  description: "an ls command with a lot of pretty colors and some other stuff",
   args: {
     isVariadic: true,
     template: "folders",

--- a/dev/lsd.ts
+++ b/dev/lsd.ts
@@ -1,233 +1,192 @@
 const completionSpec: Fig.Spec = {
   name: "lsd",
-  description: "list directory contents",
+  description: "as ls command with a lot of pretty colors and some other stuff",
   args: {
     isVariadic: true,
     template: "folders",
+    default: "."
   },
   options: [
     {
-      name: "-@",
+      name: ["-1", "--oneline"],
       description:
-        "Display extended attribute keys and sizes in long (-l) output.",
+        "Display one entry per line",
     },
-
     {
-      name: "-1",
+      name: ["-A", "--almost-all"],
       description:
-        "(The numeric digit ``one''.)  Force output to be one entry per line.  This is the default when output is not to a terminal.",
+        "Do not list implied . and ..",
     },
-
     {
-      name: "-A",
+      name: ["-a", "--all"],
       description:
-        "List all entries except for . and ...  Always set for the super-user.",
+        "Do not ignore entries starting with .",
     },
-
     {
-      name: "-a",
+      name: ["-d", "--directory-only"],
       description:
-        "Include directory entries whose names begin with a dot (.).",
+        "Display directories themselves, and not their contents (recursively when used with --tree)",
     },
-
     {
-      name: "-B",
+      name: ["-F", "--classify"],
       description:
-        "Force printing of non-printable characters (as defined by ctype(3) and current locale settings) in file names as xxx, where xxx is the numeric value of the character in octal.",
+        "Append indicator (one of */=>@|) at the end of the file names",
     },
-
     {
-      name: "-b",
-      description: "As -B, but use C escape codes whenever possible.",
-    },
-
-    {
-      name: "-C",
+      name: ["-h", "--human-readable"],
       description:
-        "Force multi-column output; this is the default when output is to a terminal.",
+        "For ls compatibility purposes ONLY, currently set by default",
     },
-
     {
-      name: "-c",
+      name: ["-i", "--inode"],
       description:
-        "Use time when file status was last changed for sorting (-t) or long printing (-l).",
+        "Display the index number of each file",
     },
-
     {
-      name: "-d",
+      name: ["-L", "--dereference"],
       description:
-        "Directories are listed as plain files (not searched recursively).",
+        "When showing file information for a symbolic link, show information for the file the link references rather than for the link itself",
     },
-
     {
-      name: "-e",
+      name: ["-l", "--long"],
       description:
-        "Print the Access Control List (ACL) associated with the file, if present, in long (-l) output.",
+        "Display the extended file metadata as a table",
     },
-
+    { 
+      name: ["-R", "--recursive"], 
+      description: "Recurse into directories" },
     {
-      name: "-F",
+      name: ["-r", "--reverse"],
       description:
-        "Display a slash (/) immediately after each pathname that is a directory, an asterisk (*) after each that is executable, an at sign (@) after each symbolic link, an equals sign (=) after each socket, a percent sign (%) after each whiteout, and a vertical bar (|) after each that is a FIFO.",
+        "Reverse the order of the sort",
     },
-
+    { 
+      name: ["-S", "--sizesort"],
+      description: "Sort by size" },
     {
-      name: "-f",
-      description: "Output is not sorted.  This option turns on the -a option.",
-    },
-
-    {
-      name: "-G",
+      name: ["-t", "--timesort"],
       description:
-        "Enable colorized output.  This option is equivalent to defining CLICOLOR in the environment.  (See below.)",
+        "Sort by time modified"
     },
-
     {
-      name: "-g",
+      name: ["-v", "--versionsort"],
       description:
-        "This option is only available for compatibility with POSIX; it is used to display the group name in the long (-l) format output (the owner name is suppressed). ",
+        "Natural sort of (version) numbers within text",
     },
-
     {
-      name: "-H",
-      description:
-        "Symbolic links on the command line are followed.  This option is assumed if none of the -F, -d, or -l options are specified.",
+      name: "--classic",
+      description: "Enable classic mode (no colors or icons)"
     },
-
     {
-      name: "-h",
-      description:
-        "When used with the -l option, use unit suffixes: Byte, Kilobyte, Megabyte, Gigabyte, Terabyte and Petabyte in order to reduce the number of digits to three or less using base 2 for sizes.",
+      name: ["-X", "--extensionsort"],
+      description: "Sort by file extension"
     },
-
     {
-      name: "-i",
-      description:
-        "For each file, print the file's file serial number (inode number).",
+      name: "--extensionsort",
+      description: "Prints help information"
     },
-
     {
-      name: "-k",
-      description:
-        "If the -s option is specified, print the file size allocation in kilobytes, not blocks.  This option overrides the environment variable BLOCKSIZE.",
+      name: "--ignore-config",
+      description: "Ignore the configuration file"
     },
-
     {
-      name: "-L",
-      description:
-        "Follow all symbolic links to final target and list the file or directory the link references rather than the link itself.  This option cancels the -P option.",
+      name: "--no-symlink",
+      description: "Do not display symlink target"
     },
-
     {
-      name: "-l",
-      description:
-        "(The lowercase letter ``ell''.)  List in long format.  (See below.)  A total sum for all the file sizes is output on a line before the long listing.",
+      name: "--total-size",
+      description: "Display the total size of directories"
     },
-
     {
-      name: "-m",
-      description:
-        "Stream output format; list files across the page, separated by commas.",
+      name: "--tree",
+      description: "Recurse into directories and present the result as a tree"
     },
-
     {
-      name: "-n",
-      description:
-        "Display user and group IDs numerically, rather than converting to a user or group name in a long (-l) output.  This option turns on the -l option.",
+      name: ["-V", "--version"],
+      description: "Prints version information"
     },
-
     {
-      name: "-O",
-      description: "Include the file flags in a long (-l) output.",
+      name: "--blocks",
+      description: "Specify the blocks that will be displayed and in what order",
+      args: {
+        name: "blocks",
+        suggestions: ["permission", "user", "group", "size", "date", "name", "inode", "links"]
+      }
     },
-
-    { name: "-o", description: "List in long format, but omit the group id." },
-
     {
-      name: "-P",
-      description:
-        "If argument is a symbolic link, list the link itself rather than the object the link references.  This option cancels the -H and -L options",
+      name: "--color",
+      description: "When to use terminal colours",
+      args: {
+        name: "color",
+        suggestions: ["always", "auto", "never"],
+        default: "auto"
+      }
     },
-
     {
-      name: "-p",
-      description:
-        "Write a slash (`/') after each filename if that file is a directory.",
+      name: "--date",
+      description: "How to display date",
+      args: {
+        name: "date",
+        suggestions: ["date", "relative", "+date-time-format"],
+        default: "date"
+      }
     },
-
     {
-      name: "-q",
-      description:
-        "Force printing of non-graphic characters in file names as the character `?'; this is the default when output is to a terminal.",
+      name: "--depth",
+      description: "Stop recursing into directories after reaching depth",
+      args: {
+        name: "num"
+      }
     },
-
-    { name: "-R", description: "Recursively list subdirectories encountered." },
-
     {
-      name: "-r",
-      description:
-        "Reverse the order of the sort to get reverse lexicographical order or the oldest entries first (or largest files last, if combined with sort by size",
+      name: "--group-dirs",
+      description: "Sort the directories then the files",
+      args: {
+        name: "group-dirs",
+        suggestions: ["none", "first", "last"]
+      }
     },
-
-    { name: "-S", description: "Sort files by size" },
-
     {
-      name: "-s",
-      description:
-        "Display the number of file system blocks actually used by each file, in units of 512 bytes, where partial units are rounded up to the next integer value.  If the output is to a terminal, a total sum for all the file sizes is output on a line before the listing.  The environment variable BLOCKSIZE overrides the unit size of 512 bytes.",
+      name: "--icon",
+      description: "When to print the icons",
+      args: {
+        name: "icon",
+        suggestions: ["always", "auto", "never"],
+        default: "auto"
+      }
     },
-
     {
-      name: "-T",
-      description:
-        "When used with the -l (lowercase letter ``ell'') option, display complete time information for the file, including month, day, hour, minute, second, and year.",
+      name: "--icon-theme",
+      description: "Whether to use fancy or unicode icons",
+      args: {
+        name: "icon-theme",
+        suggestions: ["fancy", "unicode"],
+        default: "fancy"
+      }
     },
-
     {
-      name: "-t",
-      description:
-        "Sort by time modified (most recently modified first) before sorting the operands by lexicographical order.",
+      name: "--ignore-glob",
+      description: "Do not display files/directories with names matching the glob pattern(s). More than one can be specified by repeating the argument",
+      args: {
+        name: "pattern"
+      }
     },
-
     {
-      name: "-u",
-      description:
-        "Use time of last access, instead of last modification of the file for sorting (-t) or long printing (-l).",
+      name: "--size",
+      description: "How to display size",
+      args: {
+        name: "size",
+        suggestions: ["default", "short", "bytes"],
+        default: "default"
+      }
     },
-
     {
-      name: "-U",
-      description:
-        "Use time of file creation, instead of last modification for sorting (-t) or long output (-l).",
-    },
-
-    {
-      name: "-v",
-      description:
-        "Force unedited printing of non-graphic characters; this is the default when output is not to a terminal.",
-    },
-
-    {
-      name: "-W",
-      description: "Display whiteouts when scanning directories.  (-S) flag).",
-    },
-
-    {
-      name: "-w",
-      description:
-        "Force raw printing of non-printable characters.  This is the default when output is not to a terminal.",
-    },
-
-    {
-      name: "-x",
-      description:
-        "The same as -C, except that the multi-column output is produced with entries sorted across, rather than down, the columns.",
-    },
-
-    {
-      name: "-%",
-      description:
-        "Distinguish dataless files and directories with a '%' character in long (-l) output, and don't materialize dataless directories when listing them.",
+      name: "--sort",
+      description: "Sort by WORD instead of name",
+      args: {
+        name: "WORD",
+        suggestions: ["size", "time", "version", "extension"]
+      }
     },
   ],
 };

--- a/dev/lsd.ts
+++ b/dev/lsd.ts
@@ -82,7 +82,7 @@ const completionSpec: Fig.Spec = {
       description: "Sort by file extension"
     },
     {
-      name: "--extensionsort",
+      name: "--help",
       description: "Prints help information"
     },
     {

--- a/dev/lsd.ts
+++ b/dev/lsd.ts
@@ -4,23 +4,20 @@ const completionSpec: Fig.Spec = {
   args: {
     isVariadic: true,
     template: "folders",
-    default: "."
+    default: ".",
   },
   options: [
     {
       name: ["-1", "--oneline"],
-      description:
-        "Display one entry per line",
+      description: "Display one entry per line",
     },
     {
       name: ["-A", "--almost-all"],
-      description:
-        "Do not list implied . and ..",
+      description: "Do not list implied . and ..",
     },
     {
       name: ["-a", "--all"],
-      description:
-        "Do not ignore entries starting with .",
+      description: "Do not ignore entries starting with .",
     },
     {
       name: ["-d", "--directory-only"],
@@ -39,8 +36,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["-i", "--inode"],
-      description:
-        "Display the index number of each file",
+      description: "Display the index number of each file",
     },
     {
       name: ["-L", "--dereference"],
@@ -49,69 +45,77 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["-l", "--long"],
-      description:
-        "Display the extended file metadata as a table",
+      description: "Display the extended file metadata as a table",
     },
-    { 
-      name: ["-R", "--recursive"], 
-      description: "Recurse into directories" },
+    {
+      name: ["-R", "--recursive"],
+      description: "Recurse into directories",
+    },
     {
       name: ["-r", "--reverse"],
-      description:
-        "Reverse the order of the sort",
+      description: "Reverse the order of the sort",
     },
-    { 
+    {
       name: ["-S", "--sizesort"],
-      description: "Sort by size" },
+      description: "Sort by size",
+    },
     {
       name: ["-t", "--timesort"],
-      description:
-        "Sort by time modified"
+      description: "Sort by time modified",
     },
     {
       name: ["-v", "--versionsort"],
-      description:
-        "Natural sort of (version) numbers within text",
+      description: "Natural sort of (version) numbers within text",
     },
     {
       name: "--classic",
-      description: "Enable classic mode (no colors or icons)"
+      description: "Enable classic mode (no colors or icons)",
     },
     {
       name: ["-X", "--extensionsort"],
-      description: "Sort by file extension"
+      description: "Sort by file extension",
     },
     {
       name: "--help",
-      description: "Prints help information"
+      description: "Prints help information",
     },
     {
       name: "--ignore-config",
-      description: "Ignore the configuration file"
+      description: "Ignore the configuration file",
     },
     {
       name: "--no-symlink",
-      description: "Do not display symlink target"
+      description: "Do not display symlink target",
     },
     {
       name: "--total-size",
-      description: "Display the total size of directories"
+      description: "Display the total size of directories",
     },
     {
       name: "--tree",
-      description: "Recurse into directories and present the result as a tree"
+      description: "Recurse into directories and present the result as a tree",
     },
     {
       name: ["-V", "--version"],
-      description: "Prints version information"
+      description: "Prints version information",
     },
     {
       name: "--blocks",
-      description: "Specify the blocks that will be displayed and in what order",
+      description:
+        "Specify the blocks that will be displayed and in what order",
       args: {
         name: "blocks",
-        suggestions: ["permission", "user", "group", "size", "date", "name", "inode", "links"]
-      }
+        suggestions: [
+          "permission",
+          "user",
+          "group",
+          "size",
+          "date",
+          "name",
+          "inode",
+          "links",
+        ],
+      },
     },
     {
       name: "--color",
@@ -119,8 +123,8 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "color",
         suggestions: ["always", "auto", "never"],
-        default: "auto"
-      }
+        default: "auto",
+      },
     },
     {
       name: "--date",
@@ -128,23 +132,23 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "date",
         suggestions: ["date", "relative", "+date-time-format"],
-        default: "date"
-      }
+        default: "date",
+      },
     },
     {
       name: "--depth",
       description: "Stop recursing into directories after reaching depth",
       args: {
-        name: "num"
-      }
+        name: "num",
+      },
     },
     {
       name: "--group-dirs",
       description: "Sort the directories then the files",
       args: {
         name: "group-dirs",
-        suggestions: ["none", "first", "last"]
-      }
+        suggestions: ["none", "first", "last"],
+      },
     },
     {
       name: "--icon",
@@ -152,8 +156,8 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "icon",
         suggestions: ["always", "auto", "never"],
-        default: "auto"
-      }
+        default: "auto",
+      },
     },
     {
       name: "--icon-theme",
@@ -161,15 +165,16 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "icon-theme",
         suggestions: ["fancy", "unicode"],
-        default: "fancy"
-      }
+        default: "fancy",
+      },
     },
     {
       name: "--ignore-glob",
-      description: "Do not display files/directories with names matching the glob pattern(s). More than one can be specified by repeating the argument",
+      description:
+        "Do not display files/directories with names matching the glob pattern(s). More than one can be specified by repeating the argument",
       args: {
-        name: "pattern"
-      }
+        name: "pattern",
+      },
     },
     {
       name: "--size",
@@ -177,16 +182,16 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "size",
         suggestions: ["default", "short", "bytes"],
-        default: "default"
-      }
+        default: "default",
+      },
     },
     {
       name: "--sort",
       description: "Sort by WORD instead of name",
       args: {
         name: "WORD",
-        suggestions: ["size", "time", "version", "extension"]
-      }
+        suggestions: ["size", "time", "version", "extension"],
+      },
     },
   ],
 };


### PR DESCRIPTION
lsd was previously a wrapper for ls but they don't have the same options or arguments.

Completed spec to match lsd --help