### PR TITLE
[nocorrect] Add spec

### DIFF
--- a/src/nocorrect.ts
+++ b/src/nocorrect.ts
@@ -1,0 +1,7 @@
+const completionSpec: Fig.Spec = {
+  name: "nocorrect",
+  args: {
+    isCommand: true,
+  },
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds the `nocorrect` spec
**What is the new behavior (if this is a feature change)?**
Prezto add `nocorrect` to a many aliases [by default](https://github.com/sorin-ionescu/prezto/blob/515d70f639d76314801bbae7e5f1e20da8a76000/modules/utility/init.zsh). This PR ensures that despite this, Fig will still show proper completions.