### PR TITLE
fix(docker): Suggestions for `ps` & `-d` option for `run`

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1271,16 +1271,6 @@ const sharedCommands: Record<string, Fig.Subcommand> = {
     args: {
       isVariadic: true,
       name: "containers",
-      suggestions: [
-        {
-          name: "$(docker ps -aq)",
-          description: "All containers, running and exited",
-        },
-        {
-          name: "$(docker ps -q)",
-          description: "All running containers",
-        },
-      ],
       generators: dockerGenerators.allDockerContainers,
     },
     options: [
@@ -1310,7 +1300,6 @@ const sharedCommands: Record<string, Fig.Subcommand> = {
       { name: ["-t", "--tty"], description: "Allocate a pseudo-TTY" },
       {
         name: "-it",
-
         description: "Launch an interactive session",
         icon: "fig://icon?type=commandkey",
       },

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1294,6 +1294,10 @@ const sharedCommands: Record<string, Fig.Subcommand> = {
     description: "Run a command in a new container",
     options: [
       {
+        name: ["-d", "--detach"],
+        description: "Run container in background and print container ID",
+      },
+      {
         name: ["-i", "--interactive"],
         description: "Keep STDIN open even if not attached",
       },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Closes #570

**What is the current behavior? (You can also link to an open issue here)**
From #570:
![Screenshot 2021-09-07 at 10 18 50](https://user-images.githubusercontent.com/1587171/132310840-41a28d0e-d208-4570-9474-3af71fa53cdd.png)

**What is the new behavior (if this is a feature change)?**
Remove those two suggestions since there is already a generator for `ps`, and add the common `-d` (or `--detach`) flag to `run`.

**Additional info:**