### PR TITLE
feat: add fvm completion spec

### DIFF
--- a/dev/fvm.ts
+++ b/dev/fvm.ts
@@ -14,11 +14,11 @@ const completionSpec: Fig.Spec = {
   options: [
     ...globalOptions,
     {
-      name: ["--verbose"],
+      name: "--verbose",
       description: "Print verbose output.",
     },
     {
-      name: ["--version"],
+      name: "--version",
       description: "Current FVM version.",
     },
   ],
@@ -101,16 +101,14 @@ const completionSpec: Fig.Spec = {
             priority: 98,
           },
         ],
-        generators: [
-          {
-            script: "fvm releases",
-            postProcess: function (out): Fig.Suggestion[] {
-              const matches = out.match(semverRegex);
-              const matchesSet = [...new Set(matches)];
-              return matchesSet.map((match) => ({ name: match })).reverse();
-            },
+        generators: {
+          script: "fvm releases",
+          postProcess: function (out): Fig.Suggestion[] {
+            const matches = out.match(semverRegex);
+            const matchesSet = [...new Set(matches)];
+            return matchesSet.map((match) => ({ name: match })).reverse();
           },
-        ],
+        },
       },
       options: [
         ...globalOptions,
@@ -140,7 +138,7 @@ const completionSpec: Fig.Spec = {
       options: [
         ...globalOptions,
         {
-          name: ["--force"],
+          name: "--force",
           description: "Skips version global check.",
         },
       ],
@@ -172,7 +170,7 @@ const completionSpec: Fig.Spec = {
             "If version provided is a channel. Will pin the latest release of the channel.",
         },
         {
-          name: ["--flavor"],
+          name: "--flavor",
           description: "Sets version for a project flavor.",
         },
       ],

--- a/dev/fvm.ts
+++ b/dev/fvm.ts
@@ -1,6 +1,6 @@
 const semverRegex = /((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/gm;
 
-const globalOptions = [
+const globalOptions: Fig.Option[] = [
   {
     name: ["-h", "--help"],
     description: "Print this usage information.",
@@ -32,6 +32,11 @@ const completionSpec: Fig.Spec = {
           name: ["-c", "--cache-path"],
           description:
             "Set the path which FVM will cache the version. Priority over FVM_HOME.",
+          args: {
+            name: "path",
+            description: "Path to the Flutter versions cache.",
+            template: "filepaths",
+          },
         },
         {
           name: ["-s", "--skip-setup", "--no-skip-setup"],
@@ -47,7 +52,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "dart",
       description: "Proxies Dart commands",
-      args: {},
     },
     {
       name: "doctor",
@@ -57,7 +61,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "flavor",
       description: "Switches between different project flavors.",
-      args: {},
+      args: {
+        name: "flavor-name",
+        description: "The flavor to switch to.",
+      },
     },
     {
       name: "flutter",
@@ -77,7 +84,23 @@ const completionSpec: Fig.Spec = {
       description: "Installs Flutter SDK version",
       args: {
         name: "version",
-        suggestions: ["stable", "beta", "dev"],
+        suggestions: [
+          {
+            name: "stable",
+            description: "Latest stable release of Flutter",
+            priority: 100,
+          },
+          {
+            name: "beta",
+            description: "Latest beta release of Flutter",
+            priority: 99,
+          },
+          {
+            name: "dev",
+            description: "Latest dev release of Flutter (master)",
+            priority: 98,
+          },
+        ],
         generators: [
           {
             script: "fvm releases",
@@ -110,7 +133,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "remove",
       description: "Removes Flutter SDK version.",
-      args: { name: "version" },
+      args: {
+        name: "version",
+        description: "The installed Flutter version to remove.",
+      },
       options: [
         ...globalOptions,
         {
@@ -122,7 +148,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "spawn",
       description: "Spawn a Flutter SDK version command",
-      args: { name: "version" },
+      args: {
+        name: "version",
+        description: "The Flutter version from which to spawn a command.",
+      },
     },
     {
       name: "use",

--- a/dev/fvm.ts
+++ b/dev/fvm.ts
@@ -1,0 +1,154 @@
+const semverRegex = /((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/gm;
+
+const globalOptions = [
+  {
+    name: ["-h", "--help"],
+    description: "Print this usage information.",
+  },
+];
+
+const completionSpec: Fig.Spec = {
+  name: "fvm",
+  description:
+    "Flutter Version Management: A cli to manage Flutter SDK versions.",
+  options: [
+    ...globalOptions,
+    {
+      name: ["--verbose"],
+      description: "Print verbose output.",
+    },
+    {
+      name: ["--version"],
+      description: "Current FVM version.",
+    },
+  ],
+  subcommands: [
+    {
+      name: "config",
+      description: "Set configuration for FVM",
+      options: [
+        ...globalOptions,
+        {
+          name: ["-c", "--cache-path"],
+          description:
+            "Set the path which FVM will cache the version. Priority over FVM_HOME.",
+        },
+        {
+          name: ["-s", "--skip-setup", "--no-skip-setup"],
+          description: "Skip setup after a version install.",
+        },
+        {
+          name: ["-g", "--git-cache", "--no-git-cache"],
+          description:
+            "ADVANCED: Will cache a local version of Flutter repo for faster version install.",
+        },
+      ],
+    },
+    {
+      name: "dart",
+      description: "Proxies Dart commands",
+      args: {},
+    },
+    {
+      name: "doctor",
+      description:
+        "Shows information about environment, and project configuration.",
+    },
+    {
+      name: "flavor",
+      description: "Switches between different project flavors.",
+      args: {},
+    },
+    {
+      name: "flutter",
+      description: "Proxies Flutter commands.",
+      loadSpec: "flutter",
+    },
+    {
+      name: "global",
+      description: "Sets Flutter SDK version as global.",
+      args: {
+        name: "version",
+        description: "Flutter SDK to set for global flutter command.",
+      },
+    },
+    {
+      name: "install",
+      description: "Installs Flutter SDK version",
+      args: {
+        name: "version",
+        suggestions: ["stable", "beta", "dev"],
+        generators: [
+          {
+            script: "fvm releases",
+            postProcess: function (out): Fig.Suggestion[] {
+              const matches = out.match(semverRegex);
+              const matchesSet = [...new Set(matches)];
+              return matchesSet.map((match) => ({ name: match })).reverse();
+            },
+          },
+        ],
+      },
+      options: [
+        ...globalOptions,
+        {
+          name: ["-s", "--skip-setup"],
+          description: "Skips Flutter setup after install.",
+        },
+      ],
+    },
+    {
+      name: "list",
+      description: "Lists installed Flutter SDK versions.",
+      options: [...globalOptions],
+    },
+    {
+      name: "releases",
+      description: "View all Flutter SDK releases available for install.",
+      options: [...globalOptions],
+    },
+    {
+      name: "remove",
+      description: "Removes Flutter SDK version.",
+      args: { name: "version" },
+      options: [
+        ...globalOptions,
+        {
+          name: ["--force"],
+          description: "Skips version global check.",
+        },
+      ],
+    },
+    {
+      name: "spawn",
+      description: "Spawn a Flutter SDK version command",
+      args: { name: "version" },
+    },
+    {
+      name: "use",
+      description: "Sets a Flutter SDK version to be used in a project",
+      args: {
+        name: "version",
+        description: "The Flutter SDK version to use",
+      },
+      options: [
+        ...globalOptions,
+        {
+          name: ["-f", "--force"],
+          description: "Skips command guards that does Flutter project checks.",
+        },
+        {
+          name: ["-p", "--pin"],
+          description:
+            "If version provided is a channel. Will pin the latest release of the channel.",
+        },
+        {
+          name: ["--flavor"],
+          description: "Sets version for a project flavor.",
+        },
+      ],
+    },
+  ],
+};
+
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This PR adds autocompletion support for the fvm CLI (Flutter version manager).
**What is the current behavior? (You can also link to an open issue here)**
Currently there is no autocomplete for fvm.
**What is the new behavior (if this is a feature change)?**
Autocomplete now works with all fvm commands and subcommands except the dart proxy command. When I get around to adding Dart autocomplete support I would like to add that to fvm autocomplete as well (the same way the flutter proxy is currently implemented).
**Additional info:**