### PR TITLE
[npm] Updates to several npm subcommands

### DIFF
--- a/dev/npm.ts
+++ b/dev/npm.ts
@@ -82,6 +82,24 @@ const dependenciesGenerator: Fig.Generator = {
   },
 };
 
+const workSpaceOptions: Fig.Option[] = [
+  {
+    name: ["-wl--workspace"],
+    description:
+      "Enable running a command in the context of the configured workspaces of the current project",
+    args: {
+      name: "workspace",
+      generators: workspaceGenerator,
+      isVariadic: true,
+    },
+  },
+  {
+    name: ["-wsl--workspaces"],
+    description:
+      "Enable running a command in the context of all the configured workspaces.",
+  },
+];
+
 const npmInstallOptions: Fig.Option[] = [
   {
     name: ["-S", "--save"],
@@ -103,21 +121,7 @@ const npmInstallOptions: Fig.Option[] = [
     name: "-g",
     description: "Uninstall global package",
   },
-  {
-    name: ["-wl--workspace"],
-    description:
-      "Enable running a command in the context of the configured workspaces of the current project",
-    args: {
-      name: "workspace",
-      generators: workspaceGenerator,
-      isVariadic: true,
-    },
-  },
-  {
-    name: ["-wsl--workspaces"],
-    description:
-      "Enable running a command in the context of all the configured workspaces.",
-  },
+  ...workSpaceOptions,
 ];
 
 const npmListOptions: Fig.Option[] = [
@@ -156,21 +160,6 @@ const npmListOptions: Fig.Option[] = [
       "Operates in 'global' mode, so that packages are installed into the prefix folder instead of the current working directory.",
   },
   {
-    name: ["-wl--workspace"],
-    description:
-      "Enable running a command in the context of the configured workspaces of the current project",
-    args: {
-      name: "workspace",
-      generators: workspaceGenerator,
-      isVariadic: true,
-    },
-  },
-  {
-    name: ["-wsl--workspaces"],
-    description:
-      "Enable running a command in the context of all the configured workspaces.",
-  },
-  {
     name: ["--omit"],
     description: "Dependency types to omit from the installation tree on disk.",
     args: {
@@ -179,6 +168,7 @@ const npmListOptions: Fig.Option[] = [
       suggestions: ["dev", "optional", "peer"],
     },
   },
+  ...workSpaceOptions,
 ];
 
 const completionSpec: Fig.Spec = {
@@ -285,42 +275,14 @@ const completionSpec: Fig.Spec = {
           description:
             "Indicates that you don't want npm to make any changes and that it should only report what it would have done.",
         },
-        {
-          name: ["-wl--workspace"],
-          description:
-            "Enable running a command in the context of the configured workspaces of the current project",
-          args: {
-            name: "workspace",
-            generators: workspaceGenerator,
-            isVariadic: true,
-          },
-        },
-        {
-          name: ["-wsl--workspaces"],
-          description:
-            "Enable running a command in the context of all the configured workspaces.",
-        },
+        ...workSpaceOptions,
       ],
     },
     {
       name: "run",
       description: "run arbitrary package scripts",
       options: [
-        {
-          name: ["-wl--workspace"],
-          description:
-            "Enable running a command in the context of the configured workspaces of the current project",
-          args: {
-            name: "workspace",
-            generators: workspaceGenerator,
-            isVariadic: true,
-          },
-        },
-        {
-          name: ["-wsl--workspaces"],
-          description:
-            "Enable running a command in the context of all the configured workspaces.",
-        },
+        ...workSpaceOptions,
         {
           name: "--if-present",
           description:
@@ -401,21 +363,7 @@ const completionSpec: Fig.Spec = {
       name: "audit",
       description: "run a security audit",
       options: [
-        {
-          name: ["-wl--workspace"],
-          description:
-            "Enable running a command in the context of the configured workspaces of the current project",
-          args: {
-            name: "workspace",
-            generators: workspaceGenerator,
-            isVariadic: true,
-          },
-        },
-        {
-          name: ["-wsl--workspaces"],
-          description:
-            "Enable running a command in the context of all the configured workspaces.",
-        },
+        ...workSpaceOptions,
         {
           name: "--audit-level",
           description:
@@ -623,21 +571,7 @@ const completionSpec: Fig.Spec = {
           name: "-g",
           description: "checks globally",
         },
-        {
-          name: ["-wl--workspace"],
-          description:
-            "Enable running a command in the context of the configured workspaces of the current project",
-          args: {
-            name: "workspace",
-            generators: workspaceGenerator,
-            isVariadic: true,
-          },
-        },
-        {
-          name: ["-wsl--workspaces"],
-          description:
-            "Enable running a command in the context of all the configured workspaces.",
-        },
+        ...workSpaceOptions,
       ],
     },
     { name: "owner", description: "manage package owners" },
@@ -682,21 +616,7 @@ const completionSpec: Fig.Spec = {
           description: "Registers the published package with the given tag",
           args: { name: "tag" },
         },
-        {
-          name: ["-wl--workspace"],
-          description:
-            "Enable running a command in the context of the configured workspaces of the current project",
-          args: {
-            name: "workspace",
-            generators: workspaceGenerator,
-            isVariadic: true,
-          },
-        },
-        {
-          name: ["-wsl--workspaces"],
-          description:
-            "Enable running a command in the context of all the configured workspaces.",
-        },
+        ...workSpaceOptions,
         {
           name: "--access",
           description:
@@ -927,21 +847,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Indicates that you don't want npm to make any changes and that it should only report what it would have done.",
         },
-        {
-          name: ["-wl--workspace"],
-          description:
-            "Enable running a command in the context of the configured workspaces of the current project",
-          args: {
-            name: "workspace",
-            generators: workspaceGenerator,
-            isVariadic: true,
-          },
-        },
-        {
-          name: ["-wsl--workspaces"],
-          description:
-            "Enable running a command in the context of all the configured workspaces.",
-        },
+        ...workSpaceOptions,
       ],
     },
     { name: "v", description: "check that you have node and npm installed" },
@@ -949,21 +855,7 @@ const completionSpec: Fig.Spec = {
       name: "version",
       description: "bump a package version",
       options: [
-        {
-          name: ["-wl--workspace"],
-          description:
-            "Enable running a command in the context of the configured workspaces of the current project",
-          args: {
-            name: "workspace",
-            generators: workspaceGenerator,
-            isVariadic: true,
-          },
-        },
-        {
-          name: ["-wsl--workspaces"],
-          description:
-            "Enable running a command in the context of all the configured workspaces.",
-        },
+        ...workSpaceOptions,
         { name: "--json", description: "show output in json format" },
       ],
     },
@@ -971,21 +863,7 @@ const completionSpec: Fig.Spec = {
       name: "view",
       description: "view registry info",
       options: [
-        {
-          name: ["-wl--workspace"],
-          description:
-            "Enable running a command in the context of the configured workspaces of the current project",
-          args: {
-            name: "workspace",
-            generators: workspaceGenerator,
-            isVariadic: true,
-          },
-        },
-        {
-          name: ["-wsl--workspaces"],
-          description:
-            "Enable running a command in the context of all the configured workspaces.",
-        },
+        ...workSpaceOptions,
         { name: "--json", description: "show output in json format" },
       ],
     },

--- a/dev/npm.ts
+++ b/dev/npm.ts
@@ -24,6 +24,34 @@ const searchGenerator: Fig.Generator = {
   // },
 };
 
+const workspaceGenerator: Fig.Generator = {
+  script: "cat package.json",
+  postProcess: function (out) {
+    const suggestions = [];
+
+    try {
+      if (out.trim() == "") {
+        return { name: "workspaces" };
+      }
+
+      const packageContent = JSON.parse(out);
+      const workspaces = packageContent["workspaces"];
+
+      if (workspaces) {
+        for (const workspace of workspaces) {
+          suggestions.push({
+            name: workspace,
+            description: "Workspaces",
+          });
+        }
+      }
+    } catch (e) {
+      console.log(e);
+    }
+    return suggestions;
+  },
+};
+
 const dependenciesGenerator: Fig.Generator = {
   script: "cat package.json",
   postProcess: function (out, context) {
@@ -74,10 +102,32 @@ const npmInstallOptions: Fig.Option[] = [
     name: "--no-save",
     description: "Prevents saving to `dependencies`",
   },
+  {
+    name: "-g",
+    description: "Uninstall global package",
+  },
+  {
+    name: ["-wl--workspace"],
+    description:
+      "Enable running a command in the context of the configured workspaces of the current project",
+    args: {
+      name: "workspace",
+      generators: workspaceGenerator,
+      isVariadic: true,
+    },
+  },
+  {
+    name: ["-wsl--workspaces"],
+    description:
+      "Enable running a command in the context of all the configured workspaces.",
+  },
 ];
 
 const completionSpec: Fig.Spec = {
   name: "npm",
+  parserDirectives: {
+    flagsArePosixNoncompliant: true,
+  },
   description: "Node package manager",
   subcommands: [
     {
@@ -112,6 +162,85 @@ const completionSpec: Fig.Spec = {
           name: ["-E", "--save-exact"],
           description:
             "Saved dependencies will be configured with an exact version rather than using npm's default semver range operator",
+        },
+        {
+          name: ["-B", "--save-bundle"],
+          description:
+            "Saved dependencies will also be added to your bundleDependencies list.",
+        },
+        {
+          name: ["-g", "--global"],
+          description:
+            "Operates in 'global' mode, so that packages are installed into the prefix folder instead of the current working directory.",
+        },
+        {
+          name: ["--global-style"],
+          description:
+            "Causes npm to install the package into your local node_modules folder with the same layout it uses with the global node_modules folder.",
+        },
+        {
+          name: ["--legacy-bundling"],
+          description:
+            "Causes npm to install the package such that versions of npm prior to 1.4, such as the one included with node 0.8, can install the package.",
+        },
+        {
+          name: ["--strict-peer-deps"],
+          description:
+            "If set to true, and --legacy-peer-deps is not set, then any conflicting peerDependencies will be treated as an install failure.",
+        },
+        {
+          name: ["--no-package-lock"],
+          description: "Ignores package-lock.json files when installing.",
+        },
+        {
+          name: ["--omit"],
+          description:
+            "Dependency types to omit from the installation tree on disk.",
+          args: {
+            name: "Package type",
+            default: "dev",
+            suggestions: ["dev", "optional", "peer"],
+          },
+        },
+        {
+          name: ["--ignore-scripts"],
+          description:
+            "If true, npm does not run scripts specified in package.json files.",
+        },
+        {
+          name: ["--no-audit"],
+          description:
+            "Submit audit reports alongside the current npm command to the default registry and all registries configured for scopes.",
+        },
+        {
+          name: ["--no-bin-links"],
+          description:
+            "Tells npm to not create symlinks (or .cmd shims on Windows) for package executables.",
+        },
+        {
+          name: ["--no-fund"],
+          description:
+            "Hides the message at the end of each npm install acknowledging the number of dependencies looking for funding.",
+        },
+        {
+          name: ["--dry-run"],
+          description:
+            "Indicates that you don't want npm to make any changes and that it should only report what it would have done.",
+        },
+        {
+          name: ["-wl--workspace"],
+          description:
+            "Enable running a command in the context of the configured workspaces of the current project",
+          args: {
+            name: "workspace",
+            generators: workspaceGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-wsl--workspaces"],
+          description:
+            "Enable running a command in the context of all the configured workspaces.",
         },
       ],
     },
@@ -161,7 +290,17 @@ const completionSpec: Fig.Spec = {
     { name: "access", description: "set access controls on private packages" },
     { name: "adduser", description: "add a registry user account" },
     { name: "audit", description: "run a security audit" },
-    { name: "bin", description: "display npm bin folder" },
+    {
+      name: "bin",
+      description: "display npm bin folder",
+      options: [
+        {
+          name: ["-g"],
+          description:
+            "Print the global folder where npm will install executables",
+        },
+      ],
+    },
     {
       name: "bugs",
       description: "show the bugs that might exist for a package",
@@ -182,7 +321,46 @@ const completionSpec: Fig.Spec = {
       description: "install a project with a clean slate and run tests",
     },
     { name: "completion", description: "tab completion for npm" },
-    { name: "config", description: "manage the npm configuration files" },
+    {
+      name: "config",
+      description: "manage the npm configuration files",
+      subcommands: [
+        {
+          name: "set",
+          description: "Sets the config key to the value",
+          args: [{ name: "key" }, { name: "value" }],
+          options: [
+            { name: ["-g", "--global"], description: "Sets it globally" },
+          ],
+        },
+        {
+          name: "get",
+          description: "Echo the config value to stdout",
+          args: { name: "key" },
+        },
+        {
+          name: "list",
+          description: "Show all the config settings",
+          options: [
+            { name: ["-g"], description: "Lists globally installed packages" },
+            { name: ["-l"], description: "Also shows defaults" },
+            { name: ["--json"], description: "Shows settings in json format" },
+          ],
+        },
+        {
+          name: "delete",
+          description: "Deletes the key from all configuration files",
+          args: { name: "key" },
+        },
+        {
+          name: "edit",
+          description: "Opens the config file in an editor",
+          options: [
+            { name: ["--global"], description: "Edits the global config" },
+          ],
+        },
+      ],
+    },
     { name: "create", description: "create a package.json file" },
     { name: "ddp", description: "reduce duplication" },
     { name: "dedupe", description: "reduce duplication" },
@@ -219,13 +397,56 @@ const completionSpec: Fig.Spec = {
     { name: "ln", description: "symlink a package folder" },
     { name: "login", description: "log in of the registry" },
     { name: "logout", description: "log out of the registry" },
-    { name: "ls", description: "list installed packages" },
+    {
+      name: "ls",
+      description: "list installed packages",
+      options: [
+        {
+          name: ["-g", "--global"],
+          description:
+            "Operates in 'global' mode, so that packages are installed into the prefix folder instead of the current working directory.",
+        },
+        {
+          name: ["-wl--workspace"],
+          description:
+            "Enable running a command in the context of the configured workspaces of the current project",
+          args: {
+            name: "workspace",
+            generators: workspaceGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-wsl--workspaces"],
+          description:
+            "Enable running a command in the context of all the configured workspaces.",
+        },
+      ],
+    },
     { name: "org", description: "manage orgs" },
-    { name: "outdated", description: "check for outdated packages" },
+    {
+      name: "outdated",
+      description: "check for outdated packages",
+      options: [
+        {
+          name: "-g",
+          description: "checks globally",
+        },
+      ],
+    },
     { name: "owner", description: "manage package owners" },
     { name: "pack", description: "create a tarball from a package" },
     { name: "ping", description: "ping npm registry" },
-    { name: "prefix", description: "display prefix" },
+    {
+      name: "prefix",
+      description: "display prefix",
+      options: [
+        {
+          name: ["-g"],
+          description: "Print the global prefix to standard out",
+        },
+      ],
+    },
     {
       name: "profile",
       description: "change settings on your registry profile",
@@ -239,7 +460,17 @@ const completionSpec: Fig.Spec = {
       description: "open package repository page in the browser",
     },
     { name: "restart", description: "restart a package" },
-    { name: "root", description: "display npm root" },
+    {
+      name: "root",
+      description: "display npm root",
+      options: [
+        {
+          name: ["-g"],
+          description:
+            "Print the effective global node_modules folder to standard out.",
+        },
+      ],
+    },
     { name: "run-script", description: "run arbitrary package scripts" },
     { name: "s", description: "search for packages" },
     { name: "se", description: "search for packages" },
@@ -324,7 +555,11 @@ const completionSpec: Fig.Spec = {
     { name: "unpublish", description: "remove a package from the registry" },
     { name: "unstar", description: "unmark your package" },
     { name: "up", description: "check the latest version of dependencies" },
-    { name: "update", description: "update a package" },
+    {
+      name: "update",
+      description: "update a package",
+      options: [{ name: "-g", description: "update global package" }],
+    },
     { name: "v", description: "check that you have node and npm installed" },
     { name: "version", description: "bump a package version" },
     { name: "view", description: "view registry info" },

--- a/dev/npm.ts
+++ b/dev/npm.ts
@@ -23,12 +23,12 @@ const searchGenerator: Fig.Generator = {
 
 const workspaceGenerator: Fig.Generator = {
   script: "cat package.json",
-  postProcess: function (out) {
+  postProcess: function (out: string) {
     const suggestions = [];
 
     try {
       if (out.trim() == "") {
-        return { name: "workspaces" };
+        return suggestions;
       }
 
       const packageContent = JSON.parse(out);

--- a/dev/npm.ts
+++ b/dev/npm.ts
@@ -19,9 +19,6 @@ const searchGenerator: Fig.Generator = {
 
     return temp;
   },
-  // trigger: function () {
-  //   return true;
-  // },
 };
 
 const workspaceGenerator: Fig.Generator = {
@@ -120,6 +117,67 @@ const npmInstallOptions: Fig.Option[] = [
     name: ["-wsl--workspaces"],
     description:
       "Enable running a command in the context of all the configured workspaces.",
+  },
+];
+
+const npmListOptions: Fig.Option[] = [
+  {
+    name: ["-a", "-all"],
+    description: "show all outdated or installed packages",
+  },
+  { name: "--json", description: "show output in json format" },
+  { name: ["-l", "--long"], description: "Show extended information" },
+  {
+    name: ["-p", "--parseable"],
+    description:
+      "Output parseable results from commands that write to standard output",
+  },
+  {
+    name: "--depth",
+    description: "The depth to go when recursing packages",
+    args: { name: "depth" },
+  },
+  {
+    name: "--link",
+    description: "limits output to only those packages that are linked",
+  },
+  {
+    name: "--package-lock-only",
+    description:
+      "current operation will only use the package-lock.json, ignoring node_modules",
+  },
+  {
+    name: "--no-unicode",
+    description: "uses unicode characters in the tree output",
+  },
+  {
+    name: ["-g", "--global"],
+    description:
+      "Operates in 'global' mode, so that packages are installed into the prefix folder instead of the current working directory.",
+  },
+  {
+    name: ["-wl--workspace"],
+    description:
+      "Enable running a command in the context of the configured workspaces of the current project",
+    args: {
+      name: "workspace",
+      generators: workspaceGenerator,
+      isVariadic: true,
+    },
+  },
+  {
+    name: ["-wsl--workspaces"],
+    description:
+      "Enable running a command in the context of all the configured workspaces.",
+  },
+  {
+    name: ["--omit"],
+    description: "Dependency types to omit from the installation tree on disk.",
+    args: {
+      name: "Package type",
+      default: "dev",
+      suggestions: ["dev", "optional", "peer"],
+    },
   },
 ];
 
@@ -247,6 +305,40 @@ const completionSpec: Fig.Spec = {
     {
       name: "run",
       description: "run arbitrary package scripts",
+      options: [
+        {
+          name: ["-wl--workspace"],
+          description:
+            "Enable running a command in the context of the configured workspaces of the current project",
+          args: {
+            name: "workspace",
+            generators: workspaceGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-wsl--workspaces"],
+          description:
+            "Enable running a command in the context of all the configured workspaces.",
+        },
+        {
+          name: "--if-present",
+          description:
+            "npm will not exit with an error code when run-script is invoked for a script that isn't defined in the scripts section of package.json",
+        },
+        {
+          name: "--silent",
+          description: "",
+        },
+        {
+          name: "--ignore-scripts",
+          description: "",
+        },
+        {
+          name: "--script-shell",
+          args: { name: "shell" },
+        },
+      ],
       args: [
         {
           generators: {
@@ -286,10 +378,78 @@ const completionSpec: Fig.Spec = {
         },
       ],
     },
-    { name: "init", description: "trigger the initialization" },
+    {
+      name: "init",
+      description: "trigger the initialization",
+      options: [
+        {
+          name: ["-y", "--yes"],
+          description:
+            "Automatically answer 'yes' to any prompts that npm might print on the command line",
+        },
+        {
+          name: "-w",
+          description:
+            "create the folders and boilerplate expected while also adding a reference to your project workspaces property",
+          args: { name: "dir" },
+        },
+      ],
+    },
     { name: "access", description: "set access controls on private packages" },
     { name: "adduser", description: "add a registry user account" },
-    { name: "audit", description: "run a security audit" },
+    {
+      name: "audit",
+      description: "run a security audit",
+      options: [
+        {
+          name: ["-wl--workspace"],
+          description:
+            "Enable running a command in the context of the configured workspaces of the current project",
+          args: {
+            name: "workspace",
+            generators: workspaceGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-wsl--workspaces"],
+          description:
+            "Enable running a command in the context of all the configured workspaces.",
+        },
+        {
+          name: "--audit-level",
+          description:
+            "The minimum level of vulnerability for npm audit to exit with a non-zero exit code",
+          args: {
+            name: "audit",
+            suggestions: [
+              "info",
+              "low",
+              "moderate",
+              "high",
+              "critical",
+              "none",
+            ],
+          },
+        },
+        {
+          name: "--package-lock-only",
+          description:
+            "current operation will only use the package-lock.json, ignoring node_modules",
+        },
+        { name: ["--json"], description: "Shows settings in json format" },
+        {
+          name: ["--omit"],
+          description:
+            "Dependency types to omit from the installation tree on disk.",
+          args: {
+            name: "Package type",
+            default: "dev",
+            suggestions: ["dev", "optional", "peer"],
+          },
+        },
+      ],
+    },
     {
       name: "bin",
       description: "display npm bin folder",
@@ -306,7 +466,23 @@ const completionSpec: Fig.Spec = {
       description: "show the bugs that might exist for a package",
     },
     { name: "c", description: "manage the npm configuration files" },
-    { name: "cache", description: "manipulates packages cache" },
+    {
+      name: "cache",
+      description: "manipulates packages cache",
+      subcommands: [
+        {
+          name: "add",
+          args: { name: "Add the specified packages to the local cache" },
+        },
+      ],
+      options: [
+        {
+          name: "--cache",
+          args: { name: "cache" },
+          description: "the location of npm's cache directory",
+        },
+      ],
+    },
     { name: "ci", description: "install a project with a clean slate" },
     {
       name: "cit",
@@ -358,18 +534,39 @@ const completionSpec: Fig.Spec = {
           options: [
             { name: ["--global"], description: "Edits the global config" },
           ],
+          args: {
+            name: "package",
+            generators: dependenciesGenerator,
+          },
         },
       ],
     },
     { name: "create", description: "create a package.json file" },
     { name: "ddp", description: "reduce duplication" },
     { name: "dedupe", description: "reduce duplication" },
-    { name: "deprecate", description: "deprecate a version of a package" },
+    {
+      name: "deprecate",
+      description: "deprecate a version of a package",
+      options: [
+        {
+          name: "--registry",
+          description: "The base URL of the npm registry",
+          args: { name: "registry" },
+        },
+      ],
+    },
     { name: "dist-tag", description: "modify package distribution tags" },
     { name: "docs", description: "docs for a package in a web browser maybe" },
     { name: "doctor", description: "check your environments" },
     { name: "edit", description: "edit an installed package" },
-    { name: "explore", description: "browse an installed package" },
+    {
+      name: "explore",
+      description: "browse an installed package",
+      args: {
+        name: "package",
+        generators: dependenciesGenerator,
+      },
+    },
     { name: "fund", description: "retrieve funding information" },
     { name: "get", description: "echo the config value to stdout" },
     { name: "help", description: "search npm help documentation" },
@@ -393,18 +590,38 @@ const completionSpec: Fig.Spec = {
     { name: "install-test", description: "install package(s) and run tests" },
     { name: "it", description: "install package(s) and run tests" },
     { name: "link", description: "symlink a package folder" },
-    { name: "list", description: "list installed packages" },
+    {
+      name: "list",
+      description: "list installed packages",
+      options: npmListOptions,
+    },
     { name: "ln", description: "symlink a package folder" },
     { name: "login", description: "log in of the registry" },
     { name: "logout", description: "log out of the registry" },
     {
       name: "ls",
       description: "list installed packages",
+      options: npmListOptions,
+    },
+    { name: "org", description: "manage orgs" },
+    {
+      name: "outdated",
+      description: "check for outdated packages",
       options: [
         {
-          name: ["-g", "--global"],
+          name: ["-a", "-all"],
+          description: "show all outdated or installed packages",
+        },
+        { name: "--json", description: "show output in json format" },
+        { name: ["-l", "--long"], description: "Show extended information" },
+        {
+          name: ["-p", "--parseable"],
           description:
-            "Operates in 'global' mode, so that packages are installed into the prefix folder instead of the current working directory.",
+            "Output parseable results from commands that write to standard output",
+        },
+        {
+          name: "-g",
+          description: "checks globally",
         },
         {
           name: ["-wl--workspace"],
@@ -420,17 +637,6 @@ const completionSpec: Fig.Spec = {
           name: ["-wsl--workspaces"],
           description:
             "Enable running a command in the context of all the configured workspaces.",
-        },
-      ],
-    },
-    { name: "org", description: "manage orgs" },
-    {
-      name: "outdated",
-      description: "check for outdated packages",
-      options: [
-        {
-          name: "-g",
-          description: "checks globally",
         },
       ],
     },
@@ -451,13 +657,34 @@ const completionSpec: Fig.Spec = {
       name: "profile",
       description: "change settings on your registry profile",
     },
-    { name: "prune", description: "remove extraneous packages" },
+    {
+      name: "prune",
+      description: "remove extraneous packages",
+      options: [
+        {
+          name: ["--dry-run"],
+          description:
+            "Indicates that you don't want npm to make any changes and that it should only report what it would have done.",
+        },
+        { name: "--json", description: "show output in json format" },
+        {
+          name: "--production",
+          description: "remove the packages specified in your devDependencies",
+        },
+      ],
+    },
     { name: "publish", description: "publish a package" },
     { name: "rb", description: "rebuild a package" },
     { name: "rebuild", description: "rebuild a package" },
     {
       name: "repo",
       description: "open package repository page in the browser",
+      args: {
+        name: "package",
+        isOptional: true,
+        generators: searchGenerator,
+        debounce: true,
+      },
     },
     { name: "restart", description: "restart a package" },
     {
@@ -482,7 +709,21 @@ const completionSpec: Fig.Spec = {
     },
     { name: "star", description: "mark your favorite packages" },
     { name: "stars", description: "view packages marked as favorites" },
-    { name: "start", description: "start a package" },
+    {
+      name: "start",
+      description: "start a package",
+      options: [
+        {
+          name: ["--ignore-scripts"],
+          description:
+            "If true, npm does not run scripts specified in package.json files.",
+        },
+        {
+          name: "--script-shell",
+          args: { name: "shell" },
+        },
+      ],
+    },
     { name: "stop", description: "stop a package" },
     { name: "t", description: "test a package" },
     {
@@ -558,11 +799,103 @@ const completionSpec: Fig.Spec = {
     {
       name: "update",
       description: "update a package",
-      options: [{ name: "-g", description: "update global package" }],
+      options: [
+        { name: "-g", description: "update global package" },
+        {
+          name: ["--global-style"],
+          description:
+            "Causes npm to install the package into your local node_modules folder with the same layout it uses with the global node_modules folder.",
+        },
+        {
+          name: ["--legacy-bundling"],
+          description:
+            "Causes npm to install the package such that versions of npm prior to 1.4, such as the one included with node 0.8, can install the package.",
+        },
+        {
+          name: ["--strict-peer-deps"],
+          description:
+            "If set to true, and --legacy-peer-deps is not set, then any conflicting peerDependencies will be treated as an install failure.",
+        },
+        {
+          name: ["--no-package-lock"],
+          description: "Ignores package-lock.json files when installing.",
+        },
+        {
+          name: ["--omit"],
+          description:
+            "Dependency types to omit from the installation tree on disk.",
+          args: {
+            name: "Package type",
+            default: "dev",
+            suggestions: ["dev", "optional", "peer"],
+          },
+        },
+        {
+          name: ["--ignore-scripts"],
+          description:
+            "If true, npm does not run scripts specified in package.json files.",
+        },
+        {
+          name: ["--no-audit"],
+          description:
+            "Submit audit reports alongside the current npm command to the default registry and all registries configured for scopes.",
+        },
+        {
+          name: ["--no-bin-links"],
+          description:
+            "Tells npm to not create symlinks (or .cmd shims on Windows) for package executables.",
+        },
+        {
+          name: ["--no-fund"],
+          description:
+            "Hides the message at the end of each npm install acknowledging the number of dependencies looking for funding.",
+        },
+        {
+          name: ["--dry-run"],
+          description:
+            "Indicates that you don't want npm to make any changes and that it should only report what it would have done.",
+        },
+        {
+          name: ["-wl--workspace"],
+          description:
+            "Enable running a command in the context of the configured workspaces of the current project",
+          args: {
+            name: "workspace",
+            generators: workspaceGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-wsl--workspaces"],
+          description:
+            "Enable running a command in the context of all the configured workspaces.",
+        },
+      ],
     },
     { name: "v", description: "check that you have node and npm installed" },
     { name: "version", description: "bump a package version" },
-    { name: "view", description: "view registry info" },
+    {
+      name: "view",
+      description: "view registry info",
+      options: [
+        {
+          name: ["-wl--workspace"],
+          description:
+            "Enable running a command in the context of the configured workspaces of the current project",
+          args: {
+            name: "workspace",
+            generators: workspaceGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-wsl--workspaces"],
+          description:
+            "Enable running a command in the context of all the configured workspaces.",
+        },
+        { name: "--json", description: "show output in json format" },
+      ],
+    },
     { name: "whoami", description: "display npm username" },
   ],
 };

--- a/dev/npm.ts
+++ b/dev/npm.ts
@@ -673,7 +673,51 @@ const completionSpec: Fig.Spec = {
         },
       ],
     },
-    { name: "publish", description: "publish a package" },
+    {
+      name: "publish",
+      description: "publish a package",
+      options: [
+        {
+          name: "--tag",
+          description: "Registers the published package with the given tag",
+          args: { name: "tag" },
+        },
+        {
+          name: ["-wl--workspace"],
+          description:
+            "Enable running a command in the context of the configured workspaces of the current project",
+          args: {
+            name: "workspace",
+            generators: workspaceGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-wsl--workspaces"],
+          description:
+            "Enable running a command in the context of all the configured workspaces.",
+        },
+        {
+          name: "--access",
+          description:
+            "Sets scoped package to be publicly viewable if set to 'public'",
+          args: {
+            default: "restricted",
+            suggestions: ["restricted", "public"],
+          },
+        },
+        {
+          name: ["--dry-run"],
+          description:
+            "Indicates that you don't want npm to make any changes and that it should only report what it would have done.",
+        },
+        {
+          name: "--otp",
+          description: "one-time password from a two-factor authenticator",
+          args: { name: "otp" },
+        },
+      ],
+    },
     { name: "rb", description: "rebuild a package" },
     { name: "rebuild", description: "rebuild a package" },
     {
@@ -725,12 +769,40 @@ const completionSpec: Fig.Spec = {
       ],
     },
     { name: "stop", description: "stop a package" },
-    { name: "t", description: "test a package" },
+    {
+      name: "t",
+      description: "test a package",
+      options: [
+        {
+          name: ["--ignore-scripts"],
+          description:
+            "If true, npm does not run scripts specified in package.json files.",
+        },
+        {
+          name: "--script-shell",
+          args: { name: "shell" },
+        },
+      ],
+    },
     {
       name: "team",
       description: "manage organization teams and team memberships",
     },
-    { name: "test", description: "test a package" },
+    {
+      name: "test",
+      description: "test a package",
+      options: [
+        {
+          name: ["--ignore-scripts"],
+          description:
+            "If true, npm does not run scripts specified in package.json files.",
+        },
+        {
+          name: "--script-shell",
+          args: { name: "shell" },
+        },
+      ],
+    },
     { name: "token", description: "manage your authentication tokens" },
     { name: "tst", description: "test a package" },
     {
@@ -873,7 +945,28 @@ const completionSpec: Fig.Spec = {
       ],
     },
     { name: "v", description: "check that you have node and npm installed" },
-    { name: "version", description: "bump a package version" },
+    {
+      name: "version",
+      description: "bump a package version",
+      options: [
+        {
+          name: ["-wl--workspace"],
+          description:
+            "Enable running a command in the context of the configured workspaces of the current project",
+          args: {
+            name: "workspace",
+            generators: workspaceGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-wsl--workspaces"],
+          description:
+            "Enable running a command in the context of all the configured workspaces.",
+        },
+        { name: "--json", description: "show output in json format" },
+      ],
+    },
     {
       name: "view",
       description: "view registry info",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adding to the npm spec
**What is the current behavior? (You can also link to an open issue here)**

- [x]  Npm install (added several missing options + generator)
- [x]  Npm uninstall (added missing options + generator)
- [x]  npm config (added missing subcommands, options, and args)
- [x]  -g flag (added to multiple subcommands)
- [x]  npm list (added missing options and args)
- [x]  npm outdated (added missing options)
- [x]  npm update (added missing options + generator)
- [x]  npm run (added missing options)
- [x]  npm deprecate (added missing options)
- [x]  npm init (-y & -w option w/ their args)
- [x]  npm start (added options)
- [x]  npm prune (added options)
- [x]  npm cache (add subcommand + option)
- [x]  npm view (added options)
- [x]  npm audit
- [x]  npm explore & edit (add generator)
- [x]  Add packages generator for npm repo
- [x]  npm test (added options)
- [x]  npm publish (added options)