### PR TITLE
[pwd] redo per BSD spec

### DIFF
--- a/dev/pwd.ts
+++ b/dev/pwd.ts
@@ -1,16 +1,14 @@
 const completionSpec: Fig.Spec = {
   name: "pwd",
-  description: "Print name of current/working directory",
+  description: "Return working directory name",
   options: [
     {
-      name: ["-L", "--logical"],
-      description: "Use PWD from environment, even if it contains symlinks",
+      name: "-L",
+      description: "Display the logical current working directory",
     },
-    { name: ["-P", "--physical"], description: "Avoid all symlinks" },
-    { name: "--help", description: "Display this help and exit" },
     {
-      name: "--version",
-      description: "Output version information and exit",
+      name: "-P",
+      description: "Display the physical current working directory",
     },
   ],
 };


### PR DESCRIPTION
pwd spec was written according to GNU spec so there were some incorrect options.

Re-wrote according to the BSD version (`man pwd` on macOS).