### PR TITLE
fix: `filterTemplateSuggestion` should not pass an array of suggestion `name` props

### DIFF
--- a/dev/flutter.ts
+++ b/dev/flutter.ts
@@ -21,9 +21,7 @@ const flutterGenerators: Record<string, Fig.Generator> = {
     filterTemplateSuggestions: function (suggestions) {
       return suggestions.filter(
         (suggestion) =>
-          suggestion.type === "folder" ||
-          (typeof suggestion.name === "string" &&
-            suggestion.name.endsWith(".dart"))
+          suggestion.type === "folder" || suggestion.name.endsWith(".dart")
       );
     },
   },

--- a/dev/node.ts
+++ b/dev/node.ts
@@ -9,14 +9,10 @@ const completionSpec: Fig.Spec = {
       filterTemplateSuggestions: function (paths) {
         return paths
           .filter((file) => {
-            if (typeof file.name === "string") {
-              return file.name.match(/.*\.m?js/g) || file.name.endsWith("/");
-            }
-            return false;
+            return file.name.match(/.*\.m?js/g) || file.name.endsWith("/");
           })
           .map((file) => {
-            const isJsFile =
-              typeof file.name === "string" && file.name.match(/.*\.m?js/g);
+            const isJsFile = file.name.match(/.*\.m?js/g);
 
             return {
               ...file,

--- a/dev/pandoc.ts
+++ b/dev/pandoc.ts
@@ -32,10 +32,7 @@ const pandocGenerators: Record<string, Fig.Generator> = {
     filterTemplateSuggestions: function (paths) {
       const suffix = ".yaml";
       return paths.filter((file) => {
-        if (typeof file.name === "string") {
-          return file.name.endsWith(suffix);
-        }
-        return false;
+        return file.name.endsWith(suffix);
       });
     },
   },
@@ -43,10 +40,7 @@ const pandocGenerators: Record<string, Fig.Generator> = {
     template: "filepaths",
     filterTemplateSuggestions: function (paths) {
       return paths.filter((file) => {
-        if (typeof file.name === "string") {
-          return file.name.endsWith(".yaml") || file.name.endsWith(".json");
-        }
-        return false;
+        return file.name.endsWith(".yaml") || file.name.endsWith(".json");
       });
     },
   },

--- a/dev/pm2.ts
+++ b/dev/pm2.ts
@@ -4,10 +4,7 @@ const generators: Record<string, Fig.Generator> = {
     filterTemplateSuggestions: function (paths) {
       const suffix = ".json";
       return paths.filter((file) => {
-        if (typeof file.name === "string") {
-          return file.name.endsWith(suffix);
-        }
-        return false;
+        return file.name.endsWith(suffix);
       });
     },
   },

--- a/dev/python.ts
+++ b/dev/python.ts
@@ -22,14 +22,10 @@ const completionSpec: Fig.Spec = {
       filterTemplateSuggestions: function (paths) {
         return paths
           .filter((file) => {
-            if (typeof file.name === "string") {
-              return file.name.endsWith(".py") || file.name.endsWith("/");
-            }
-            return false;
+            return file.name.endsWith(".py") || file.name.endsWith("/");
           })
           .map((file) => {
-            const isPyFile =
-              typeof file.name === "string" && file.name.endsWith(".js");
+            const isPyFile = file.name.endsWith(".py");
 
             return {
               ...file,

--- a/dev/python3.ts
+++ b/dev/python3.ts
@@ -22,14 +22,10 @@ const completionSpec: Fig.Spec = {
       filterTemplateSuggestions: function (paths) {
         return paths
           .filter((file) => {
-            if (typeof file.name === "string") {
-              return file.name.endsWith(".py") || file.name.endsWith("/");
-            }
-            return false;
+            return file.name.endsWith(".py") || file.name.endsWith("/");
           })
           .map((file) => {
-            const isPyFile =
-              typeof file.name === "string" && file.name.endsWith(".js");
+            const isPyFile = file.name.endsWith(".py");
 
             return {
               ...file,

--- a/dev/shortcuts.ts
+++ b/dev/shortcuts.ts
@@ -125,8 +125,7 @@ const subcommands: Fig.Subcommand[] = [
               suggestions.filter(
                 (suggestion) =>
                   suggestion.type === "folder" ||
-                  (typeof suggestion.name === "string" &&
-                    suggestion.name.endsWith(".shortcut"))
+                  suggestion.name.endsWith(".shortcut")
               ),
           },
         },

--- a/dev/tsc.ts
+++ b/dev/tsc.ts
@@ -723,14 +723,10 @@ const completionSpec: Fig.Spec = {
       filterTemplateSuggestions: function (paths) {
         return paths
           .filter((file) => {
-            if (typeof file.name === "string") {
-              return file.name.endsWith(".ts") || file.name.endsWith("/");
-            }
-            return false;
+            return file.name.endsWith(".ts") || file.name.endsWith("/");
           })
           .map((file) => {
-            const isTsFile =
-              typeof file.name === "string" && file.name.endsWith(".ts");
+            const isTsFile = file.name.endsWith(".ts");
             return {
               ...file,
               priority: isTsFile ? 76 : 70,

--- a/schemas/fig.d.ts
+++ b/schemas/fig.d.ts
@@ -22,6 +22,9 @@ declare namespace Fig {
   // set to void by default
   export type Function<T = void, R = void> = (param?: T) => R;
 
+  // A utility type to modify a property type
+  export type Modify<T, R> = Omit<T, keyof R> & R;
+
   // A string or a function which can have a T argument and a R result,
   // both set to void by default
   export type StringOrFunction<T = void, R = void> = string | Function<T, R>;
@@ -412,7 +415,10 @@ declare namespace Fig {
      * @example
      * The python spec has an arg object which has a template for "filepaths" and then filters out all suggestions generated that don't end with "/" (to keep folders) or ".py" (to keep python files)
      */
-    filterTemplateSuggestions?: Function<Suggestion[], Suggestion[]>;
+    filterTemplateSuggestions?: Function<
+      Modify<Suggestion, { name?: string }>[],
+      Suggestion[]
+    >;
     /**
      * In order to generate contextual suggestions for arguments, Fig lets you execute a shell command on the users local device as if it were done in their current working directory.
      * You can either specify


### PR DESCRIPTION
As outlined in https://github.com/withfig/autocomplete/pull/505#discussion_r693496425 It is impossible that `filterTemplateSuggestion` function ever returns more than one string in `name`, so we simplify development by updating `.d.ts`