### PR TITLE
[npm] Add --legacy-peer-deps for npm install

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -230,6 +230,11 @@ const completionSpec: Fig.Spec = {
             "Causes npm to install the package such that versions of npm prior to 1.4, such as the one included with node 0.8, can install the package",
         },
         {
+          name: "--legacy-peer-deps",
+          description:
+            "Bypass peerDependency auto-installation. Emulate install behavior of NPM v4 through v6",
+        },
+        {
           name: "--strict-peer-deps",
           description:
             "If set to true, and --legacy-peer-deps is not set, then any conflicting peerDependencies will be treated as an install failure",


### PR DESCRIPTION
--legacy-peer-deps is a common option used with npm install but it is not in the current spec.

This option tells npm to skip installing peer dependencies. It is most commonly use when building a react app with react >= 17 and installing packages that don't explicitly have react >= 17 listed as a peer dependency.

This flag tells npm to behave as it did in versions v4 - v6 when installing packages.

https://stackoverflow.com/questions/66239691/what-does-npm-install-legacy-peer-deps-do-exactly-when-is-it-recommended-wh

Re: https://github.com/withfig/autocomplete/issues/545