### PR TITLE
feat(deno): add generator for doc filters

### DIFF
--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -768,24 +768,17 @@ const denoDoc: Fig.Subcommand = {
           // The names are added to a set because duplicates are common.
           const names = new Set<string>();
 
-          // More nodes should be visible if --private was used. This is two
-          // separate loops because the logic is fundamentally different - one
-          // loop just adds all the nodes, while the other is a filter. It also
-          // avoids checking showPrivateSymbols in each iteration, since that
-          // value won't change.
-          if (showPrivateSymbols) {
-            for (const node of suggestNodes) {
+          // More nodes should be visible if --private was used.
+          for (const node of suggestNodes) {
+            if (showPrivateSymbols) {
               names.add(node.name);
+              continue;
             }
-          } else {
-            for (const node of suggestNodes) {
-              // Deno includes imports in the JSON regardless of privacy,
-              // probably so it's easier to build a module graph. However,
-              // imports are (by definition) private, so they must be removed.
-              if (node.kind === "import") continue;
-
-              names.add(node.name);
-            }
+            // Deno includes imports in the JSON regardless of privacy,
+            // probably so it's easier to build a module graph. However,
+            // imports are (by definition) private, so they must be removed.
+            if (node.kind === "import") continue;
+            names.add(node.name);
           }
 
           // Deno uses the name <TODO> when it gets confused, which is common in

--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -581,11 +581,36 @@ const denoLint: Fig.Subcommand = {
   ],
 };
 
-// The following region was adapted from denoland/deno_doc:
-// https://github.com/denoland/deno_doc/blob/main/lib/types.d.ts
-// It is not stripped further to make updating it easier.
-
 //#region Documentation types
+
+type Named = { name: string };
+type Kind<T = string> = { kind: T };
+
+type DocNodeFunction = Named & Kind<"function">;
+type DocNodeVariable = Named & Kind<"variable">;
+type DocNodeEnum = Named & Kind<"enum">;
+type DocNodeClass = Named &
+  Kind<"class"> & {
+    classDef: {
+      properties: Named[];
+      methods: (Named & Kind)[];
+    };
+  };
+type DocNodeTypeAlias = Named & Kind<"typeAlias">;
+type DocNodeNamespace = Named &
+  Kind<"namespace"> & {
+    namespaceDef: {
+      elements: DocNode[];
+    };
+  };
+type DocNodeInterface = Named &
+  Kind<"interface"> & {
+    interfaceDef: {
+      properties: Named[];
+      methods: (Named & Kind)[];
+    };
+  };
+type DocNodeImport = Named & Kind<"import">;
 
 type DocNode =
   | DocNodeFunction
@@ -596,95 +621,6 @@ type DocNode =
   | DocNodeNamespace
   | DocNodeInterface
   | DocNodeImport;
-
-interface DocNodeBase {
-  kind: DocNodeKind;
-  name: string;
-}
-
-type DocNodeKind =
-  | "function"
-  | "variable"
-  | "enum"
-  | "class"
-  | "typeAlias"
-  | "namespace"
-  | "interface"
-  | "import";
-
-interface DocNodeFunction extends DocNodeBase {
-  kind: "function";
-}
-
-interface DocNodeVariable extends DocNodeBase {
-  kind: "variable";
-}
-
-interface DocNodeEnum extends DocNodeBase {
-  kind: "enum";
-  enumDef: EnumDef;
-}
-
-interface DocNodeClass extends DocNodeBase {
-  kind: "class";
-  classDef: ClassDef;
-}
-
-interface DocNodeTypeAlias extends DocNodeBase {
-  kind: "typeAlias";
-}
-
-interface DocNodeNamespace extends DocNodeBase {
-  kind: "namespace";
-  namespaceDef: NamespaceDef;
-}
-
-interface DocNodeInterface extends DocNodeBase {
-  kind: "interface";
-  interfaceDef: InterfaceDef;
-}
-
-interface DocNodeImport extends DocNodeBase {
-  kind: "import";
-}
-
-interface ClassDef {
-  properties: ClassPropertyDef[];
-  methods: ClassMethodDef[];
-}
-
-interface ClassMethodDef {
-  name: string;
-}
-
-interface ClassPropertyDef {
-  name: string;
-}
-
-interface EnumDef {
-  members: EnumMemberDef[];
-}
-
-interface EnumMemberDef {
-  name: string;
-}
-
-interface InterfaceDef {
-  methods: InterfaceMethodDef[];
-  properties: InterfacePropertyDef[];
-}
-
-interface InterfaceMethodDef {
-  name: string;
-}
-
-interface InterfacePropertyDef {
-  name: string;
-}
-
-interface NamespaceDef {
-  elements: DocNode[];
-}
 
 //#endregion
 

--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -1117,10 +1117,12 @@ const completionSpec: Fig.Spec = {
     {
       name: "--version",
       description: "Prints version information, including TypeScript and V8",
+      exclusiveOn: ["-V"],
     },
     {
       name: "-V",
       description: "Prints Deno's version",
+      exclusiveOn: ["--version"],
       priority: 25,
     },
   ],

--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -583,8 +583,14 @@ const denoLint: Fig.Subcommand = {
 
 //#region Documentation types
 
+// Everything has a name. Some things have a kind, but only a subset of those
+// have a kind that actually matters (hence the default of `string`)
 type Named = { name: string };
-type Kind<T = string> = { kind: T };
+type Kind<T extends string = string> = { kind: T };
+
+// Type aliases to make records clearer
+type DocProperty = Named;
+type DocMethod = Named & Kind;
 
 type DocNodeFunction = Named & Kind<"function">;
 type DocNodeVariable = Named & Kind<"variable">;
@@ -592,8 +598,8 @@ type DocNodeEnum = Named & Kind<"enum">;
 type DocNodeClass = Named &
   Kind<"class"> & {
     classDef: {
-      properties: Named[];
-      methods: (Named & Kind)[];
+      properties: DocProperty[];
+      methods: DocMethod[];
     };
   };
 type DocNodeTypeAlias = Named & Kind<"typeAlias">;
@@ -606,8 +612,8 @@ type DocNodeNamespace = Named &
 type DocNodeInterface = Named &
   Kind<"interface"> & {
     interfaceDef: {
-      properties: Named[];
-      methods: (Named & Kind)[];
+      properties: DocProperty[];
+      methods: DocMethod[];
     };
   };
 type DocNodeImport = Named & Kind<"import">;
@@ -621,6 +627,12 @@ type DocNode =
   | DocNodeNamespace
   | DocNodeInterface
   | DocNodeImport;
+
+/** Any node is assignable to this type. */
+type AnyNode = {
+  name: string;
+  kind?: string;
+};
 
 //#endregion
 
@@ -731,7 +743,7 @@ const denoDoc: Fig.Subcommand = {
           // Based on whether the user has typed a period, this will be
           // populated with either the top level nodes or the children of
           // whatever node the user has searched for.
-          const suggestNodes: (Named & Partial<Kind>)[] = [];
+          const suggestNodes: AnyNode[] = [];
 
           if (firstDotIndex === -1) {
             suggestNodes.push(...docNodes);

--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -69,6 +69,11 @@ function generateFilepathsMatch(init: {
   };
 }
 
+type VersionsJSON = {
+  latest: string;
+  versions: string[];
+};
+
 /**
  * Generates a list of Deno versions and caches that list for one day.
  */
@@ -77,8 +82,11 @@ const generateDenoVersions: Fig.Generator = {
   cache: { ttl: 1000 * 60 * 60 * 24 },
   postProcess: (out) => {
     try {
-      const data = JSON.parse(out);
-      return (data.versions as string[]).map((version) => ({
+      const data: VersionsJSON = JSON.parse(out);
+      // Using a regex instead of a slice because it's more resilient, even
+      // though it's marginally slower. The versions are currently tagged with
+      // a leading 'v', but that may not always be the case.
+      return data.versions.map((version) => ({
         name: version.replace(/^v/, ""),
       }));
     } catch (e) {

--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -7,8 +7,7 @@
 const CPU_ICON =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAVNSURBVHgBrVdLbxtVFP7unTt+pHaah/qigEIVUFsF1ZRHC9k4QkhtF8hIbOim6j/ooixaNpUQ6qKbbqqyq9iUBUKUTUAC1YkURLIg8SJBlSJEiojapE3iJI4f8+ScO5nUSTxxHnzS9YztM+f77rnnnjlXoAE+vZXJKtO8JJTI0tcuIQAe/ur/AtHwN974KHiOX7Ad+8fvrxYebLRf5yt3M9MVT6p7ZsLIGqaEVIKIacg69nVU4sVVYL1C3w++0pUEwKl5sCrOlFVz+x5cK0xtEpD76t1MMoV8LKXaVExqUk0eMXMfmyPhN7DhD5/FeIGI6opd9EpO33dfFAprPvXME2os0WoSuQFpCLiWj6d/1PBs3EJt0cNu0HLQwD4aRz9IIN4q4bk++XVRXrKL1qLz1oMbhSnFhoYU+ViLajOU1OTPJyw8zlfgVH3sBeVZV4/5SRsvk4jDb8fg09LGiYuW5R6Z9Incl5lcolX9kEib4NDPFGw8fljRDkrLK5h9MoNKpQrXdbFTpFL70N7Zrgfj2PkWdJ5QFAVaiiUb1WWnTwlD5AzT0GtuLfmY/q2qjWeIOKbiuH//W/T09GD//v3YKfr7+3H9+nXt69CRQ3pi7cfSIE4YvNTSuSSlgVNSBsn27+9VShQfC3MLmnxwcBC9vb27ImdcuHBB+2BfpdIKXPL9dLSmuYRBBlJkFWVpBjJ4oDIbJBsLuHv3a008OTmJkZERWJaFnSCVSuH06dPo7u7GnTt3cPHiZ0i9cYzyy8aR92LhDutS4RZmrDwL1pnVsnrG2NiYXoKOjg4kk0kopfTDG8FbjeE4DuVMBXNzcxgeHtYC+HnOI0ZtKZikdkEfKvgWPZNSqYR0Oq3JtxIQirBtW185AmHUOJJRSaywDZimqYl5xGKxhjYsyvOC2XEU+JmtsBowFtCozG52LqXUI1g7serEX3ffyCbCI8K/ZVP2yBn460g2Em4t4AWnRH0WRqCRM/4tTLwogdvBniLQ6D5EsyUIsa0kbEaw1baM8Lh2JwNj7Akhmb8LRzoCQjQn4MHbLIqkXkQ4msMPBDSz5X3NBYbrAMMwjDWC+vCHhYjtm7499eNcCbchtFqtrpFzgWlWCcvlsi7HTfnJXumJ+FtHgctx6DwsxeE2rBfDS8SzZ8EsIpJ8lZOH4l5Nh7NOAId4cXFR13AuvQsLC7qux+PxtUhEZT6HngWwaH4fRCkIeLUA6F6Nf+C+jd9WyWQC4+Pjuhc4e/YsRkdHMT09jZ2AhZ85c0bfc2MSikkekJqY+ZhXfHzj1N8t7WZXLKkwM2bjyYilX8dO1cHAwMCum5EQHMlsNgtPevRKb6eWzMQr2RissotK0SpI1/EHuV12HQ8H3jRhxIXu5Wp2TT/I6ndLPDQ0pH2wLyZn34ffMeHZ3KK7dF5AQZy72pONtxp5asmh4rT2f7n452FNO5mfX0DxeVGv507BecT9w8EjB5FK79O/He2NofOkgk3k3JRaJe8TnUnnr/Xkk61m1qRl4M54bsLBzKite7j/Azzzl9430dYddMRWmbqmZWvqp5sTrwWFqOJctiTG6LbN9yTajxtofZVa9FEynKcWem53BxMzLdHxuoHOHqWbULvq6tDXyk7R990+tlnbSx99fjJjmjJPydhmUBT4kMIPidWOOazXYhvE+lS4WluCbKedRjmmZ191i7bl9v1y68/CJn/nrhzvopNLnnKhi5dCGnxGDKzEdpjrRYQFjgRQosO1PR4DqLmXf779aCq0a+j2wysnchSBHPGf8oXISIkdof5QSh9TdBkg8m9+vf1oYKPtf7NIvBdpvFmHAAAAAElFTkSuQmCC";
 
-const VERSIONS_URL =
-  "https://raw.githubusercontent.com/denoland/deno_website2/main/versions.json";
+const VERSIONS_URL = "https://cdn.deno.land/deno/meta/versions.json";
 
 /**
  * Equivalent to the `"filepaths"` template, but boosts the priority of files
@@ -72,14 +71,12 @@ function generateFilepathsMatch(init: {
  * Generates a list of Deno versions and caches that list for one day.
  */
 const generateDenoVersions: Fig.Generator = {
-  script: `curl -s '${VERSIONS_URL}'`,
+  script: `curl -sL '${VERSIONS_URL}'`,
   cache: { ttl: 1000 * 60 * 60 * 24 },
   postProcess: (out) => {
     try {
-      const versions = JSON.parse(out);
-      return (versions.cli as string[]).map((version) => ({
-        // Currently, the JSON does have a leading 'v', but that may not always
-        // be the case. Removing a leading 'v' instead of slicing is resilient.
+      const data = JSON.parse(out);
+      return (data.versions as string[]).map((version) => ({
         name: version.replace(/^v/, ""),
       }));
     } catch (e) {

--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -581,6 +581,113 @@ const denoLint: Fig.Subcommand = {
   ],
 };
 
+// The following region was adapted from denoland/deno_doc:
+// https://github.com/denoland/deno_doc/blob/main/lib/types.d.ts
+// It is not stripped further to make updating it easier.
+
+//#region Documentation types
+
+type DocNode =
+  | DocNodeFunction
+  | DocNodeVariable
+  | DocNodeEnum
+  | DocNodeClass
+  | DocNodeTypeAlias
+  | DocNodeNamespace
+  | DocNodeInterface
+  | DocNodeImport;
+
+interface DocNodeBase {
+  kind: DocNodeKind;
+  name: string;
+}
+
+type DocNodeKind =
+  | "function"
+  | "variable"
+  | "enum"
+  | "class"
+  | "typeAlias"
+  | "namespace"
+  | "interface"
+  | "import";
+
+interface DocNodeFunction extends DocNodeBase {
+  kind: "function";
+}
+
+interface DocNodeVariable extends DocNodeBase {
+  kind: "variable";
+}
+
+interface DocNodeEnum extends DocNodeBase {
+  kind: "enum";
+  enumDef: EnumDef;
+}
+
+interface DocNodeClass extends DocNodeBase {
+  kind: "class";
+  classDef: ClassDef;
+}
+
+interface DocNodeTypeAlias extends DocNodeBase {
+  kind: "typeAlias";
+}
+
+interface DocNodeNamespace extends DocNodeBase {
+  kind: "namespace";
+  namespaceDef: NamespaceDef;
+}
+
+interface DocNodeInterface extends DocNodeBase {
+  kind: "interface";
+  interfaceDef: InterfaceDef;
+}
+
+interface DocNodeImport extends DocNodeBase {
+  kind: "import";
+}
+
+interface ClassDef {
+  properties: ClassPropertyDef[];
+  methods: ClassMethodDef[];
+}
+
+interface ClassMethodDef {
+  name: string;
+}
+
+interface ClassPropertyDef {
+  name: string;
+}
+
+interface EnumDef {
+  members: EnumMemberDef[];
+}
+
+interface EnumMemberDef {
+  name: string;
+}
+
+interface InterfaceDef {
+  methods: InterfaceMethodDef[];
+  properties: InterfacePropertyDef[];
+}
+
+interface InterfaceMethodDef {
+  name: string;
+}
+
+interface InterfacePropertyDef {
+  name: string;
+}
+
+interface NamespaceDef {
+  elements: DocNode[];
+}
+
+//#endregion
+
 function getNamePriority(name: string): number {
   if (/^[A-Z]/.test(name)) {
     return 60;
@@ -665,7 +772,7 @@ const denoDoc: Fig.Subcommand = {
           // The output for `deno doc --json` is `DocNode[]` - the types:
           // https://github.com/denoland/deno_doc/blob/dbf9e21/lib/types.d.ts
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let docNodes: any[];
+          let docNodes: DocNode[];
           try {
             docNodes = JSON.parse(out);
             if (!Array.isArray(docNodes)) {

--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -642,16 +642,19 @@ const denoDoc: Fig.Subcommand = {
         // The output for `deno doc --json` is `DocNode[]` - the types:
         // https://github.com/denoland/deno_doc/blob/dbf9e21/lib/types.d.ts
         postProcess: (out, tokens) => {
-          let nodes;
+          let allNodes;
           try {
-            nodes = JSON.parse(out);
-            if (!Array.isArray(nodes)) {
+            allNodes = JSON.parse(out);
+            if (!Array.isArray(allNodes)) {
               throw new Error(`Output data was JSON, but was not an array`);
             }
           } catch (err) {
             console.error("Returning early due to error:", err);
             return [];
           }
+
+          // Imports won't show in deno doc, these should never be suggested.
+          const nodes = allNodes.filter((node) => node.kind !== "import");
 
           // The final token has to be the filter, it's the only way this
           // generator could have been invoked.
@@ -695,6 +698,8 @@ const denoDoc: Fig.Subcommand = {
               );
             }
           }
+          // This array doesn't need to be filtered for imports because, at
+          // least as far as I know, they can only appear at the top level.
           const childNames = childNodes.map((node) => node.name);
           const uniqueNames = new Set(childNames);
           for (const name of uniqueNames) {

--- a/dev/deno.ts
+++ b/dev/deno.ts
@@ -4,6 +4,8 @@
 // All objects marked with '// requiresEquals: true' are Clap args with '.require_equals(true)'
 // TODO: When fig supports this option (or something like it), uncomment the arguments.
 
+const STRING_ICON = "fig://icon?type=string";
+
 const CPU_ICON =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAVNSURBVHgBrVdLbxtVFP7unTt+pHaah/qigEIVUFsF1ZRHC9k4QkhtF8hIbOim6j/ooixaNpUQ6qKbbqqyq9iUBUKUTUAC1YkURLIg8SJBlSJEiojapE3iJI4f8+ScO5nUSTxxHnzS9YztM+f77rnnnjlXoAE+vZXJKtO8JJTI0tcuIQAe/ur/AtHwN974KHiOX7Ad+8fvrxYebLRf5yt3M9MVT6p7ZsLIGqaEVIKIacg69nVU4sVVYL1C3w++0pUEwKl5sCrOlFVz+x5cK0xtEpD76t1MMoV8LKXaVExqUk0eMXMfmyPhN7DhD5/FeIGI6opd9EpO33dfFAprPvXME2os0WoSuQFpCLiWj6d/1PBs3EJt0cNu0HLQwD4aRz9IIN4q4bk++XVRXrKL1qLz1oMbhSnFhoYU+ViLajOU1OTPJyw8zlfgVH3sBeVZV4/5SRsvk4jDb8fg09LGiYuW5R6Z9Incl5lcolX9kEib4NDPFGw8fljRDkrLK5h9MoNKpQrXdbFTpFL70N7Zrgfj2PkWdJ5QFAVaiiUb1WWnTwlD5AzT0GtuLfmY/q2qjWeIOKbiuH//W/T09GD//v3YKfr7+3H9+nXt69CRQ3pi7cfSIE4YvNTSuSSlgVNSBsn27+9VShQfC3MLmnxwcBC9vb27ImdcuHBB+2BfpdIKXPL9dLSmuYRBBlJkFWVpBjJ4oDIbJBsLuHv3a008OTmJkZERWJaFnSCVSuH06dPo7u7GnTt3cPHiZ0i9cYzyy8aR92LhDutS4RZmrDwL1pnVsnrG2NiYXoKOjg4kk0kopfTDG8FbjeE4DuVMBXNzcxgeHtYC+HnOI0ZtKZikdkEfKvgWPZNSqYR0Oq3JtxIQirBtW185AmHUOJJRSaywDZimqYl5xGKxhjYsyvOC2XEU+JmtsBowFtCozG52LqXUI1g7serEX3ffyCbCI8K/ZVP2yBn460g2Em4t4AWnRH0WRqCRM/4tTLwogdvBniLQ6D5EsyUIsa0kbEaw1baM8Lh2JwNj7Akhmb8LRzoCQjQn4MHbLIqkXkQ4msMPBDSz5X3NBYbrAMMwjDWC+vCHhYjtm7499eNcCbchtFqtrpFzgWlWCcvlsi7HTfnJXumJ+FtHgctx6DwsxeE2rBfDS8SzZ8EsIpJ8lZOH4l5Nh7NOAId4cXFR13AuvQsLC7qux+PxtUhEZT6HngWwaH4fRCkIeLUA6F6Nf+C+jd9WyWQC4+Pjuhc4e/YsRkdHMT09jZ2AhZ85c0bfc2MSikkekJqY+ZhXfHzj1N8t7WZXLKkwM2bjyYilX8dO1cHAwMCum5EQHMlsNgtPevRKb6eWzMQr2RissotK0SpI1/EHuV12HQ8H3jRhxIXu5Wp2TT/I6ndLPDQ0pH2wLyZn34ffMeHZ3KK7dF5AQZy72pONtxp5asmh4rT2f7n452FNO5mfX0DxeVGv507BecT9w8EjB5FK79O/He2NofOkgk3k3JRaJe8TnUnnr/Xkk61m1qRl4M54bsLBzKite7j/Azzzl9430dYddMRWmbqmZWvqp5sTrwWFqOJctiTG6LbN9yTajxtofZVa9FEynKcWem53BxMzLdHxuoHOHqWbULvq6tDXyk7R990+tlnbSx99fjJjmjJPydhmUBT4kMIPidWOOazXYhvE+lS4WluCbKedRjmmZ191i7bl9v1y68/CJn/nrhzvopNLnnKhi5dCGnxGDKzEdpjrRYQFjgRQosO1PR4DqLmXf779aCq0a+j2wysnchSBHPGf8oXISIkdof5QSh9TdBkg8m9+vf1oYKPtf7NIvBdpvFmHAAAAAElFTkSuQmCC";
 
@@ -331,7 +333,10 @@ const globalOptions: Fig.Option[] = [
     description: "Set log level",
     priority: 40,
     args: {
-      suggestions: ["info", "debug"],
+      suggestions: [
+        { name: "info", icon: STRING_ICON },
+        { name: "debug", icon: STRING_ICON },
+      ],
     },
   },
   {
@@ -590,7 +595,7 @@ function createFilterSuggestion(name: string): Fig.Suggestion {
   return {
     name: name,
     priority: getNamePriority(name),
-    icon: "fig://icon?type=string",
+    icon: STRING_ICON,
   };
 }
 
@@ -628,8 +633,7 @@ const denoDoc: Fig.Subcommand = {
         script: (tokens) => {
           // A filter can't be used with `--json`, so it has to be removed.
           const command = tokens.slice(0, -1);
-          const jsonFlagIndex = command.indexOf("--json");
-          if (jsonFlagIndex === -1) {
+          if (!command.includes("--json")) {
             command.push("--json");
           }
           const script = command.join(" ");
@@ -695,9 +699,9 @@ const denoDoc: Fig.Subcommand = {
             // same name with different values, eg. overloads and interface
             // merging. Deno's builtin types actually do this with the `Deno`
             // interface. Typically this will only be one or two nodes.
-            const foundNodes = docNodes.filter(
-              (node) => node.name === filterName
-            );
+            const foundNodes = docNodes.filter((node) => {
+              return node.name === filterName;
+            });
 
             // `deno doc` can only generate docs for these nodes' children
             for (const node of foundNodes) {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature: Improves `deno doc` suggestions 🎉

---

<details>
<summary><b>Screenshots</b> (warning: very compelling)</summary>
<br>

_Fig. 1. Top-level results for a file_
![Results for `deno doc src/models.ts`](https://user-images.githubusercontent.com/52195359/132427710-ebc372b3-e13c-411d-bf36-72d97b1854f5.png)

_Fig. 2. Results for members of `API`_
![Results for `deno doc src/models.ts API.`](https://user-images.githubusercontent.com/52195359/132427806-a02f1f1e-dc73-4d5e-a3ec-eebf1d82e9ff.png)

_Fig. 3. Private symbols work, too!_
![Results for `deno doc --private scripts/redact.ts`](https://user-images.githubusercontent.com/52195359/132672704-beee2bc3-1bc2-4f41-a0d0-3579c8028a8d.png)

Aside: I can't use `src/models.ts` with `--private` because it causes a stack overflow in Deno! So that's fun.

</details>

---

**What is the current behavior? (You can also link to an open issue here)**
Suggests files to doc, doesn't suggest a filter.

**What is the new behavior (if this is a feature change)?**
Uses the scope (the file) to suggest a filter as you type. It really does Just Work(tm).

**Additional info:**
It's a relatively complicated generator but it runs decently fast. It also isn't extracted to its own variable, because it isn't usable outside of this one particular command. Having the extra context above it makes it significantly easier to understand.

I basically never use `deno doc` because searching it is a pain and I can't remember what I named that type... this generator just suggests what I'm looking for while I'm typing!

**What I need advice on:**
The icon used for suggestions is currently `fig://icon?type=string`, which isn't _super_ fitting. I don't intend on going full IntelliSense with the icons, though.