### PR TITLE
Autocomplete spec for ionic cli

### DIFF
--- a/dev/ionic.ts
+++ b/dev/ionic.ts
@@ -29,6 +29,12 @@ const completionSpec = {
         {
           name: ["--configuration", "-c"],
           description: "Specify the configuration to use",
+          args: [
+            {
+              name: "conf",
+              template: ["filepaths", "folders"],
+            },
+          ],
         },
         {
           name: ["--source-map"],
@@ -255,6 +261,7 @@ const completionSpec = {
           args: [
             {
               name: "conf",
+              template: ["filepaths", "folders"],
             },
           ],
         },
@@ -599,6 +606,12 @@ const completionSpec = {
             {
               name: ["--configuration", "-c"],
               description: "Specify the configuration to use",
+              args: [
+                {
+                  name: "conf",
+                  template: ["filepaths", "folders"],
+                },
+              ],
             },
             {
               name: ["--source-map"],
@@ -633,6 +646,12 @@ const completionSpec = {
             {
               name: ["--configuration", "-c"],
               description: "Specify the configuration to use",
+              args: [
+                {
+                  name: "conf",
+                  template: ["filepaths", "folders"],
+                },
+              ],
             },
             {
               name: ["--source-map"],
@@ -1292,6 +1311,7 @@ const completionSpec = {
               description: "Use the specified build configuration",
               args: {
                 name: "file",
+                template: ["filepaths", "folders"],
               },
             },
             {
@@ -1301,6 +1321,12 @@ const completionSpec = {
             {
               name: ["--configuration", "-c"],
               description: "Specify the configuration to use",
+              args: [
+                {
+                  name: "conf",
+                  template: ["filepaths", "folders"],
+                },
+              ],
             },
             {
               name: ["--source-map"],
@@ -1342,6 +1368,7 @@ const completionSpec = {
               description: "Use the specified build configuration",
               args: {
                 name: "file",
+                template: ["filepaths", "folders"],
               },
             },
           ],
@@ -1426,6 +1453,7 @@ const completionSpec = {
               description: "Use the specified build configuration",
               args: {
                 name: "file",
+                template: ["filepaths", "folders"],
               },
             },
             {
@@ -1472,6 +1500,12 @@ const completionSpec = {
             {
               name: ["--configuration", "-c"],
               description: "Specify the configuration to use",
+              args: [
+                {
+                  name: "conf",
+                  template: ["filepaths", "folders"],
+                },
+              ],
             },
             {
               name: ["--source-map"],
@@ -1483,6 +1517,7 @@ const completionSpec = {
               args: [
                 {
                   name: "file",
+                  template: ["filepaths", "folders"],
                 },
               ],
             },
@@ -1574,6 +1609,7 @@ const completionSpec = {
               args: [
                 {
                   name: "conf",
+                  template: ["filepaths", "folders"],
                 },
               ],
             },
@@ -1706,6 +1742,7 @@ const completionSpec = {
               description: "Use the specified build configuration",
               args: {
                 name: "file",
+                template: ["filepaths", "folders"],
               },
             },
             {
@@ -1755,6 +1792,7 @@ const completionSpec = {
               args: [
                 {
                   name: "conf",
+                  template: ["filepaths", "folders"],
                 },
               ],
             },

--- a/dev/ionic.ts
+++ b/dev/ionic.ts
@@ -347,6 +347,7 @@ const completionSpec = {
     },
     {
       name: "config",
+      description: "Config commands for Ionic",
       subcommands: [
         {
           name: "get",
@@ -432,6 +433,7 @@ const completionSpec = {
     },
     {
       name: "capacitor",
+      description: "Capacitor commands Ionic",
       subcommands: [
         {
           name: "add",
@@ -668,6 +670,7 @@ const completionSpec = {
     },
     {
       name: "deploy",
+      description: "AppFlow deploy commands for Ionic",
       subcommands: [
         {
           name: "add",
@@ -809,6 +812,7 @@ const completionSpec = {
     },
     {
       name: "git",
+      description: "Git commands for Ionic",
       subcommands: [
         {
           name: "remote",
@@ -819,6 +823,7 @@ const completionSpec = {
     },
     {
       name: "package",
+      description: "Package commands for Ionic",
       subcommands: [
         {
           name: "build",
@@ -970,6 +975,7 @@ const completionSpec = {
     },
     {
       name: "ssl",
+      description: "SSL commands for Ionic",
       subcommands: [
         {
           name: "generate",
@@ -1046,6 +1052,7 @@ const completionSpec = {
     },
     {
       name: "ssh",
+      description: "SSH commands for Ionic",
       subcommands: [
         {
           name: "add",
@@ -1143,6 +1150,7 @@ const completionSpec = {
     },
     {
       name: "doctor",
+      description: "Doctor commands for Ionic",
       subcommands: [
         {
           name: "check",
@@ -1174,6 +1182,7 @@ const completionSpec = {
     },
     {
       name: "integrations",
+      description: "Integration commands for Ionic",
       subcommands: [
         {
           name: "disable",
@@ -1227,6 +1236,7 @@ const completionSpec = {
     },
     {
       name: "enterprise",
+      description: "Enterprise commands for Ionic",
       subcommands: [
         {
           name: "register",
@@ -1252,6 +1262,7 @@ const completionSpec = {
     },
     {
       name: "cordova",
+      description: "Cordova commands for Ionic",
       subcommands: [
         {
           name: "build",

--- a/dev/ionic.ts
+++ b/dev/ionic.ts
@@ -11,6 +11,7 @@ const completionSpec = {
           description: "Target engine (e.g. browser, cordova)",
           args: {
             name: "engine",
+            suggestions: ["browser", "cordova"],
           },
         },
         {
@@ -18,7 +19,24 @@ const completionSpec = {
           description: "Target platform on chosen engine (e.g. ios, android)",
           args: {
             name: "platform",
+            suggestions: ["ios", "android"],
           },
+        },
+        {
+          name: ["--prod"],
+          description: "Flag to use the production configuration",
+        },
+        {
+          name: ["--configuration", "-c"],
+          description: "Specify the configuration to use",
+        },
+        {
+          name: ["--source-map"],
+          description: "Output source maps",
+        },
+        {
+          name: ["--watch"],
+          description: "Rebuild when files change",
         },
       ],
       description:
@@ -37,6 +55,7 @@ const completionSpec = {
             "Specifies the browser to use (safari, firefox, google chrome)",
           args: {
             name: "browser",
+            suggestions: ["safari", "firefox", "google chrome"],
           },
         },
       ],
@@ -60,6 +79,7 @@ const completionSpec = {
           description: "Type of project (e.g. angular, react, vue, custom)",
           args: {
             name: "type",
+            suggestions: ["angular", "react", "vue", "custom"],
           },
         },
         {
@@ -153,6 +173,7 @@ const completionSpec = {
           description: "Use specific port for the dev server",
           args: {
             name: "port",
+            default: 8100,
           },
         },
         {
@@ -160,10 +181,11 @@ const completionSpec = {
           description: "The host used for the browser or web view",
           args: {
             name: "host",
+            default: "localhost",
           },
         },
         {
-          name: ["--livereload"],
+          name: ["--no-livereload"],
           description: "Do not spin up dev server--just serve files",
         },
         {
@@ -171,6 +193,7 @@ const completionSpec = {
           description: "Use specific host for Ionic Lab server",
           args: {
             name: "host",
+            default: 8200,
           },
         },
         {
@@ -181,7 +204,7 @@ const completionSpec = {
           },
         },
         {
-          name: ["--open"],
+          name: ["--no-open"],
           description: "Do not open a browser window",
         },
         {
@@ -190,6 +213,7 @@ const completionSpec = {
             "Specifies the browser to use (safari, firefox, google chrome)",
           args: {
             name: "browser",
+            suggestions: ["safari", "firefox", "google chrome"],
           },
         },
         {
@@ -203,6 +227,40 @@ const completionSpec = {
           name: ["--lab", "-l"],
           description:
             "Test your apps on multiple platform types in the browser",
+        },
+        {
+          name: ["--ssl"],
+          description: "Use HTTPS for the dev server",
+        },
+        {
+          name: ["--prod"],
+          description: "Flag to use the production configuration",
+        },
+        {
+          name: ["--consolelogs"],
+          description: "Print app console logs to the terminal",
+        },
+        {
+          name: ["--consolelogs-port"],
+          description: "Use specific port for console logs server",
+          args: [
+            {
+              name: "port",
+            },
+          ],
+        },
+        {
+          name: ["--configuration", "-c"],
+          description: "Specify the configuration to use",
+          args: [
+            {
+              name: "conf",
+            },
+          ],
+        },
+        {
+          name: ["--source-map"],
+          description: "Output sourcemaps",
         },
       ],
       description: "Start a local dev server for app dev/testing",
@@ -224,6 +282,7 @@ const completionSpec = {
             "Type of project to start (e.g. vue, angular, react, ionic-angular, ionic1)",
           args: {
             name: "type",
+            suggestions: ["vue", "angular", "react", "ionic-angular", "ionic1"],
           },
         },
         {
@@ -235,11 +294,11 @@ const completionSpec = {
           description: "Include Capacitor integration",
         },
         {
-          name: ["--deps"],
+          name: ["--no-deps"],
           description: "Do not install npm/yarn dependencies",
         },
         {
-          name: ["--git"],
+          name: ["--no-git"],
           description: "Do not initialize a git repo",
         },
         {
@@ -276,6 +335,7 @@ const completionSpec = {
           description: 'The name of your new project (e.g. myApp, "My App")',
           isOptional: false,
         },
+        // Hard to do suggestions for template b/c different templates exist for different --types
         {
           name: "template",
           description:
@@ -380,6 +440,7 @@ const completionSpec = {
               name: "platform",
               description: "The platform to add (e.g. android, ios)",
               isOptional: false,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Add a native platform to your Ionic project",
@@ -388,12 +449,28 @@ const completionSpec = {
           name: "build",
           options: [
             {
-              name: ["--build"],
+              name: ["--no-build"],
               description: "Do not invoke Ionic build",
             },
             {
-              name: ["--open"],
+              name: ["--no-open"],
               description: "Do not invoke Capacitor open",
+            },
+            {
+              name: ["--prod"],
+              description: "Flag to use the production configuration",
+            },
+            {
+              name: ["configuration", "-c"],
+              description: "Specify the configuration to use",
+            },
+            {
+              name: ["--source-map"],
+              description: "Output source maps",
+            },
+            {
+              name: ["--watch"],
+              description: "Rebuild when files change",
             },
           ],
           args: [
@@ -401,6 +478,7 @@ const completionSpec = {
               name: "platform",
               description: "The platform to build for (e.g. android, ios)",
               isOptional: false,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Build an Ionic project for a given platform",
@@ -409,8 +487,24 @@ const completionSpec = {
           name: "copy",
           options: [
             {
-              name: ["--build"],
+              name: ["--no-build"],
               description: "Do not invoke an Ionic build",
+            },
+            {
+              name: ["--prod"],
+              description: "Flag to use the production configuration",
+            },
+            {
+              name: ["configuration", "-c"],
+              description: "Specify the configuration to use",
+            },
+            {
+              name: ["--source-map"],
+              description: "Output source maps",
+            },
+            {
+              name: ["--watch"],
+              description: "Rebuild when files change",
             },
           ],
           args: [
@@ -429,6 +523,7 @@ const completionSpec = {
               name: "platform",
               description: "The platform to open (e.g. android, ios)",
               isOptional: false,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Open the IDE for a given native platform project",
@@ -453,7 +548,7 @@ const completionSpec = {
               description: "Open native IDE instead of using capacitor run",
             },
             {
-              name: ["--build"],
+              name: ["--no-build"],
               description: "Do not invoke Ionic build",
             },
             {
@@ -466,6 +561,7 @@ const completionSpec = {
               description: "Use specific host for the dev server",
               args: {
                 name: "host",
+                default: "localhost",
               },
             },
             {
@@ -473,6 +569,7 @@ const completionSpec = {
               description: "Use specific port for the dev server",
               args: {
                 name: "port",
+                default: 8100,
               },
             },
             {
@@ -493,12 +590,29 @@ const completionSpec = {
                 name: "url",
               },
             },
+            {
+              name: ["--prod"],
+              description: "Flag to use the production configuration",
+            },
+            {
+              name: ["--configuration", "-c"],
+              description: "Specify the configuration to use",
+            },
+            {
+              name: ["--source-map"],
+              description: "Output source maps",
+            },
+            {
+              name: ["--watch"],
+              description: "Rebuild when files change",
+            },
           ],
           args: [
             {
               name: "platform",
               description: "The platform to run (e.g. android, ios)",
               isOptional: false,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Run an Ionic project on a connected device",
@@ -507,8 +621,24 @@ const completionSpec = {
           name: "sync",
           options: [
             {
-              name: ["--build"],
+              name: ["--no-build"],
               description: "Do not invoke an Ionic build",
+            },
+            {
+              name: ["--prod"],
+              description: "Flag to use the production configuration",
+            },
+            {
+              name: ["--configuration", "-c"],
+              description: "Specify the configuration to use",
+            },
+            {
+              name: ["--source-map"],
+              description: "Output source maps",
+            },
+            {
+              name: ["--watch"],
+              description: "Rebuild when files change",
             },
           ],
           args: [
@@ -516,6 +646,7 @@ const completionSpec = {
               name: "platform",
               description: "The platform to sync (e.g. android, ios)",
               isOptional: true,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Sync (copy + update) an Ionic project",
@@ -527,6 +658,7 @@ const completionSpec = {
               name: "platform",
               description: "The platform to update (e.g. android, ios)",
               isOptional: true,
+              suggestions: ["ios", "android"],
             },
           ],
           description:
@@ -568,6 +700,7 @@ const completionSpec = {
                 "The maximum number of downloaded versions to store on the device",
               args: {
                 name: "quantity",
+                default: 2,
               },
             },
             {
@@ -576,6 +709,7 @@ const completionSpec = {
                 "The minimum duration after which the app checks for an update in the background",
               args: {
                 name: "seconds",
+                default: 30,
               },
             },
           ],
@@ -733,6 +867,11 @@ const completionSpec = {
                 'Target platform ("Android", "iOS - Xcode 11 (Preferred)", "iOS - Xcode 10")',
               args: {
                 name: "name",
+                suggestions: [
+                  "Android",
+                  "iOS - Xcode 11 (Preferred)",
+                  "iOS - Xcode 10",
+                ],
               },
             },
             {
@@ -775,6 +914,7 @@ const completionSpec = {
               description: "The artifact type (aab, apk, ipa, dsym)",
               args: {
                 name: "name",
+                suggestions: ["aab", "apl", "ipa", "dysm"],
               },
             },
             {
@@ -788,12 +928,21 @@ const completionSpec = {
               name: "platform",
               description: "The platform to package (android, ios)",
               isOptional: false,
+              suggestions: ["ios", "android"],
             },
             {
               name: "type",
               description:
                 "The build type (debug, release, development, ad-hoc, app-store, enterprise)",
               isOptional: false,
+              suggestions: [
+                "debug",
+                "release",
+                "development",
+                "ad-hoc",
+                "app-stpre",
+                "enterprise",
+              ],
             },
           ],
           description: "Create a package build on Appflow",
@@ -830,6 +979,7 @@ const completionSpec = {
               description: "Destination of private key file",
               args: {
                 name: "path",
+                default: "./.ionic/ssl/key.pem",
               },
             },
             {
@@ -837,6 +987,7 @@ const completionSpec = {
               description: "Destination of certificate file",
               args: {
                 name: "path",
+                default: "./.ionic/ssl/cert.pem",
               },
             },
             {
@@ -844,6 +995,7 @@ const completionSpec = {
               description: "The country name (C) of the SSL certificate",
               args: {
                 name: "C",
+                default: "US",
               },
             },
             {
@@ -852,6 +1004,7 @@ const completionSpec = {
                 "The state or province name (ST) of the SSL certificate",
               args: {
                 name: "ST",
+                default: "Wisconsin",
               },
             },
             {
@@ -859,6 +1012,7 @@ const completionSpec = {
               description: "The locality name (L) of the SSL certificate",
               args: {
                 name: "L",
+                default: "Madison",
               },
             },
             {
@@ -866,6 +1020,7 @@ const completionSpec = {
               description: "The organization name (O) of the SSL certificate",
               args: {
                 name: "O",
+                default: "Ionic",
               },
             },
             {
@@ -873,6 +1028,7 @@ const completionSpec = {
               description: "The common name (CN) of the SSL certificate",
               args: {
                 name: "CN",
+                default: "localhost",
               },
             },
             {
@@ -880,6 +1036,7 @@ const completionSpec = {
               description: "Number of bits in the key",
               args: {
                 name: "bits",
+                default: 2048,
               },
             },
           ],
@@ -927,6 +1084,8 @@ const completionSpec = {
               description: "The type of key to generate: ecdsa, ed25519, rsa",
               args: {
                 name: "type",
+                suggestions: ["ecdsa", "ed25519", "rsa"],
+                default: "rsa",
               },
             },
             {
@@ -934,6 +1093,7 @@ const completionSpec = {
               description: "Number of bits in the key",
               args: {
                 name: "bits",
+                default: 2048,
               },
             },
             {
@@ -1023,6 +1183,7 @@ const completionSpec = {
               description:
                 "The integration to disable (e.g. capacitor, cordova, enterprise)",
               isOptional: false,
+              suggestions: ["capacitor", "cordova", "enterprise"],
             },
           ],
           description: "Disable an integration",
@@ -1053,6 +1214,7 @@ const completionSpec = {
               description:
                 "The integration to enable (e.g. capacitor, cordova, enterprise)",
               isOptional: false,
+              suggestions: ["capacitor", "cordova", "enterprise"],
             },
           ],
           description: "Add & enable integrations to your app",
@@ -1095,7 +1257,7 @@ const completionSpec = {
           name: "build",
           options: [
             {
-              name: ["--build"],
+              name: ["--no-build"],
               description: "Do not invoke an Ionic build",
             },
             {
@@ -1121,12 +1283,25 @@ const completionSpec = {
                 name: "file",
               },
             },
+            {
+              name: ["--prod"],
+              description: "Flag to use the production configuration",
+            },
+            {
+              name: ["--configuration", "-c"],
+              description: "Specify the configuration to use",
+            },
+            {
+              name: ["--source-map"],
+              description: "Output source maps",
+            },
           ],
           args: [
             {
               name: "platform",
               description: "The platform to build (e.g. android, ios)",
               isOptional: false,
+              suggestions: ["ios", "android"],
             },
           ],
           description:
@@ -1164,6 +1339,7 @@ const completionSpec = {
               name: "platform",
               description: "The platform to compile (android, ios)",
               isOptional: false,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Compile native platform code",
@@ -1176,7 +1352,7 @@ const completionSpec = {
               description: "List all available targets",
             },
             {
-              name: ["--build"],
+              name: ["--no-build"],
               description: "Do not invoke Ionic build",
             },
             {
@@ -1189,6 +1365,7 @@ const completionSpec = {
               description: "Use specific host for the dev server",
               args: {
                 name: "host",
+                default: "localhost",
               },
             },
             {
@@ -1196,6 +1373,7 @@ const completionSpec = {
               description: "Use specific port for the dev server",
               args: {
                 name: "port",
+                default: 8100,
               },
             },
             {
@@ -1247,7 +1425,7 @@ const completionSpec = {
               },
             },
             {
-              name: ["--native-run"],
+              name: ["--no-native-run"],
               description:
                 "Do not use native-run to run the app; use Cordova instead",
             },
@@ -1259,12 +1437,51 @@ const completionSpec = {
               name: ["--json"],
               description: "Output targets in JSON",
             },
+            {
+              name: ["--ssl"],
+              description: "Use HTTPS for the dev serve",
+            },
+            {
+              name: ["--prod"],
+              description: "Flag to use the production configuration",
+            },
+            {
+              name: ["--consolelogs"],
+              description: "Print app console logs to the terminal",
+            },
+            {
+              name: ["--consolelogs-port"],
+              description: "Use specific port for console logs server",
+              args: [
+                {
+                  name: "port",
+                },
+              ],
+            },
+            {
+              name: ["--configuration", "-c"],
+              description: "Specify the configuration to use",
+            },
+            {
+              name: ["--source-map"],
+              description: "Output source maps",
+            },
+            {
+              name: ["--buildconfig"],
+              description: "Use the specified build configuration",
+              args: [
+                {
+                  name: "file",
+                },
+              ],
+            },
           ],
           args: [
             {
               name: "platform",
               description: "The platform to run (e.g. android, ios)",
               isOptional: false,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Emulate an Ionic project on a simulator/emulator",
@@ -1273,7 +1490,7 @@ const completionSpec = {
           name: "platform",
           options: [
             {
-              name: ["--resources"],
+              name: ["--no-resources"],
               description:
                 "Do not pregenerate icons and splash screen resources (corresponds to add)",
             },
@@ -1284,12 +1501,14 @@ const completionSpec = {
               description:
                 "add, remove, or update a platform; ls, check, or save all project platforms",
               isOptional: true,
+              suggestions: ["add", "remove", "update", "ls", "check", "save"],
             },
             {
               name: "platform",
               description:
                 "The platform that you would like to add (android, ios)",
               isOptional: true,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Manage Cordova platform targets",
@@ -1316,6 +1535,7 @@ const completionSpec = {
               description:
                 "add or remove a plugin; ls or save all project plugins",
               isOptional: true,
+              suggestions: ["add", "remove", "ls", "save"],
             },
             {
               name: "plugin",
@@ -1330,8 +1550,29 @@ const completionSpec = {
           name: "prepare",
           options: [
             {
-              name: ["--build"],
+              name: ["--no-build"],
               description: "Do not invoke an Ionic build",
+            },
+            {
+              name: ["--prod"],
+              description: "Flag to use the production configuration",
+            },
+            {
+              name: ["--configuration", "-c"],
+              description: "Specify the configuration to use",
+              args: [
+                {
+                  name: "conf",
+                },
+              ],
+            },
+            {
+              name: ["--source-map"],
+              description: "Output source maps",
+            },
+            {
+              name: ["--watch"],
+              description: "Rebuild when files change",
             },
           ],
           args: [
@@ -1340,6 +1581,7 @@ const completionSpec = {
               description:
                 "The platform you would like to prepare (e.g. android, ios)",
               isOptional: true,
+              suggestions: ["ios", "android"],
             },
           ],
           description:
@@ -1353,6 +1595,7 @@ const completionSpec = {
               description:
                 "The platform for which you would like to gather requirements (android, ios)",
               isOptional: true,
+              suggestions: ["ios", "android"],
             },
           ],
           description:
@@ -1376,6 +1619,7 @@ const completionSpec = {
               description:
                 "The platform for which you would like to generate resources (ios, android)",
               isOptional: true,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Automatically create icon and splash screen resources",
@@ -1388,7 +1632,7 @@ const completionSpec = {
               description: "List all available targets",
             },
             {
-              name: ["--build"],
+              name: ["--no-build"],
               description: "Do not invoke Ionic build",
             },
             {
@@ -1401,6 +1645,7 @@ const completionSpec = {
               description: "Use specific host for the dev server",
               args: {
                 name: "host",
+                default: "localhost",
               },
             },
             {
@@ -1408,6 +1653,7 @@ const completionSpec = {
               description: "Use specific port for the dev server",
               args: {
                 name: "port",
+                default: 8100,
               },
             },
             {
@@ -1459,7 +1705,7 @@ const completionSpec = {
               },
             },
             {
-              name: ["--native-run"],
+              name: ["--no-native-run"],
               description:
                 "Do not use native-run to run the app; use Cordova instead",
             },
@@ -1471,12 +1717,43 @@ const completionSpec = {
               name: ["--json"],
               description: "Output targets in JSON",
             },
+            {
+              name: ["--ssl"],
+              description: "Use HTTPS for the dev server",
+            },
+            {
+              name: ["--prod"],
+              description: "Flag to use the production configuration",
+            },
+            {
+              name: ["--consolelogs"],
+              description: "Print app console logs to the terminal",
+            },
+            {
+              name: ["--consolelogs-port"],
+              description: "Use specific port for console logs server",
+              args: [
+                {
+                  name: "port",
+                },
+              ],
+            },
+            {
+              name: ["--configuration", "-c"],
+              description: "Specify the configuration to use",
+              args: [
+                {
+                  name: "conf",
+                },
+              ],
+            },
           ],
           args: [
             {
               name: "platform",
               description: "The platform to run (e.g. android, ios)",
               isOptional: false,
+              suggestions: ["ios", "android"],
             },
           ],
           description: "Run an Ionic project on a connected device",

--- a/dev/ionic.ts
+++ b/dev/ionic.ts
@@ -21,12 +21,12 @@ const completionSpec = {
           },
         },
       ],
-      args: [],
+      description:
+        "Build web assets and prepare your app for any platform targets",
     },
     {
       name: "completion",
-      options: [],
-      args: [],
+      description: "Enables tab-completion for Ionic CLI commands.",
     },
     {
       name: "docs",
@@ -40,7 +40,7 @@ const completionSpec = {
           },
         },
       ],
-      args: [],
+      description: "Open the Ionic documentation website",
     },
     {
       name: "info",
@@ -50,7 +50,7 @@ const completionSpec = {
           description: "Print system/environment info in JSON format",
         },
       ],
-      args: [],
+      description: "Print project, system, and environment information",
     },
     {
       name: "init",
@@ -89,10 +89,10 @@ const completionSpec = {
           isOptional: true,
         },
       ],
+      description: "Initialize existing projects with Ionic",
     },
     {
       name: "link",
-      options: [],
       args: [
         {
           name: "id",
@@ -100,10 +100,10 @@ const completionSpec = {
           isOptional: true,
         },
       ],
+      description: "Connect local apps to Ionic",
     },
     {
       name: "login",
-      options: [],
       args: [
         {
           name: "email",
@@ -116,11 +116,11 @@ const completionSpec = {
           isOptional: true,
         },
       ],
+      description: "Log in to Ionic",
     },
     {
       name: "logout",
-      options: [],
-      args: [],
+      description: "Log out of Ionic",
     },
     {
       name: "repair",
@@ -131,7 +131,7 @@ const completionSpec = {
             "Only perform the repair steps for Cordova platforms and plugins.",
         },
       ],
-      args: [],
+      description: "Remove and recreate dependencies and generated files",
     },
     {
       name: "serve",
@@ -205,12 +205,11 @@ const completionSpec = {
             "Test your apps on multiple platform types in the browser",
         },
       ],
-      args: [],
+      description: "Start a local dev server for app dev/testing",
     },
     {
       name: "signup",
-      options: [],
-      args: [],
+      description: "Create an Ionic account",
     },
     {
       name: "start",
@@ -284,6 +283,7 @@ const completionSpec = {
           isOptional: false,
         },
       ],
+      description: "Create a new project",
     },
     {
       name: "config",
@@ -311,6 +311,7 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Print config values",
         },
         {
           name: "set",
@@ -344,6 +345,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Set config values",
         },
         {
           name: "unset",
@@ -364,6 +366,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Delete config values",
         },
       ],
     },
@@ -372,7 +375,6 @@ const completionSpec = {
       subcommands: [
         {
           name: "add",
-          options: [],
           args: [
             {
               name: "platform",
@@ -380,6 +382,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Add a native platform to your Ionic project",
         },
         {
           name: "build",
@@ -400,6 +403,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Build an Ionic project for a given platform",
         },
         {
           name: "copy",
@@ -416,10 +420,10 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Copy web assets to native platforms",
         },
         {
           name: "open",
-          options: [],
           args: [
             {
               name: "platform",
@@ -427,6 +431,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Open the IDE for a given native platform project",
         },
         {
           name: "run",
@@ -496,6 +501,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Run an Ionic project on a connected device",
         },
         {
           name: "sync",
@@ -512,10 +518,10 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Sync (copy + update) an Ionic project",
         },
         {
           name: "update",
-          options: [],
           args: [
             {
               name: "platform",
@@ -523,6 +529,8 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description:
+            "Update Capacitor native platforms, install Capacitor/Cordova plugins",
         },
       ],
     },
@@ -571,7 +579,7 @@ const completionSpec = {
               },
             },
           ],
-          args: [],
+          description: "Adds Appflow Deploy to the project",
         },
         {
           name: "build",
@@ -605,7 +613,7 @@ const completionSpec = {
                 "Skip downloading build artifacts after command succeeds.",
             },
           ],
-          args: [],
+          description: "Create a deploy build on Appflow",
         },
         {
           name: "configure",
@@ -656,11 +664,12 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Overrides Appflow Deploy configuration",
         },
         {
           name: "manifest",
-          options: [],
-          args: [],
+          description:
+            "Generates a manifest file for the deploy service from a built app directory",
         },
       ],
     },
@@ -669,8 +678,8 @@ const completionSpec = {
       subcommands: [
         {
           name: "remote",
-          options: [],
-          args: [],
+          description:
+            "Adds/updates the Appflow git remote to your local Ionic app",
         },
       ],
     },
@@ -787,10 +796,10 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Create a package build on Appflow",
         },
         {
           name: "deploy",
-          options: [],
           args: [
             {
               name: "build-id",
@@ -805,6 +814,8 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description:
+            "Deploys a binary to a destination, such as an app store using Appflow",
         },
       ],
     },
@@ -872,7 +883,7 @@ const completionSpec = {
               },
             },
           ],
-          args: [],
+          description: "Generates an SSL key & certificate",
         },
       ],
     },
@@ -895,10 +906,10 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Add an SSH public key to Ionic",
         },
         {
           name: "delete",
-          options: [],
           args: [
             {
               name: "key-id",
@@ -906,6 +917,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Delete an SSH public key from Ionic",
         },
         {
           name: "generate",
@@ -940,6 +952,7 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Generates a private and public SSH key pair",
         },
         {
           name: "list",
@@ -949,16 +962,14 @@ const completionSpec = {
               description: "Output SSH keys in JSON",
             },
           ],
-          args: [],
+          description: "List your SSH public keys on Ionic",
         },
         {
           name: "setup",
-          options: [],
-          args: [],
+          description: "Setup your Ionic SSH keys automatically",
         },
         {
           name: "use",
-          options: [],
           args: [
             {
               name: "key-path",
@@ -966,6 +977,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Set your active Ionic SSH key",
         },
       ],
     },
@@ -974,7 +986,6 @@ const completionSpec = {
       subcommands: [
         {
           name: "check",
-          options: [],
           args: [
             {
               name: "id",
@@ -982,15 +993,14 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Check the health of your Ionic project",
         },
         {
           name: "list",
-          options: [],
-          args: [],
+          description: "List all issues and their identifiers",
         },
         {
           name: "treat",
-          options: [],
           args: [
             {
               name: "id",
@@ -998,6 +1008,7 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Attempt to fix issues in your Ionic project",
         },
       ],
     },
@@ -1006,7 +1017,6 @@ const completionSpec = {
       subcommands: [
         {
           name: "disable",
-          options: [],
           args: [
             {
               name: "name",
@@ -1015,6 +1025,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Disable an integration",
         },
         {
           name: "enable",
@@ -1044,11 +1055,11 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Add & enable integrations to your app",
         },
         {
           name: "list",
-          options: [],
-          args: [],
+          description: "List available and active integrations in your app",
         },
       ],
     },
@@ -1073,7 +1084,7 @@ const completionSpec = {
               },
             },
           ],
-          args: [],
+          description: "Register your Product Key with this app",
         },
       ],
     },
@@ -1118,6 +1129,8 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description:
+            "Use Cordova to build for Android and iOS platform targets",
         },
         {
           name: "compile",
@@ -1153,6 +1166,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Compile native platform code",
         },
         {
           name: "emulate",
@@ -1253,6 +1267,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Emulate an Ionic project on a simulator/emulator",
         },
         {
           name: "platform",
@@ -1277,6 +1292,7 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Manage Cordova platform targets",
         },
         {
           name: "plugin",
@@ -1308,6 +1324,7 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Manage Cordova plugins",
         },
         {
           name: "prepare",
@@ -1325,10 +1342,11 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description:
+            "Copies assets to Cordova platforms, preparing them for native builds",
         },
         {
           name: "requirements",
-          options: [],
           args: [
             {
               name: "platform",
@@ -1337,6 +1355,8 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description:
+            "Checks and print out all the requirements for platforms",
         },
         {
           name: "resources",
@@ -1358,6 +1378,7 @@ const completionSpec = {
               isOptional: true,
             },
           ],
+          description: "Automatically create icon and splash screen resources",
         },
         {
           name: "run",
@@ -1458,6 +1479,7 @@ const completionSpec = {
               isOptional: false,
             },
           ],
+          description: "Run an Ionic project on a connected device",
         },
       ],
     },

--- a/dev/ionic.ts
+++ b/dev/ionic.ts
@@ -1,0 +1,1467 @@
+const completionSpec = {
+  name: "ionic",
+  description:
+    "The Ionic command-line interface (CLI) is the go-to tool for developing Ionic apps.",
+  subcommands: [
+    {
+      name: "build",
+      options: [
+        {
+          name: ["--engine"],
+          description: "Target engine (e.g. browser, cordova)",
+          args: {
+            name: "engine",
+          },
+        },
+        {
+          name: ["--platform"],
+          description: "Target platform on chosen engine (e.g. ios, android)",
+          args: {
+            name: "platform",
+          },
+        },
+      ],
+      args: [],
+    },
+    {
+      name: "completion",
+      options: [],
+      args: [],
+    },
+    {
+      name: "docs",
+      options: [
+        {
+          name: ["--browser", "-w"],
+          description:
+            "Specifies the browser to use (safari, firefox, google chrome)",
+          args: {
+            name: "browser",
+          },
+        },
+      ],
+      args: [],
+    },
+    {
+      name: "info",
+      options: [
+        {
+          name: ["--json"],
+          description: "Print system/environment info in JSON format",
+        },
+      ],
+      args: [],
+    },
+    {
+      name: "init",
+      options: [
+        {
+          name: ["--type"],
+          description: "Type of project (e.g. angular, react, vue, custom)",
+          args: {
+            name: "type",
+          },
+        },
+        {
+          name: ["--force", "-f"],
+          description: "Initialize even if a project already exists",
+        },
+        {
+          name: ["--multi-app"],
+          description: "Initialize a multi-app project",
+        },
+        {
+          name: ["--project-id"],
+          description: "Specify a slug for your app",
+          args: {
+            name: "slug",
+          },
+        },
+        {
+          name: ["--default"],
+          description: "Mark the initialized app as the default project",
+        },
+      ],
+      args: [
+        {
+          name: "name",
+          description: 'The name of your project (e.g. myApp, "My App")',
+          isOptional: true,
+        },
+      ],
+    },
+    {
+      name: "link",
+      options: [],
+      args: [
+        {
+          name: "id",
+          description: "The Appflow ID of the app to link (e.g. a1b2c3d4)",
+          isOptional: true,
+        },
+      ],
+    },
+    {
+      name: "login",
+      options: [],
+      args: [
+        {
+          name: "email",
+          description: "Your email address",
+          isOptional: true,
+        },
+        {
+          name: "password",
+          description: "Your password",
+          isOptional: true,
+        },
+      ],
+    },
+    {
+      name: "logout",
+      options: [],
+      args: [],
+    },
+    {
+      name: "repair",
+      options: [
+        {
+          name: ["--cordova"],
+          description:
+            "Only perform the repair steps for Cordova platforms and plugins.",
+        },
+      ],
+      args: [],
+    },
+    {
+      name: "serve",
+      options: [
+        {
+          name: ["--external"],
+          description:
+            "Host dev server on all network interfaces (i.e. --host=0.0.0.0)",
+        },
+        {
+          name: ["--host"],
+          description: "Use specific host for the dev server",
+          args: {
+            name: "host",
+          },
+        },
+        {
+          name: ["--port", "-p"],
+          description: "Use specific port for the dev server",
+          args: {
+            name: "port",
+          },
+        },
+        {
+          name: ["--public-host"],
+          description: "The host used for the browser or web view",
+          args: {
+            name: "host",
+          },
+        },
+        {
+          name: ["--livereload"],
+          description: "Do not spin up dev server--just serve files",
+        },
+        {
+          name: ["--lab-host"],
+          description: "Use specific host for Ionic Lab server",
+          args: {
+            name: "host",
+          },
+        },
+        {
+          name: ["--lab-port"],
+          description: "Use specific port for Ionic Lab server",
+          args: {
+            name: "port",
+          },
+        },
+        {
+          name: ["--open"],
+          description: "Do not open a browser window",
+        },
+        {
+          name: ["--browser", "-w"],
+          description:
+            "Specifies the browser to use (safari, firefox, google chrome)",
+          args: {
+            name: "browser",
+          },
+        },
+        {
+          name: ["--browseroption", "-o"],
+          description: "Specifies a path to open to (/#/tab/dash)",
+          args: {
+            name: "path",
+          },
+        },
+        {
+          name: ["--lab", "-l"],
+          description:
+            "Test your apps on multiple platform types in the browser",
+        },
+      ],
+      args: [],
+    },
+    {
+      name: "signup",
+      options: [],
+      args: [],
+    },
+    {
+      name: "start",
+      options: [
+        {
+          name: ["--list", "-l"],
+          description: "List available starter templates",
+        },
+        {
+          name: ["--type"],
+          description:
+            "Type of project to start (e.g. vue, angular, react, ionic-angular, ionic1)",
+          args: {
+            name: "type",
+          },
+        },
+        {
+          name: ["--cordova"],
+          description: "Include Cordova integration",
+        },
+        {
+          name: ["--capacitor"],
+          description: "Include Capacitor integration",
+        },
+        {
+          name: ["--deps"],
+          description: "Do not install npm/yarn dependencies",
+        },
+        {
+          name: ["--git"],
+          description: "Do not initialize a git repo",
+        },
+        {
+          name: ["--link"],
+          description: "Connect your new app to Ionic",
+        },
+        {
+          name: ["--id"],
+          description: "Specify an Ionic App ID to link",
+          args: {
+            name: "id",
+          },
+        },
+        {
+          name: ["--project-id"],
+          description:
+            "Specify a slug for your app (used for the directory name and package name)",
+          args: {
+            name: "slug",
+          },
+        },
+        {
+          name: ["--package-id"],
+          description:
+            "Specify the bundle ID/application ID for your app (reverse-DNS notation)",
+          args: {
+            name: "id",
+          },
+        },
+      ],
+      args: [
+        {
+          name: "name",
+          description: 'The name of your new project (e.g. myApp, "My App")',
+          isOptional: false,
+        },
+        {
+          name: "template",
+          description:
+            "The starter template to use (e.g. blank, tabs; use --list to see all)",
+          isOptional: false,
+        },
+      ],
+    },
+    {
+      name: "config",
+      subcommands: [
+        {
+          name: "get",
+          options: [
+            {
+              name: ["--global", "-g"],
+              description: "Use global CLI config",
+            },
+            {
+              name: ["--json"],
+              description: "Output config values in JSON",
+            },
+            {
+              name: ["--root"],
+              description: "Operate on root of ionic.config.json",
+            },
+          ],
+          args: [
+            {
+              name: "property",
+              description: "The property name you wish to get",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "set",
+          options: [
+            {
+              name: ["--global", "-g"],
+              description: "Use global CLI config",
+            },
+            {
+              name: ["--json"],
+              description: "Always interpret value as JSON",
+            },
+            {
+              name: ["--force"],
+              description: "Always overwrite existing values",
+            },
+            {
+              name: ["--root"],
+              description: "Operate on root of ./ionic.config.json",
+            },
+          ],
+          args: [
+            {
+              name: "property",
+              description: "The property name you wish to set",
+              isOptional: false,
+            },
+            {
+              name: "value",
+              description: "The new value of the given property",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "unset",
+          options: [
+            {
+              name: ["--global", "-g"],
+              description: "Use global CLI config",
+            },
+            {
+              name: ["--root"],
+              description: "Operate on root of ./ionic.config.json",
+            },
+          ],
+          args: [
+            {
+              name: "property",
+              description: "The property name you wish to delete",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "capacitor",
+      subcommands: [
+        {
+          name: "add",
+          options: [],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to add (e.g. android, ios)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "build",
+          options: [
+            {
+              name: ["--build"],
+              description: "Do not invoke Ionic build",
+            },
+            {
+              name: ["--open"],
+              description: "Do not invoke Capacitor open",
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to build for (e.g. android, ios)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "copy",
+          options: [
+            {
+              name: ["--build"],
+              description: "Do not invoke an Ionic build",
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to copy (e.g. android, ios)",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "open",
+          options: [],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to open (e.g. android, ios)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "run",
+          options: [
+            {
+              name: ["--list"],
+              description: "List all available targets",
+            },
+            {
+              name: ["--target"],
+              description:
+                "Deploy to a specific device by its ID (use --list to see all)",
+              args: {
+                name: "target",
+              },
+            },
+            {
+              name: ["--open"],
+              description: "Open native IDE instead of using capacitor run",
+            },
+            {
+              name: ["--build"],
+              description: "Do not invoke Ionic build",
+            },
+            {
+              name: ["--external"],
+              description:
+                "Host dev server on all network interfaces (i.e. --host=0.0.0.0)",
+            },
+            {
+              name: ["--host"],
+              description: "Use specific host for the dev server",
+              args: {
+                name: "host",
+              },
+            },
+            {
+              name: ["--port", "-p"],
+              description: "Use specific port for the dev server",
+              args: {
+                name: "port",
+              },
+            },
+            {
+              name: ["--public-host"],
+              description: "The host used for the browser or web view",
+              args: {
+                name: "host",
+              },
+            },
+            {
+              name: ["--livereload", "-l"],
+              description: "Spin up dev server to live-reload www files",
+            },
+            {
+              name: ["--livereload-url"],
+              description: "Provide a custom URL to the dev server",
+              args: {
+                name: "url",
+              },
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to run (e.g. android, ios)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "sync",
+          options: [
+            {
+              name: ["--build"],
+              description: "Do not invoke an Ionic build",
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to sync (e.g. android, ios)",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "update",
+          options: [],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to update (e.g. android, ios)",
+              isOptional: true,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "deploy",
+      subcommands: [
+        {
+          name: "add",
+          options: [
+            {
+              name: ["--app-id"],
+              description: "Your Appflow app ID",
+              args: {
+                name: "id",
+              },
+            },
+            {
+              name: ["--channel-name"],
+              description: "The channel to check for updates from",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--update-method"],
+              description:
+                "The update method that dictates the behavior of the plugin",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--max-store"],
+              description:
+                "The maximum number of downloaded versions to store on the device",
+              args: {
+                name: "quantity",
+              },
+            },
+            {
+              name: ["--min-background-duration"],
+              description:
+                "The minimum duration after which the app checks for an update in the background",
+              args: {
+                name: "seconds",
+              },
+            },
+          ],
+          args: [],
+        },
+        {
+          name: "build",
+          options: [
+            {
+              name: ["--environment"],
+              description:
+                "The group of environment variables exposed to your build",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--channel"],
+              description:
+                "The channel you want to auto deploy the build to. This can be repeated multiple times if multiple channels need to be specified.",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--commit"],
+              description: "Commit (defaults to HEAD)",
+              args: {
+                name: "sha1",
+              },
+            },
+            {
+              name: ["--skip-download"],
+              description:
+                "Skip downloading build artifacts after command succeeds.",
+            },
+          ],
+          args: [],
+        },
+        {
+          name: "configure",
+          options: [
+            {
+              name: ["--app-id"],
+              description: "Your Appflow app ID",
+              args: {
+                name: "id",
+              },
+            },
+            {
+              name: ["--channel-name"],
+              description: "The channel to check for updates from",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--update-method"],
+              description:
+                "The update method that dictates the behavior of the plugin",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--max-store"],
+              description:
+                "The maximum number of downloaded versions to store on the device",
+              args: {
+                name: "quantity",
+              },
+            },
+            {
+              name: ["--min-background-duration"],
+              description:
+                "The minimum duration after which the app checks for an update in the background",
+              args: {
+                name: "seconds",
+              },
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The native platform (e.g. ios, android)",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "manifest",
+          options: [],
+          args: [],
+        },
+      ],
+    },
+    {
+      name: "git",
+      subcommands: [
+        {
+          name: "remote",
+          options: [],
+          args: [],
+        },
+      ],
+    },
+    {
+      name: "package",
+      subcommands: [
+        {
+          name: "build",
+          options: [
+            {
+              name: ["--signing-certificate"],
+              description: "Signing certificate",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--environment"],
+              description:
+                "The group of environment variables exposed to your build",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--native-config"],
+              description:
+                "The group of native config variables exposed to your build",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--destination"],
+              description:
+                "The configuration to deploy the build artifact to the app store",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--commit"],
+              description: "Commit (defaults to HEAD)",
+              args: {
+                name: "sha1",
+              },
+            },
+            {
+              name: ["--build-stack"],
+              description:
+                'Target platform ("Android", "iOS - Xcode 11 (Preferred)", "iOS - Xcode 10")',
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--build-file-name"],
+              description: "The name for the downloaded build file",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--ipa-name"],
+              description: "The name for the downloaded ipa file",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--dsym-name"],
+              description: "The name for the downloaded dsym file",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--apk-name"],
+              description: "The name for the downloaded apk file",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--aab-name"],
+              description: "The name for the downloaded aab file",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--artifact-type"],
+              description: "The artifact type (aab, apk, ipa, dsym)",
+              args: {
+                name: "name",
+              },
+            },
+            {
+              name: ["--skip-download"],
+              description:
+                "Skip downloading build artifacts after command succeeds.",
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to package (android, ios)",
+              isOptional: false,
+            },
+            {
+              name: "type",
+              description:
+                "The build type (debug, release, development, ad-hoc, app-store, enterprise)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "deploy",
+          options: [],
+          args: [
+            {
+              name: "build-id",
+              description:
+                "The build id of the desired successful package build",
+              isOptional: false,
+            },
+            {
+              name: "destination",
+              description:
+                "The destination to deploy the build artifact to the app store",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "ssl",
+      subcommands: [
+        {
+          name: "generate",
+          options: [
+            {
+              name: ["--key-path"],
+              description: "Destination of private key file",
+              args: {
+                name: "path",
+              },
+            },
+            {
+              name: ["--cert-path"],
+              description: "Destination of certificate file",
+              args: {
+                name: "path",
+              },
+            },
+            {
+              name: ["--country-name"],
+              description: "The country name (C) of the SSL certificate",
+              args: {
+                name: "C",
+              },
+            },
+            {
+              name: ["--state-or-province-name"],
+              description:
+                "The state or province name (ST) of the SSL certificate",
+              args: {
+                name: "ST",
+              },
+            },
+            {
+              name: ["--locality-name"],
+              description: "The locality name (L) of the SSL certificate",
+              args: {
+                name: "L",
+              },
+            },
+            {
+              name: ["--organization-name"],
+              description: "The organization name (O) of the SSL certificate",
+              args: {
+                name: "O",
+              },
+            },
+            {
+              name: ["--common-name"],
+              description: "The common name (CN) of the SSL certificate",
+              args: {
+                name: "CN",
+              },
+            },
+            {
+              name: ["--bits", "-b"],
+              description: "Number of bits in the key",
+              args: {
+                name: "bits",
+              },
+            },
+          ],
+          args: [],
+        },
+      ],
+    },
+    {
+      name: "ssh",
+      subcommands: [
+        {
+          name: "add",
+          options: [
+            {
+              name: ["--use"],
+              description:
+                "Use the newly added key as your default SSH key for Ionic",
+            },
+          ],
+          args: [
+            {
+              name: "pubkey-path",
+              description: "Location of public key file to add to Ionic",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "delete",
+          options: [],
+          args: [
+            {
+              name: "key-id",
+              description: "The ID of the public key to delete",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "generate",
+          options: [
+            {
+              name: ["--type", "-t"],
+              description: "The type of key to generate: ecdsa, ed25519, rsa",
+              args: {
+                name: "type",
+              },
+            },
+            {
+              name: ["--bits", "-b"],
+              description: "Number of bits in the key",
+              args: {
+                name: "bits",
+              },
+            },
+            {
+              name: ["--annotation", "-C"],
+              description:
+                "Annotation (comment) in public key. Your Ionic email address will be used",
+              args: {
+                name: "annotation",
+              },
+            },
+          ],
+          args: [
+            {
+              name: "key-path",
+              description: "Destination of private key file",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "list",
+          options: [
+            {
+              name: ["--json"],
+              description: "Output SSH keys in JSON",
+            },
+          ],
+          args: [],
+        },
+        {
+          name: "setup",
+          options: [],
+          args: [],
+        },
+        {
+          name: "use",
+          options: [],
+          args: [
+            {
+              name: "key-path",
+              description: "Location of private key file to use",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "doctor",
+      subcommands: [
+        {
+          name: "check",
+          options: [],
+          args: [
+            {
+              name: "id",
+              description: "The issue identifier",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "list",
+          options: [],
+          args: [],
+        },
+        {
+          name: "treat",
+          options: [],
+          args: [
+            {
+              name: "id",
+              description: "The issue identifier",
+              isOptional: true,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "integrations",
+      subcommands: [
+        {
+          name: "disable",
+          options: [],
+          args: [
+            {
+              name: "name",
+              description:
+                "The integration to disable (e.g. capacitor, cordova, enterprise)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "enable",
+          options: [
+            {
+              name: ["--add"],
+              description: "Download and add the integration even if enabled",
+            },
+            {
+              name: ["--root"],
+              description:
+                "Specify an alternative destination to download into when adding",
+              args: {
+                name: "path",
+              },
+            },
+            {
+              name: ["--quiet"],
+              description: "Less verbose output, ignore integration errors",
+            },
+          ],
+          args: [
+            {
+              name: "name",
+              description:
+                "The integration to enable (e.g. capacitor, cordova, enterprise)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "list",
+          options: [],
+          args: [],
+        },
+      ],
+    },
+    {
+      name: "enterprise",
+      subcommands: [
+        {
+          name: "register",
+          options: [
+            {
+              name: ["--app-id"],
+              description: "The Ionic App ID",
+              args: {
+                name: "id",
+              },
+            },
+            {
+              name: ["--key"],
+              description: "The Product Key",
+              args: {
+                name: "key",
+              },
+            },
+          ],
+          args: [],
+        },
+      ],
+    },
+    {
+      name: "cordova",
+      subcommands: [
+        {
+          name: "build",
+          options: [
+            {
+              name: ["--build"],
+              description: "Do not invoke an Ionic build",
+            },
+            {
+              name: ["--debug"],
+              description: "Mark as a debug build",
+            },
+            {
+              name: ["--release"],
+              description: "Mark as a release build",
+            },
+            {
+              name: ["--device"],
+              description: "Deploy build to a device",
+            },
+            {
+              name: ["--emulator"],
+              description: "Deploy build to an emulator",
+            },
+            {
+              name: ["--buildConfig"],
+              description: "Use the specified build configuration",
+              args: {
+                name: "file",
+              },
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to build (e.g. android, ios)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "compile",
+          options: [
+            {
+              name: ["--debug"],
+              description: "Mark as a debug build",
+            },
+            {
+              name: ["--release"],
+              description: "Mark as a release build",
+            },
+            {
+              name: ["--device"],
+              description: "Deploy build to a device",
+            },
+            {
+              name: ["--emulator"],
+              description: "Deploy build to an emulator",
+            },
+            {
+              name: ["--buildConfig"],
+              description: "Use the specified build configuration",
+              args: {
+                name: "file",
+              },
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to compile (android, ios)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "emulate",
+          options: [
+            {
+              name: ["--list"],
+              description: "List all available targets",
+            },
+            {
+              name: ["--build"],
+              description: "Do not invoke Ionic build",
+            },
+            {
+              name: ["--external"],
+              description:
+                "Host dev server on all network interfaces (i.e. --host=0.0.0.0)",
+            },
+            {
+              name: ["--host"],
+              description: "Use specific host for the dev server",
+              args: {
+                name: "host",
+              },
+            },
+            {
+              name: ["--port", "-p"],
+              description: "Use specific port for the dev server",
+              args: {
+                name: "port",
+              },
+            },
+            {
+              name: ["--public-host"],
+              description: "The host used for the browser or web view",
+              args: {
+                name: "host",
+              },
+            },
+            {
+              name: ["--livereload", "-l"],
+              description: "Spin up dev server to live-reload www files",
+            },
+            {
+              name: ["--livereload-url"],
+              description: "Provide a custom URL to the dev server",
+              args: {
+                name: "url",
+              },
+            },
+            {
+              name: ["--debug"],
+              description: "Mark as a debug build",
+            },
+            {
+              name: ["--release"],
+              description: "Mark as a release build",
+            },
+            {
+              name: ["--device"],
+              description: "Deploy build to a device",
+            },
+            {
+              name: ["--emulator"],
+              description: "Deploy build to an emulator",
+            },
+            {
+              name: ["--buildConfig"],
+              description: "Use the specified build configuration",
+              args: {
+                name: "file",
+              },
+            },
+            {
+              name: ["--target"],
+              description: "Deploy build to a device (use --list to see all)",
+              args: {
+                name: "target",
+              },
+            },
+            {
+              name: ["--native-run"],
+              description:
+                "Do not use native-run to run the app; use Cordova instead",
+            },
+            {
+              name: ["--connect"],
+              description: "Tie the running app to the process",
+            },
+            {
+              name: ["--json"],
+              description: "Output targets in JSON",
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to run (e.g. android, ios)",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: "platform",
+          options: [
+            {
+              name: ["--resources"],
+              description:
+                "Do not pregenerate icons and splash screen resources (corresponds to add)",
+            },
+          ],
+          args: [
+            {
+              name: "action",
+              description:
+                "add, remove, or update a platform; ls, check, or save all project platforms",
+              isOptional: true,
+            },
+            {
+              name: "platform",
+              description:
+                "The platform that you would like to add (android, ios)",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "plugin",
+          options: [
+            {
+              name: ["--force"],
+              description:
+                "Force overwrite the plugin if it exists (corresponds to add)",
+            },
+            {
+              name: ["--variable"],
+              description: "Specify plugin variables",
+              args: {
+                name: "KEY=VALUE",
+              },
+            },
+          ],
+          args: [
+            {
+              name: "action",
+              description:
+                "add or remove a plugin; ls or save all project plugins",
+              isOptional: true,
+            },
+            {
+              name: "plugin",
+              description:
+                "The name of the plugin (corresponds to add and remove)",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "prepare",
+          options: [
+            {
+              name: ["--build"],
+              description: "Do not invoke an Ionic build",
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description:
+                "The platform you would like to prepare (e.g. android, ios)",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "requirements",
+          options: [],
+          args: [
+            {
+              name: "platform",
+              description:
+                "The platform for which you would like to gather requirements (android, ios)",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "resources",
+          options: [
+            {
+              name: ["--icon", "-i"],
+              description: "Generate icon resources",
+            },
+            {
+              name: ["--splash", "-s"],
+              description: "Generate splash screen resources",
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description:
+                "The platform for which you would like to generate resources (ios, android)",
+              isOptional: true,
+            },
+          ],
+        },
+        {
+          name: "run",
+          options: [
+            {
+              name: ["--list"],
+              description: "List all available targets",
+            },
+            {
+              name: ["--build"],
+              description: "Do not invoke Ionic build",
+            },
+            {
+              name: ["--external"],
+              description:
+                "Host dev server on all network interfaces (i.e. --host=0.0.0.0)",
+            },
+            {
+              name: ["--host"],
+              description: "Use specific host for the dev server",
+              args: {
+                name: "host",
+              },
+            },
+            {
+              name: ["--port", "-p"],
+              description: "Use specific port for the dev server",
+              args: {
+                name: "port",
+              },
+            },
+            {
+              name: ["--public-host"],
+              description: "The host used for the browser or web view",
+              args: {
+                name: "host",
+              },
+            },
+            {
+              name: ["--livereload", "-l"],
+              description: "Spin up dev server to live-reload www files",
+            },
+            {
+              name: ["--livereload-url"],
+              description: "Provide a custom URL to the dev server",
+              args: {
+                name: "url",
+              },
+            },
+            {
+              name: ["--debug"],
+              description: "Mark as a debug build",
+            },
+            {
+              name: ["--release"],
+              description: "Mark as a release build",
+            },
+            {
+              name: ["--device"],
+              description: "Deploy build to a device",
+            },
+            {
+              name: ["--emulator"],
+              description: "Deploy build to an emulator",
+            },
+            {
+              name: ["--buildConfig"],
+              description: "Use the specified build configuration",
+              args: {
+                name: "file",
+              },
+            },
+            {
+              name: ["--target"],
+              description: "Deploy build to a device (use --list to see all)",
+              args: {
+                name: "target",
+              },
+            },
+            {
+              name: ["--native-run"],
+              description:
+                "Do not use native-run to run the app; use Cordova instead",
+            },
+            {
+              name: ["--connect"],
+              description: "Tie the running app to the process",
+            },
+            {
+              name: ["--json"],
+              description: "Output targets in JSON",
+            },
+          ],
+          args: [
+            {
+              name: "platform",
+              description: "The platform to run (e.g. android, ios)",
+              isOptional: false,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export default completionSpec;


### PR DESCRIPTION
Adds autocomplete spec for Ionic CLI.

Working on the generator over here:[https://github.com/EthanOrlander/ionic-fig-generator]( https://github.com/EthanOrlander/ionic-fig-generator)
Hooking into the Ionic CLI using `ionic help --json` and programatically generating the spec.
- Turns out `ionic help --json` is incomplete and incorrect, so there's a bit of manual post-processing work 

Please let me know if there's any issues thus far!
