### PR TITLE
[git] stash pop arg fix

### DIFF
--- a/dev/git.ts
+++ b/dev/git.ts
@@ -3083,7 +3083,6 @@ const completionSpec: Fig.Spec = {
         {
           name: "pop",
           description: "Restores the most recently stashed files",
-          insertValue: "pop {cursor}",
           options: [
             {
               name: "--index",


### PR DESCRIPTION
git stash pop takes an optional arg. However the spec had an insertValue of 'pop {cursor}' which made it seem as if the arg was mandatory.

This makes it so completing on pop will not add a space or make fig popup again.