### PR TITLE
feat: add completion spec for kubecolor

### DIFF
--- a/dev/kubecolor.ts
+++ b/dev/kubecolor.ts
@@ -1,0 +1,2 @@
+// Kubecolor (https://github.com/dty1er/kubecolor) takes identical arguments to kubectl.
+export { default } from "./kubectl";


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds support for [kubecolor](https://github.com/dty1er/kubecolor), a tool which colorizes kubectl output. It takes identical arguments to kubectl as under the hood it just invokes kubectl and reformats the output.

**What is the current behavior? (You can also link to an open issue here)**

No completions are given for kubecolor or kubectl when kubecolor is used (assuming it is aliased to kubectl).

**What is the new behavior (if this is a feature change)?**

Support completions for both `kubecolor` and an alias from `kubectl` to `kubecolor`.

<img width="1275" alt="Screenshot 2021-09-03 at 02 30 23" src="https://user-images.githubusercontent.com/20439493/131936980-a9388a11-5de5-47df-ab41-25054b4a49fb.png">

**Additional info:**

This PR just re-exports the completions from kubectl as kubecolor.