### PR TITLE
[npm] changes to dependencies gen and npm uninstall

### DIFF
--- a/dev/npm.ts
+++ b/dev/npm.ts
@@ -50,7 +50,8 @@ const workspaceGenerator: Fig.Generator = {
 };
 
 const dependenciesGenerator: Fig.Generator = {
-  script: "cat package.json",
+  script:
+    "until [[ -f package.json ]] || [[ $PWD = '/' ]]; do cd ..; done; cat package.json",
   postProcess: function (out, context) {
     if (out.trim() === "") {
       return [];
@@ -723,7 +724,47 @@ const completionSpec: Fig.Spec = {
     { name: "token", description: "manage your authentication tokens" },
     { name: "tst", description: "test a package" },
     {
-      name: ["uninstall", "remove", "rm", "r", "unlink", "un"],
+      name: "uninstall",
+      description: "uninstall a package",
+      args: {
+        name: "package",
+        generators: dependenciesGenerator,
+        isVariadic: true,
+      },
+      options: npmInstallOptions,
+    },
+    {
+      name: "remove",
+      description: "uninstall a package",
+      args: {
+        name: "package",
+        generators: dependenciesGenerator,
+        isVariadic: true,
+      },
+      options: npmInstallOptions,
+    },
+    {
+      name: ["r", "rm"],
+      description: "uninstall a package",
+      args: {
+        name: "package",
+        generators: dependenciesGenerator,
+        isVariadic: true,
+      },
+      options: npmInstallOptions,
+    },
+    {
+      name: "un",
+      description: "uninstall a package",
+      args: {
+        name: "package",
+        generators: dependenciesGenerator,
+        isVariadic: true,
+      },
+      options: npmInstallOptions,
+    },
+    {
+      name: "unlink",
       description: "uninstall a package",
       args: {
         name: "package",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature

**What is the current behavior? (You can also link to an open issue here)**
- Npm uninstall has too many acronyms that provides suboptimal user experience
- Package.json doesn't check top level folders if user is running a command from within a nested folder

**What is the new behavior (if this is a feature change)?**
- Breaking up npm uninstall for better UX
- Change script of dependencies generator taken from Brendan's previous PR