### PR TITLE
Docs: Use 'GitHub' instead of 'Github'

### DIFF
--- a/dangerfile-invite.ts
+++ b/dangerfile-invite.ts
@@ -13,9 +13,9 @@ schedule(async () => {
 
   const org = "withfig";
   const inviteMarkdown = `
-  @${username} Hey! Thanks so much for your contribution! 
+  @${username} Hey! Thanks so much for your contribution!
 
-As a token of our appreciation, we've invited you to join the Fig GitHub organization. Accepting means you can display Fig's logo on your Github profile's list of member orgs. We also have a special #contributors channel in our [community Discord](https://fig.io/community) and we'd love for you to join.
+As a token of our appreciation, we've invited you to join the Fig GitHub organization. Accepting means you can display Fig's logo on your GitHub profile's list of member orgs. We also have a special #contributors channel in our [community Discord](https://fig.io/community) and we'd love for you to join.
 
 Excited to have you in the community!
 

--- a/src/fig.ts
+++ b/src/fig.ts
@@ -196,7 +196,7 @@ const completionSpec: Fig.Spec = {
     { name: "diagnostic", description: "Display diagnostic information" },
     {
       name: "issue",
-      description: "Create a new Github issue in withfig/fig",
+      description: "Create a new GitHub issue in withfig/fig",
       icon: "fig://icon?type=github",
     },
 

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -38,7 +38,7 @@ const ghOptions: Record<string, Fig.Option> = {
 
 const completionSpec: Fig.Spec = {
   name: "gh",
-  description: "Github's CLI tool",
+  description: "GitHub's CLI tool",
   subcommands: [
     {
       name: "alias",

--- a/src/ns.ts
+++ b/src/ns.ts
@@ -831,10 +831,10 @@ const pluginCommand: Fig.Subcommand = {
         {
           name: "--username",
           description:
-            "Specifies the Github username, which will be used to build the URLs in the plugin's package.json file",
+            "Specifies the GitHub username, which will be used to build the URLs in the plugin's package.json file",
           args: {
             name: "username",
-            description: "Github username",
+            description: "GitHub username",
           },
         },
         {

--- a/src/pipenv.ts
+++ b/src/pipenv.ts
@@ -703,7 +703,7 @@ const completionSpec: Fig.Spec = {
 
     {
       name: "--support",
-      description: "View diagnostic information for use in Github issues",
+      description: "View diagnostic information for use in GitHub issues",
     },
 
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bulk replacement.

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**