### PR TITLE
fix: Use right binary instead of possible aliased ones

### DIFF
--- a/src/bazel.ts
+++ b/src/bazel.ts
@@ -1,5 +1,5 @@
 const bazelBuildFiles: Fig.Generator = {
-  script: `FILES=( $(find ./ -name BUILD) ); for f in $FILES; do echo "----$f"; cat "$f"; done`,
+  script: `FILES=( $(find ./ -name BUILD) ); for f in $FILES; do echo "----$f"; \cat "$f"; done`,
   // returns filepaths and contents in the form below, note the "----" to indicate the filepath
   // ----.//lib/BUILD
   // load("@rules_cc//cc:defs.bzl", "cc_library")

--- a/src/cargo.ts
+++ b/src/cargo.ts
@@ -43,7 +43,7 @@ const searchGenerator: Fig.Generator = {
   script: function (context) {
     if (context[context.length - 1] === "") return "";
     const searchTerm = context[context.length - 1];
-    return `cargo search "${searchTerm}" | grep -E "^\\w"`;
+    return `cargo search "${searchTerm}" | \grep -E "^\\w"`;
   },
   postProcess: function (out) {
     return out.split("\n").map((line) => {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -336,7 +336,7 @@ const sharedCommands: Record<string, Fig.Subcommand> = {
                 dockerfilePath = "$PWD/Dockerfile";
               }
 
-              return `grep -iE 'FROM.*AS' "${dockerfilePath}"`;
+              return `\grep -iE 'FROM.*AS' "${dockerfilePath}"`;
             },
             postProcess: function (out) {
               // This just searches the Dockerfile for the alias name after AS,

--- a/src/fig.ts
+++ b/src/fig.ts
@@ -104,7 +104,7 @@ const completionSpec: Fig.Spec = {
       description: "Update preferences",
       generateSpec: async (_, executeShellCommand) => {
         const settings: Settings[] = JSON.parse(
-          await executeShellCommand(`cat ${SETTINGS_PATH}`)
+          await executeShellCommand(`\cat ${SETTINGS_PATH}`)
         );
 
         return {

--- a/src/lerna.ts
+++ b/src/lerna.ts
@@ -27,7 +27,7 @@ const getBranches: Fig.Generator = {
 
 const getAllScriptsFromPackages: Fig.Generator = {
   // Get all lerna packages, loop over them and get content of package.json
-  script: `lerna list -p | while read p; do\n cat $p/package.json && echo ${SPLIT_CHAR}\ndone`,
+  script: `lerna list -p | while read p; do\n \cat $p/package.json && echo ${SPLIT_CHAR}\ndone`,
   postProcess: (output) => {
     // Split output by the divider and remove empty entry
     const packages = output.split(SPLIT_CHAR).filter((e) => e.trim() !== "");

--- a/src/mask.ts
+++ b/src/mask.ts
@@ -15,7 +15,7 @@ const completionSpec: Fig.Spec = {
       out = await executeShellCommand("cat maskfile.md 2> /dev/null");
     } else {
       out = await executeShellCommand(
-        `cat ${tokens[maskfileLocationIdx + 1]} 2> /dev/null`
+        `\cat ${tokens[maskfileLocationIdx + 1]} 2> /dev/null`
       );
     }
 

--- a/src/open.ts
+++ b/src/open.ts
@@ -1,5 +1,5 @@
 const appGenerator = (path: string): Fig.Generator => ({
-  script: `ls -1 ${path}`,
+  script: `\ls -1 ${path}`,
   postProcess: (out) => {
     return out.split("\n").map((line) => ({
       name: line,

--- a/src/rails.ts
+++ b/src/rails.ts
@@ -613,7 +613,7 @@ const completionSpec: Fig.Spec = {
   description: "Ruby on Rails CLI",
   async generateSpec(_, executeShellCommand) {
     const gemfileMatch = await executeShellCommand(
-      `until [[ -f Gemfile ]] || [[ $PWD = '/' ]]; do cd ..; done; if [ -f Gemfile ]; then cat Gemfile | grep "gem 'rails'"; else echo ""; fi`
+      `until [[ -f Gemfile ]] || [[ $PWD = '/' ]]; do cd ..; done; if [ -f Gemfile ]; then cat Gemfile | \grep "gem 'rails'"; else echo ""; fi`
     );
     const isRails = !!gemfileMatch;
 

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -63,7 +63,7 @@ const getGlobalPackagesGenerator: Fig.Generator = {
 // generate workspace argument completion
 const scriptList: Fig.Generator = {
   script: function (context) {
-    return `cat ${context[context.length - 2]}/package.json`;
+    return `\cat ${context[context.length - 2]}/package.json`;
   },
   postProcess: function (out) {
     if (out.trim() == "") {
@@ -1265,7 +1265,7 @@ const completionSpec: Fig.Spec = {
             for (const workspace of workspaces) {
               if (workspace.includes("*")) {
                 const out = await executeShellCommand(
-                  `ls ${workspace.slice(0, -1)}`
+                  `\ls ${workspace.slice(0, -1)}`
                 );
                 const workspaceList = out.split("\n");
 
@@ -1276,7 +1276,7 @@ const completionSpec: Fig.Spec = {
                     args: {
                       name: "script",
                       generators: {
-                        script: `cat ${workspace.slice(
+                        script: `\cat ${workspace.slice(
                           0,
                           -1
                         )}/${space}/package.json`,
@@ -1292,7 +1292,7 @@ const completionSpec: Fig.Spec = {
                   args: {
                     name: "script",
                     generators: {
-                      script: `cat ${workspace}/package.json`,
+                      script: `\cat ${workspace}/package.json`,
                       postProcess,
                     },
                   },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix (ttps://github.com/withfig/autocomplete/pull/619#issuecomment-932371933)

**What is the current behavior? (You can also link to an open issue here)**
Commands like `ls`, `cat`, etc are often aliased to alternatives like [exa](https://github.com/ogham/exa), [bat](https://github.com/sharkdp/bat), etc. The output and options might not be exactly the same as the native ones, so it can break generators using those commands.

**What is the new behavior (if this is a feature change)?**
Prepend a `\` before the name of the command to make the shell execute the right binary

**Additional info:**