### PR TITLE
[git] remove insertValue from clone --recurse-submodules

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -3400,7 +3400,6 @@ const completionSpec: Fig.Spec = {
           name: "--recurse-submodules",
           description:
             "After the clone is created, initialize and clone submodules within based on the provided pathspec. If no pathspec is provided, all submodules are initialized and cloned. This option can be given multiple times for pathspecs consisting of multiple entries",
-          insertValue: "--recurse-submodules=",
           args: {
             isOptional: true,
             name: "pathspec",


### PR DESCRIPTION
The argument for `git clone --recurse-submodules` is optional but the insertValue of "--recurse-submodules=" made it appear mandatory.

Users would need to backspace the '=' after entering the suggestion or believed that the arg was mandatory.