### PR TITLE
feat: add htop completion spec

### DIFF
--- a/src/htop.ts
+++ b/src/htop.ts
@@ -1,0 +1,83 @@
+const completionSpec: Fig.Spec = {
+  name: "htop",
+  description: "Improved top (interactive process viewer)",
+
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for htop",
+    },
+    {
+      name: ["--no-color", "-C"],
+      description: "Use a monochrome color scheme",
+    },
+    {
+      name: ["--delay", "-d"],
+      description: "Delay between updates, in tenths of sec",
+      args: {
+        name: "delay",
+        suggestions: ["10"],
+        isOptional: false,
+      },
+    },
+    {
+      name: ["--filter", "-F"],
+      description: "Filter commands",
+      args: {
+        name: "filter",
+        isOptional: false,
+      },
+    },
+    {
+      name: ["--highlight-changes", "-H"],
+      description: "Highlight new and old processes",
+      args: {
+        name: "delay",
+        isOptional: true,
+      },
+    },
+    {
+      name: ["--no-mouse", "-M"],
+      description: "Disable the mouse",
+    },
+    {
+      name: ["--pid", "-p"],
+      description: "Show only the given PIDs",
+      args: {
+        name: "PID",
+        isOptional: false,
+        isVariadic: true,
+      },
+    },
+    {
+      name: ["--sort-key", "-s"],
+      description: "Sort by COLUMN in list view",
+      args: {
+        name: "column",
+        isOptional: false,
+      },
+    },
+    {
+      name: ["--tree", "-t"],
+      description: "Show the tree view",
+    },
+    {
+      name: ["--user", "-u"],
+      description: "Show only processes for a given user (or $USER)",
+      args: {
+        name: "user",
+        isOptional: true,
+        suggestions: ["$USER"],
+      },
+    },
+    {
+      name: ["--no-unicode", "-U"],
+      description: "Do not use unicode but plain ASCII",
+    },
+    {
+      name: ["--version", "-V"],
+      description: "Print version info",
+    },
+  ],
+};
+export default completionSpec;

--- a/src/htop.ts
+++ b/src/htop.ts
@@ -1,7 +1,6 @@
 const completionSpec: Fig.Spec = {
   name: "htop",
   description: "Improved top (interactive process viewer)",
-
   options: [
     {
       name: ["--help", "-h"],
@@ -16,8 +15,7 @@ const completionSpec: Fig.Spec = {
       description: "Delay between updates, in tenths of sec",
       args: {
         name: "delay",
-        suggestions: ["10"],
-        isOptional: false,
+        suggestions: ["10", "1", "60"],
       },
     },
     {
@@ -25,7 +23,6 @@ const completionSpec: Fig.Spec = {
       description: "Filter commands",
       args: {
         name: "filter",
-        isOptional: false,
       },
     },
     {
@@ -34,6 +31,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "delay",
         description: "Delay between updates of highlights, in tenths of sec",
+        suggestions: ["10", "1", "60"],
         isOptional: true,
       },
     },
@@ -46,7 +44,6 @@ const completionSpec: Fig.Spec = {
       description: "Show only the given PIDs",
       args: {
         name: "PID",
-        isOptional: false,
         isVariadic: true,
       },
     },
@@ -55,7 +52,6 @@ const completionSpec: Fig.Spec = {
       description: "Sort by COLUMN in list view",
       args: {
         name: "column",
-        isOptional: false,
       },
     },
     {

--- a/src/htop.ts
+++ b/src/htop.ts
@@ -33,6 +33,7 @@ const completionSpec: Fig.Spec = {
       description: "Highlight new and old processes",
       args: {
         name: "delay",
+        description: "Delay between updates of highlights, in tenths of sec",
         isOptional: true,
       },
     },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
New feature: add htop completion spec

**What is the current behavior? (You can also link to an open issue here)**
There is no current behavior.

**What is the new behavior (if this is a feature change)?**
The new behavior is to show completion options for the `htop` command.

**Additional info:**
None.