### PR TITLE
Pathspec arg can be a dir

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -1454,7 +1454,7 @@ const completionSpec: Fig.Spec = {
         //         icon: "fig://icon?type=folder"
         //     }
         // ],
-        generators: gitGenerators.files_for_staging,
+        generators: [gitGenerators.files_for_staging, { template: "folders" }],
       },
     },
     {


### PR DESCRIPTION
man git-add:
<pathspec>
...Also a leading directory name (e.g.  dir to add dir/file1 and dir/file2) can be given to update the index to match the current state of the directory as a whole (e.g. specifying dir will record not just a file dir/file1 modified in the working tree, a file dir/file2 added to the working tree, but also a file dir/file3 removed from the working tree)...