### PR TITLE
[echo] Changed arg name to string and removed description

### DIFF
--- a/dev/echo.ts
+++ b/dev/echo.ts
@@ -2,9 +2,7 @@ const completionSpec: Fig.Spec = {
   name: "echo",
   description: "Write arguments to the standard output",
   args: {
-    name: "operands",
-    description:
-      "Write any specified operands, separated by single blank characters and followed by a newline character, to the standard output",
+    name: "string",
     isVariadic: true,
   },
   options: [


### PR DESCRIPTION
The argument is self explanatory as echo only does one thing. The description box was very long despite how simple the argument is.