### PR TITLE
feat: Add `shortcuts` spec (macOS Monterey)

### DIFF
--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -13,12 +13,7 @@ const shortcut: Fig.Arg = {
 const completionSpec: Fig.Spec = {
   name: "shortcuts",
   description: "Command-line utility for running shortcuts.",
-  options: [
-    {
-      name: ["--help", "-h"],
-      description: "Show help information.",
-    },
-  ],
+
   subcommands: [
     {
       name: "run",
@@ -35,23 +30,19 @@ const completionSpec: Fig.Spec = {
       options: [
         {
           name: ["-i", "--input-path"],
-          isRequired: false, // Default: stdin
           args: [
             {
               name: "input-path",
               template: "filepaths",
-              isOptional: false,
             },
           ],
           description: "The input to provide to the shortcut.",
         },
         {
           name: ["-o", "--output-path"],
-          isRequired: false,
           args: [
             {
               name: "output-path",
-              isOptional: false,
               template: "filepaths",
             },
           ],
@@ -59,7 +50,6 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: ["--output-type"],
-          isRequired: false,
           args: [
             {
               name: "output-type",
@@ -97,7 +87,7 @@ const completionSpec: Fig.Spec = {
                   postProcess: (list) =>
                     list.split("\n").map((folder) => ({
                       name: folder,
-                      icon: "fig://icon?type=folder",
+                      icon: "📂",
                     })),
                 },
               ],
@@ -107,6 +97,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["--folders"],
           description: "List folders instead of shortcuts.",
+          icon: "📂",
         },
       ],
     },
@@ -141,8 +132,20 @@ const completionSpec: Fig.Spec = {
           args: [
             {
               name: "input",
-              template: "filepaths",
               isOptional: false,
+              generators: [
+                {
+                  template: "filepaths",
+                  filterTemplateSuggestions: function (suggestions) {
+                    return suggestions.filter(
+                      (suggestion) =>
+                        suggestion.type === "folder" ||
+                        (typeof suggestion.name === "string" &&
+                          suggestion.name.endsWith(".shortcut"))
+                    );
+                  },
+                },
+              ],
             },
           ],
         },
@@ -183,9 +186,36 @@ const completionSpec: Fig.Spec = {
           name: "subcommand",
           description: "The subcommand to show help for.",
           isOptional: true,
-          suggestions: ["run", "list", "view", "sign"],
+          suggestions: [
+            {
+              name: "run",
+              description: "Run a shortcut.",
+              icon: "▶️",
+            },
+            {
+              name: "list",
+              description: "List your shortcuts.",
+              icon: "📂",
+            },
+            {
+              name: "view",
+              description: "View a shortcut in Shortcuts.",
+              icon: "🔍",
+            },
+            {
+              name: "sign",
+              description: "Sign a shortcut file.",
+              icon: "🔏",
+            },
+          ],
         },
       ],
+    },
+  ],
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help information.",
     },
   ],
 };

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -23,7 +23,6 @@ const completionSpec: Fig.Spec = {
         {
           name: "shortcut-name",
           description: "The name of the shortcut to run.",
-          isOptional: false,
           generators: shortcut.generators,
         },
       ],
@@ -53,15 +52,10 @@ const completionSpec: Fig.Spec = {
           args: [
             {
               name: "output-type",
-              isOptional: false,
             },
           ],
           description:
             "What type to output data in, in Universal Type Identifier format.",
-        },
-        {
-          name: ["--help", "-h"],
-          description: "Show help information.",
         },
       ],
     },
@@ -71,16 +65,11 @@ const completionSpec: Fig.Spec = {
       icon: "📂",
       options: [
         {
-          name: ["--help", "-h"],
-          description: "Show help information.",
-        },
-        {
           name: ["--folder-name", "-f"],
           description: "The name of the folder to list.",
           args: [
             {
               name: "folder-name",
-              isOptional: false,
               generators: [
                 {
                   script: "shortcuts list --folders",
@@ -109,14 +98,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "shortcut-name",
           description: "The name of the shortcut to run.",
-          isOptional: false,
           generators: shortcut.generators,
-        },
-      ],
-      options: [
-        {
-          name: ["--help", "-h"],
-          description: "Show help information.",
         },
       ],
     },
@@ -128,11 +110,9 @@ const completionSpec: Fig.Spec = {
         {
           name: ["--input", "-i"],
           description: "The shortcut file to sign.",
-          isRequired: true,
           args: [
             {
               name: "input",
-              isOptional: false,
               generators: [
                 {
                   template: "filepaths",
@@ -152,27 +132,19 @@ const completionSpec: Fig.Spec = {
         {
           name: ["--output", "-o"],
           description: "Output path for the signed shortcut file.",
-          isRequired: true,
           args: [
             {
               name: "output",
               template: "filepaths",
-              isOptional: false,
             },
           ],
         },
         {
-          name: ["--help", "-h"],
-          description: "Show help information.",
-        },
-        {
           name: ["--mode", "-m"],
-          description: "The  signing mode. (default: people-who-know-me)",
-          isRequired: false,
+          description: "The signing mode. (default: people-who-know-me)",
           args: [
             {
               name: "mode",
-              isOptional: false,
             },
           ],
         },
@@ -181,41 +153,28 @@ const completionSpec: Fig.Spec = {
     {
       name: "help",
       description: "Show help information.",
-      args: [
+      subcommands: [
         {
-          name: "subcommand",
-          description: "The subcommand to show help for.",
-          isOptional: true,
-          suggestions: [
-            {
-              name: "run",
-              description: "Run a shortcut.",
-              icon: "▶️",
-            },
-            {
-              name: "list",
-              description: "List your shortcuts.",
-              icon: "📂",
-            },
-            {
-              name: "view",
-              description: "View a shortcut in Shortcuts.",
-              icon: "🔍",
-            },
-            {
-              name: "sign",
-              description: "Sign a shortcut file.",
-              icon: "🔏",
-            },
-          ],
+          name: "run",
+          description: "Run a shortcut.",
+          icon: "▶️",
+        },
+        {
+          name: "list",
+          description: "List your shortcuts.",
+          icon: "📂",
+        },
+        {
+          name: "view",
+          description: "View a shortcut in Shortcuts.",
+          icon: "🔍",
+        },
+        {
+          name: "sign",
+          description: "Sign a shortcut file.",
+          icon: "🔏",
         },
       ],
-    },
-  ],
-  options: [
-    {
-      name: ["--help", "-h"],
-      description: "Show help information.",
     },
   ],
 };

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -1,0 +1,169 @@
+const completionSpec: Fig.Spec = {
+  name: "shortcuts",
+  description: "Command-line utility for running shortcuts.",
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help information.",
+    },
+  ],
+  subcommands: [
+    {
+      name: "run",
+      description: "Run a shortcut.",
+      args: [
+        {
+          name: "shortcut-name",
+          description: "The name of the shortcut to run.",
+          isOptional: false,
+          generators: [
+            {
+              script: "shortcuts list",
+              postProcess: (list) =>
+                list.split("\n").map((shortcut) => ({ name: shortcut })),
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          name: ["-i", "--input-path"],
+          args: [
+            {
+              name: "input-path",
+              template: "filepaths",
+            },
+          ],
+          description: "The input to provide to the shortcut.",
+        },
+        {
+          name: ["-o", "--output-path"],
+          args: [
+            {
+              name: "output-path",
+              template: "filepaths",
+            },
+          ],
+          description: "Where to write the shortcut output, if applicable.",
+        },
+        {
+          name: ["--output-type"],
+          args: [
+            {
+              name: "output-type",
+            },
+          ],
+          description:
+            "What type to output data in, in Universal Type Identifier format.",
+        },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information.",
+        },
+      ],
+    },
+    {
+      name: "list",
+      description: "List your shortcuts.",
+      options: [
+        {
+          name: ["--help", "-h"],
+          description: "Show help information.",
+        },
+        {
+          name: ["--folder-name", "-f"],
+          description: "The name of the folder to list.",
+          args: [
+            {
+              name: "folder-name",
+              isOptional: false,
+              generators: [
+                {
+                  script: "shortcuts list --folders",
+                  postProcess: (list) =>
+                    list.split("\n").map((folder) => ({ name: folder })),
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: ["--folders"],
+          description: "List folders instead of shortcuts.",
+        },
+      ],
+    },
+    {
+      name: "view",
+      description: "View a shortcut in Shortcuts.",
+      args: [
+        {
+          name: "shortcut-name",
+          description: "The name of the shortcut to run.",
+          isOptional: false,
+          generators: [
+            {
+              script: "shortcuts list",
+              postProcess: (list) =>
+                list.split("\n").map((shortcut) => ({ name: shortcut })),
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          name: ["--help", "-h"],
+          description: "Show help information.",
+        },
+      ],
+    },
+    {
+      name: "sign",
+      description: "Sign a shortcut file.",
+      options: [
+        {
+          name: ["--input", "-i"],
+          description: "The shortcut file to sign.",
+          isRequired: true,
+          args: [
+            {
+              name: "input",
+              template: "filepaths",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: ["--output", "-o"],
+          description: "Output path for the signed shortcut file.",
+          isRequired: true,
+          args: [
+            {
+              name: "output",
+              template: "filepaths",
+              isOptional: false,
+            },
+          ],
+        },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information.",
+        },
+        {
+          name: ["--mode", "-m"],
+          description: "The  signing mode. (default: people-who-know-me)",
+          args: [
+            {
+              name: "mode",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "help",
+      description: "Show help information.",
+    },
+  ],
+};
+export default completionSpec;

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -97,7 +97,7 @@ const completionSpec: Fig.Spec = {
       args: [
         {
           name: "shortcut-name",
-          description: "The name of the shortcut to run.",
+          description: "The name of the shortcut to view.",
           generators: shortcut.generators,
         },
       ],
@@ -116,14 +116,13 @@ const completionSpec: Fig.Spec = {
               generators: [
                 {
                   template: "filepaths",
-                  filterTemplateSuggestions: function (suggestions) {
-                    return suggestions.filter(
+                  filterTemplateSuggestions: (suggestions) =>
+                    suggestions.filter(
                       (suggestion) =>
                         suggestion.type === "folder" ||
                         (typeof suggestion.name === "string" &&
                           suggestion.name.endsWith(".shortcut"))
-                    );
-                  },
+                    ),
                 },
               ],
             },

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -5,12 +5,11 @@ const shortcut: Fig.Arg = {
       postProcess: (list) =>
         list.split("\n").map((shortcut) => ({
           name: shortcut,
-          icon: shortcutsIcon,
+          icon: "fig:///System/Applications/Shortcuts.app",
         })),
     },
   ],
 };
-
 const completionSpec: Fig.Spec = {
   name: "shortcuts",
   description: "Command-line utility for running shortcuts.",
@@ -186,7 +185,4 @@ const completionSpec: Fig.Spec = {
     },
   ],
 };
-// "fig://type=shortcut" does work, but it's in the generic file icon. looks bad.
-const shortcutsIcon =
-  "https://help.apple.com/assets/5E8CEA35094622DF10489984/5E8CEA42094622DF1048998D/en_US/18c714c61bfdebca44fe6989f0a2511d.png";
 export default completionSpec;

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -10,170 +10,185 @@ const shortcut: Fig.Arg = {
     },
   ],
 };
+
+const subcommands: Fig.Subcommand[] = [
+  {
+    name: "run",
+    description: "Run a shortcut.",
+    icon: "▶️",
+    args: [
+      {
+        name: "shortcut-name",
+        description: "The name of the shortcut to run.",
+        generators: shortcut.generators,
+      },
+    ],
+    options: [
+      {
+        name: ["-i", "--input-path"],
+        args: [
+          {
+            name: "input-path",
+            template: "filepaths",
+          },
+        ],
+        description: "The input to provide to the shortcut.",
+      },
+      {
+        name: ["-o", "--output-path"],
+        args: [
+          {
+            name: "output-path",
+            template: "filepaths",
+          },
+        ],
+        description: "Where to write the shortcut output, if applicable.",
+      },
+      {
+        name: ["--output-type"],
+        args: [
+          {
+            name: "output-type",
+            suggestions: [
+              {
+                name: "public.json",
+                description: "JavaScript Object Notation (JSON)",
+              },
+              {
+                name: "public.plain-text",
+                description: "Plain text",
+              },
+              {
+                name: "public.html",
+                description: "HTML",
+              },
+              {
+                name: "public.xml",
+                description: "XML",
+              },
+              {
+                name: "com.adobe.pdf",
+                description: "Adobe PDF",
+              },
+              {
+                name: "public.vcard",
+                description: "vCard",
+              },
+            ],
+          },
+        ],
+        description:
+          "What type to output data in, in Universal Type Identifier format.",
+      },
+    ],
+  },
+  {
+    name: "list",
+    description: "List your shortcuts.",
+    icon: "📂",
+    options: [
+      {
+        name: ["--folder-name", "-f"],
+        description: "The name of the folder to list.",
+        args: [
+          {
+            name: "folder-name",
+            generators: [
+              {
+                script: "shortcuts list --folders",
+                postProcess: (list) =>
+                  list.split("\n").map((folder) => ({
+                    name: folder,
+                    icon: "📂",
+                  })),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: ["--folders"],
+        description: "List folders instead of shortcuts.",
+        icon: "📂",
+      },
+    ],
+  },
+  {
+    name: "view",
+    description: "View a shortcut in Shortcuts.",
+    icon: "🔍",
+    args: [
+      {
+        name: "shortcut-name",
+        description: "The name of the shortcut to view.",
+        generators: shortcut.generators,
+      },
+    ],
+  },
+  {
+    name: "sign",
+    description: "Sign a shortcut file.",
+    icon: "🔏",
+    options: [
+      {
+        name: ["--input", "-i"],
+        description: "The shortcut file to sign.",
+        args: [
+          {
+            name: "input",
+            generators: [
+              {
+                template: "filepaths",
+                filterTemplateSuggestions: (suggestions) =>
+                  suggestions.filter(
+                    (suggestion) =>
+                      suggestion.type === "folder" ||
+                      (typeof suggestion.name === "string" &&
+                        suggestion.name.endsWith(".shortcut"))
+                  ),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: ["--output", "-o"],
+        description: "Output path for the signed shortcut file.",
+        args: [
+          {
+            name: "output",
+            template: "filepaths",
+          },
+        ],
+      },
+      {
+        name: ["--mode", "-m"],
+        description: "The signing mode. (default: people-who-know-me)",
+        args: [
+          {
+            name: "mode",
+            suggestions: ["people-who-know-me", "anyone"],
+          },
+        ],
+      },
+    ],
+  },
+];
+
 const completionSpec: Fig.Spec = {
   name: "shortcuts",
   description: "Command-line utility for running shortcuts.",
-
   subcommands: [
-    {
-      name: "run",
-      description: "Run a shortcut.",
-      icon: "▶️",
-      args: [
-        {
-          name: "shortcut-name",
-          description: "The name of the shortcut to run.",
-          generators: shortcut.generators,
-        },
-      ],
-      options: [
-        {
-          name: ["-i", "--input-path"],
-          args: [
-            {
-              name: "input-path",
-              template: "filepaths",
-            },
-          ],
-          description: "The input to provide to the shortcut.",
-        },
-        {
-          name: ["-o", "--output-path"],
-          args: [
-            {
-              name: "output-path",
-              template: "filepaths",
-            },
-          ],
-          description: "Where to write the shortcut output, if applicable.",
-        },
-        {
-          name: ["--output-type"],
-          args: [
-            {
-              name: "output-type",
-            },
-          ],
-          description:
-            "What type to output data in, in Universal Type Identifier format.",
-        },
-      ],
-    },
-    {
-      name: "list",
-      description: "List your shortcuts.",
-      icon: "📂",
-      options: [
-        {
-          name: ["--folder-name", "-f"],
-          description: "The name of the folder to list.",
-          args: [
-            {
-              name: "folder-name",
-              generators: [
-                {
-                  script: "shortcuts list --folders",
-                  postProcess: (list) =>
-                    list.split("\n").map((folder) => ({
-                      name: folder,
-                      icon: "📂",
-                    })),
-                },
-              ],
-            },
-          ],
-        },
-        {
-          name: ["--folders"],
-          description: "List folders instead of shortcuts.",
-          icon: "📂",
-        },
-      ],
-    },
-    {
-      name: "view",
-      description: "View a shortcut in Shortcuts.",
-      icon: "🔍",
-      args: [
-        {
-          name: "shortcut-name",
-          description: "The name of the shortcut to view.",
-          generators: shortcut.generators,
-        },
-      ],
-    },
-    {
-      name: "sign",
-      description: "Sign a shortcut file.",
-      icon: "🔏",
-      options: [
-        {
-          name: ["--input", "-i"],
-          description: "The shortcut file to sign.",
-          args: [
-            {
-              name: "input",
-              generators: [
-                {
-                  template: "filepaths",
-                  filterTemplateSuggestions: (suggestions) =>
-                    suggestions.filter(
-                      (suggestion) =>
-                        suggestion.type === "folder" ||
-                        (typeof suggestion.name === "string" &&
-                          suggestion.name.endsWith(".shortcut"))
-                    ),
-                },
-              ],
-            },
-          ],
-        },
-        {
-          name: ["--output", "-o"],
-          description: "Output path for the signed shortcut file.",
-          args: [
-            {
-              name: "output",
-              template: "filepaths",
-            },
-          ],
-        },
-        {
-          name: ["--mode", "-m"],
-          description: "The signing mode. (default: people-who-know-me)",
-          args: [
-            {
-              name: "mode",
-            },
-          ],
-        },
-      ],
-    },
+    ...subcommands,
     {
       name: "help",
       description: "Show help information.",
-      subcommands: [
-        {
-          name: "run",
-          description: "Run a shortcut.",
-          icon: "▶️",
-        },
-        {
-          name: "list",
-          description: "List your shortcuts.",
-          icon: "📂",
-        },
-        {
-          name: "view",
-          description: "View a shortcut in Shortcuts.",
-          icon: "🔍",
-        },
-        {
-          name: "sign",
-          description: "Sign a shortcut file.",
-          icon: "🔏",
-        },
-      ],
+      subcommands: subcommands.map(
+        (_) =>
+          Object.fromEntries(
+            ["name", "description", "icon"].map((k) => [k, _[k]])
+          ) as Fig.Subcommand
+      ),
     },
   ],
 };

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -3,7 +3,10 @@ const shortcut: Fig.Arg = {
     {
       script: "shortcuts list",
       postProcess: (list) =>
-        list.split("\n").map((shortcut) => ({ name: shortcut })),
+        list.split("\n").map((shortcut) => ({
+          name: shortcut,
+          icon: shortcutsIcon,
+        })),
     },
   ],
 };
@@ -91,7 +94,10 @@ const completionSpec: Fig.Spec = {
                 {
                   script: "shortcuts list --folders",
                   postProcess: (list) =>
-                    list.split("\n").map((folder) => ({ name: folder })),
+                    list.split("\n").map((folder) => ({
+                      name: folder,
+                      icon: "fig://icon?type=folder",
+                    })),
                 },
               ],
             },
@@ -180,4 +186,7 @@ const completionSpec: Fig.Spec = {
     },
   ],
 };
+// "fig://type=shortcut" does work, but it's in the generic file icon. looks bad.
+const shortcutsIcon =
+  "https://help.apple.com/assets/5E8CEA35094622DF10489984/5E8CEA42094622DF1048998D/en_US/18c714c61bfdebca44fe6989f0a2511d.png";
 export default completionSpec;

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -23,6 +23,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "run",
       description: "Run a shortcut.",
+      icon: "▶️",
       args: [
         {
           name: "shortcut-name",
@@ -77,6 +78,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "list",
       description: "List your shortcuts.",
+      icon: "📂",
       options: [
         {
           name: ["--help", "-h"],
@@ -111,6 +113,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "view",
       description: "View a shortcut in Shortcuts.",
+      icon: "🔍",
       args: [
         {
           name: "shortcut-name",
@@ -129,6 +132,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "sign",
       description: "Sign a shortcut file.",
+      icon: "🔏",
       options: [
         {
           name: ["--input", "-i"],

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -163,6 +163,14 @@ const completionSpec: Fig.Spec = {
     {
       name: "help",
       description: "Show help information.",
+      args: [
+        {
+          name: "subcommand",
+          description: "The subcommand to show help for.",
+          isOptional: true,
+          suggestions: ["run", "list", "view", "sign"],
+        },
+      ],
     },
   ],
 };

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -183,12 +183,11 @@ const completionSpec: Fig.Spec = {
     {
       name: "help",
       description: "Show help information.",
-      subcommands: subcommands.map(
-        (_) =>
-          Object.fromEntries(
-            ["name", "description", "icon"].map((k) => [k, _[k]])
-          ) as Fig.Subcommand
-      ),
+      subcommands: subcommands.map(({ name, description, icon }) => ({
+        name,
+        description,
+        icon,
+      })),
     },
   ],
 };

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -1,3 +1,13 @@
+const shortcut: Fig.Arg = {
+  generators: [
+    {
+      script: "shortcuts list",
+      postProcess: (list) =>
+        list.split("\n").map((shortcut) => ({ name: shortcut })),
+    },
+  ],
+};
+
 const completionSpec: Fig.Spec = {
   name: "shortcuts",
   description: "Command-line utility for running shortcuts.",
@@ -16,31 +26,29 @@ const completionSpec: Fig.Spec = {
           name: "shortcut-name",
           description: "The name of the shortcut to run.",
           isOptional: false,
-          generators: [
-            {
-              script: "shortcuts list",
-              postProcess: (list) =>
-                list.split("\n").map((shortcut) => ({ name: shortcut })),
-            },
-          ],
+          generators: shortcut.generators,
         },
       ],
       options: [
         {
           name: ["-i", "--input-path"],
+          isRequired: false, // Default: stdin
           args: [
             {
               name: "input-path",
               template: "filepaths",
+              isOptional: false,
             },
           ],
           description: "The input to provide to the shortcut.",
         },
         {
           name: ["-o", "--output-path"],
+          isRequired: false,
           args: [
             {
               name: "output-path",
+              isOptional: false,
               template: "filepaths",
             },
           ],
@@ -48,9 +56,11 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: ["--output-type"],
+          isRequired: false,
           args: [
             {
               name: "output-type",
+              isOptional: false,
             },
           ],
           description:
@@ -101,13 +111,7 @@ const completionSpec: Fig.Spec = {
           name: "shortcut-name",
           description: "The name of the shortcut to run.",
           isOptional: false,
-          generators: [
-            {
-              script: "shortcuts list",
-              postProcess: (list) =>
-                list.split("\n").map((shortcut) => ({ name: shortcut })),
-            },
-          ],
+          generators: shortcut.generators,
         },
       ],
       options: [
@@ -152,9 +156,11 @@ const completionSpec: Fig.Spec = {
         {
           name: ["--mode", "-m"],
           description: "The  signing mode. (default: people-who-know-me)",
+          isRequired: false,
           args: [
             {
               name: "mode",
+              isOptional: false,
             },
           ],
         },

--- a/this.txt
+++ b/this.txt
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
Backend doesn't exist

**What is the new behavior (if this is a feature change)?**
It does exist

**Additional info:**
The Shortucts app and this utility are currently available in the macOS Monterey Public Beta, slated for release this Fall.

https://www.apple.com/macos/monterey-preview/
https://sixcolors.com/link/2021/06/shortcuts-shaping-up-on-the-mac/


## Examples
 - `shortcuts list`
 - `shortcuts list --folders`
 - `shortcuts run HelloWorld`
 - `shortcuts view HelloWorld`

<img height="140" alt="Screen Shot 2021-08-17 at 5 01 00 PM" src="https://user-images.githubusercontent.com/4590343/129799972-001b03fe-2c34-4619-bcb6-848401b13c9a.png">

 <img height="100" alt="Screen Shot 2021-08-17 at 2 44 21 PM" src="https://user-images.githubusercontent.com/4590343/129782928-c90efef2-bdd4-4a68-bbc6-3bdcfda778e8.png">
