### PR TITLE
feat: add `php please` spec for Statamic 3

### DIFF
--- a/src/php.ts
+++ b/src/php.ts
@@ -11,6 +11,10 @@ const completionSpec: Fig.Spec = {
       subcommands.push({ name: "artisan", loadSpec: "php/artisan" });
     }
 
+    if ((await executeShellCommand("ls -1 please")) === "please") {
+      subcommands.push({ name: "please", loadSpec: "php/please" });
+    }
+
     return {
       name: "php",
       subcommands,

--- a/src/php/please.ts
+++ b/src/php/please.ts
@@ -1,0 +1,52 @@
+const completionSpec: Fig.Spec = {
+  name: "please",
+  description: "Statamic Please command",
+  generateSpec: async (tokens, executeShellCommand) => {
+    var out = await executeShellCommand("php please list --format=json");
+    const subcommands = [];
+
+    try {
+      const commandDefinition = JSON.parse(out);
+
+      commandDefinition.commands.map((command) => {
+        subcommands.push({
+          name: command.name,
+          description: command.description,
+
+          args: Object.keys(command.definition.arguments).map((argumentKey) => {
+            const argument = command.definition.arguments[argumentKey];
+
+            return {
+              name: argument.name,
+              description: argument.description,
+              isOptional: !argument.is_required,
+            };
+          }),
+          options: Object.keys(command.definition.options).map((optionKey) => {
+            const option = command.definition.options[optionKey];
+            const names = [option.name];
+
+            if (option.shortcut !== "") {
+              names.push(option.shortcut);
+            }
+
+            return {
+              name: names,
+              description: option.description,
+            };
+          }),
+        });
+      });
+    } catch (err) {
+      //
+    }
+
+    return {
+      name: "please",
+      debounce: true,
+      subcommands,
+    };
+  },
+};
+
+export default completionSpec;

--- a/src/php/please.ts
+++ b/src/php/please.ts
@@ -13,17 +13,14 @@ const completionSpec: Fig.Spec = {
           name: command.name,
           description: command.description,
 
-          args: Object.keys(command.definition.arguments).map((argumentKey) => {
-            const argument = command.definition.arguments[argumentKey];
-
+          args: Object.values(command.definition.arguments).map((argument) => {
             return {
               name: argument.name,
               description: argument.description,
               isOptional: !argument.is_required,
             };
           }),
-          options: Object.keys(command.definition.options).map((optionKey) => {
-            const option = command.definition.options[optionKey];
+          options: Object.values(command.definition.options).map((option) => {
             const names = [option.name];
 
             if (option.shortcut !== "") {

--- a/src/php/please.ts
+++ b/src/php/please.ts
@@ -1,3 +1,21 @@
+interface Argument {
+  name: string;
+  is_required: boolean;
+  is_array: boolean;
+  description: string;
+  default: string;
+}
+
+interface Option {
+  name: string;
+  shortcut: string;
+  accept_value: boolean;
+  is_value_required: boolean;
+  is_multiple: false;
+  description: string;
+  default: string;
+}
+
 const completionSpec: Fig.Spec = {
   name: "please",
   description: "Statamic Please command",
@@ -13,25 +31,29 @@ const completionSpec: Fig.Spec = {
           name: command.name,
           description: command.description,
 
-          args: Object.values(command.definition.arguments).map((argument) => {
-            return {
-              name: argument.name,
-              description: argument.description,
-              isOptional: !argument.is_required,
-            };
-          }),
-          options: Object.values(command.definition.options).map((option) => {
-            const names = [option.name];
-
-            if (option.shortcut !== "") {
-              names.push(option.shortcut);
+          args: Object.values(command.definition.arguments).map(
+            (argument: Argument) => {
+              return {
+                name: argument.name,
+                description: argument.description,
+                isOptional: !argument.is_required,
+              };
             }
+          ),
+          options: Object.values(command.definition.options).map(
+            (option: Option) => {
+              const names = [option.name];
 
-            return {
-              name: names,
-              description: option.description,
-            };
-          }),
+              if (option.shortcut !== "") {
+                names.push(option.shortcut);
+              }
+
+              return {
+                name: names,
+                description: option.description,
+              };
+            }
+          ),
         });
       });
     } catch (err) {

--- a/src/php/please.ts
+++ b/src/php/please.ts
@@ -2,7 +2,7 @@ const completionSpec: Fig.Spec = {
   name: "please",
   description: "Statamic Please command",
   generateSpec: async (tokens, executeShellCommand) => {
-    var out = await executeShellCommand("php please list --format=json");
+    const out = await executeShellCommand("php please list --format=json");
     const subcommands = [];
 
     try {
@@ -38,7 +38,7 @@ const completionSpec: Fig.Spec = {
         });
       });
     } catch (err) {
-      //
+      console.error(err);
     }
 
     return {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Spec addition: Statamic 3's `please` command

**What is the current behavior? (You can also link to an open issue here)**
Currently `please` is not available.

**What is the new behavior (if this is a feature change)?**
Add's Statamic 3's `please` spec based on the command list json output

**Additional info:**
This is replicating the setup of the `artisan` spec for Laravel - perfect fit as Statamic is built on top of Laravel. Full credit to the original authors of the `artisan` implementation for this - this PR operates the same way, but runs the `please` command instead. This includes:
- only adding the spec if `please` is in the current directory, 
- pulls the available options from the `php please list --format=json` command