### PR TITLE
[mv] Fixed 1st arg and options

### DIFF
--- a/dev/afplay.ts
+++ b/dev/afplay.ts
@@ -21,7 +21,7 @@ const completionSpec: Fig.Spec = {
       description: "print help",
     },
     {
-      name: ["--leaks"],
+      name: "--leaks",
       description: "Run leaks analysis.",
     },
     {

--- a/dev/mv.ts
+++ b/dev/mv.ts
@@ -3,20 +3,36 @@ const completionSpec: Fig.Spec = {
   description: "move & rename files and folders",
   args: [
     {
+      name: "source",
+      isVariadic: true,
       template: ["filepaths", "folders"],
     },
     {
+      name: "target",
       template: ["filepaths", "folders"],
     },
   ],
   options: [
     {
-      name: "-R",
-      description: "recursive",
+      name: "-f",
+      description:
+        "Do not prompt for confirmation before overwriting the destination path",
+      exclusiveOn: ["-i", "-n"],
     },
     {
-      name: "-P",
-      description: "Don't follow symbolic links",
+      name: "-i",
+      description:
+        "Cause mv to write a prompt to standard error before moving a file that would overwrite an existing file",
+      exclusiveOn: ["-f", "-n"],
+    },
+    {
+      name: "-n",
+      description: "Do not overwrite existing file",
+      exclusiveOn: ["-f", "-i"],
+    },
+    {
+      name: "-v",
+      description: "Cause mv to be verbose, showing files after they are moved",
     },
   ],
 };


### PR DESCRIPTION
-R and -P are not options on mv so they were removed and replaced with -f, -i, -n, and -v

First arg should also be variadic