### PR TITLE
feat: add remotion autocompletion to fig

### DIFF
--- a/src/create-video.ts
+++ b/src/create-video.ts
@@ -1,0 +1,7 @@
+const completionSpec: Fig.Spec = {
+  name: "create-video",
+  description: "CLI used to create remotion video project",
+  icon:
+    "https://raw.githubusercontent.com/remotion-dev/remotion/main/packages/docs/static/img/logo-small.png",
+};
+export default completionSpec;

--- a/src/npx.ts
+++ b/src/npx.ts
@@ -58,6 +58,11 @@ const suggestions: Fig.Suggestion[] = [
     icon: "https://nextjs.org/static/favicon/favicon-16x16.png",
   },
   {
+    name: "create-video",
+    icon:
+      "https://raw.githubusercontent.com/remotion-dev/remotion/main/packages/docs/static/img/logo-small.png",
+  },
+  {
     name: "remotion",
     icon:
       "https://raw.githubusercontent.com/remotion-dev/remotion/main/packages/docs/static/img/logo-small.png",

--- a/src/npx.ts
+++ b/src/npx.ts
@@ -57,6 +57,11 @@ const suggestions: Fig.Suggestion[] = [
     name: "create-next-app",
     icon: "https://nextjs.org/static/favicon/favicon-16x16.png",
   },
+  {
+    name: "remotion",
+    icon:
+      "https://raw.githubusercontent.com/remotion-dev/remotion/main/packages/docs/static/img/logo-small.png",
+  },
 ];
 
 const completionSpec: Fig.Spec = {

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -10,7 +10,6 @@ const completionSpec: Fig.Spec = {
       args: [
         {
           name: "entry",
-          isOptional: false,
           template: ["filepaths"],
         },
         {
@@ -53,7 +52,14 @@ const completionSpec: Fig.Spec = {
           name: "--image-format",
           description: 'Format to render the frames in, "jpeg" or "png"',
           args: {
-            template: ["filepaths"],
+            suggestions: [
+              {
+                name: "jpeg",
+              },
+              {
+                name: "png",
+              },
+            ],
           },
         },
         {
@@ -83,6 +89,11 @@ const completionSpec: Fig.Spec = {
           description: "Quality for rendered frames, JPEG only, 0-100",
           args: {
             default: "80",
+            suggestions: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map(
+              (e) => ({
+                name: e.toString(),
+              })
+            ),
           },
         },
         {
@@ -126,6 +137,9 @@ const completionSpec: Fig.Spec = {
         {
           name: "--frames",
           description: "Render a portion or a still of a video, 0-9, 50",
+          args: {
+            name: "frames",
+          },
         },
         {
           name: "--bundle-cache",
@@ -148,6 +162,10 @@ const completionSpec: Fig.Spec = {
         {
           name: "--port",
           description: "Custom port to use for the HTTP server",
+          args: {
+            name: "port",
+            default: "3333",
+          },
         },
         {
           name: "--env-file",
@@ -188,7 +206,11 @@ const completionSpec: Fig.Spec = {
         },
       ],
       options: [
-        { name: "--frame", description: "Which frame to render (default 0)" },
+        {
+          name: "--frame",
+          description: "Which frame to render (default 0)",
+          args: { name: "frame", default: "0" },
+        },
         {
           name: "--image-format",
           description: 'Format to render the frames in, "jpeg" or "png"',
@@ -255,6 +277,10 @@ const completionSpec: Fig.Spec = {
         {
           name: "--port",
           description: "Custom port to use for the HTTP server",
+          args: {
+            name: "port",
+            default: "3333",
+          },
         },
         {
           name: "--env-file",

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -1,0 +1,304 @@
+const completionSpec: Fig.Spec = {
+  name: "remotion",
+  description: "Create videos programmatically in React",
+  subcommands: [
+    {
+      name: "render",
+      priority: 60,
+      description:
+        "Render a video based on the entry point, the composition ID and save it to the output location",
+      args: [
+        {
+          name: "entry",
+          isOptional: false,
+          template: ["filepaths"],
+        },
+        {
+          name: "comp-id",
+          description: "The composition ID",
+          suggestions: [
+            {
+              type: "arg",
+              displayName: "[comp-id]",
+            },
+          ],
+          isOptional: false,
+        },
+        {
+          name: "output",
+          isOptional: false,
+          template: ["filepaths"],
+          suggestions: ["out.mp4"],
+        },
+      ],
+      options: [
+        {
+          name: "--props",
+          description: "Pass input props as filename or as JSON",
+          args: {
+            template: ["filepaths"],
+            suggestions: [
+              {
+                type: "arg",
+                displayName: "[json string]",
+              },
+            ],
+          },
+        },
+        {
+          name: "--concurrency",
+          description: "How many frames to render in parallel",
+        },
+        {
+          name: "--image-format",
+          description: 'Format to render the frames in, "jpeg" or "png"',
+          args: {
+            template: ["filepaths"],
+          },
+        },
+        {
+          name: "--pixel-format",
+          description: "Custom pixel format, see docs for available values",
+          args: {
+            suggestions: [
+              { name: "yuv420p" },
+              { name: "yuv422p" },
+              { name: "yuv444p" },
+              { name: "yuv420p10le" },
+              { name: "yuv422p10le" },
+              { name: "yuv444p10le" },
+              { name: "yuva420p" },
+            ],
+          },
+        },
+        {
+          name: "--config",
+          description: "Custom location for a Remotion config file",
+          args: {
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--quality",
+          description: "Quality for rendered frames, JPEG only, 0-100",
+          args: {
+            default: "80",
+          },
+        },
+        {
+          name: "--overwrite",
+          description: "Overwrite if file exists, default true",
+        },
+        {
+          name: "--sequence",
+          description: "Output as an image sequence",
+        },
+        {
+          name: "--codec",
+          description: "Video of audio codec",
+          args: {
+            default: "h264",
+            suggestions: [
+              { name: "h264" },
+              { name: "h265" },
+              { name: "png" },
+              { name: "vp8" },
+              { name: "vp9" },
+              { name: "mp3" },
+              { name: "aac" },
+              { name: "wav" },
+              { name: "prores" },
+              { name: "h264-mkv" },
+            ],
+          },
+        },
+        {
+          name: "--crf",
+          description: "FFMPEG CRF value, controls quality, see docs for info",
+        },
+        {
+          name: "--browser-executable",
+          description: "Custom path for browser executable",
+          args: {
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--frames",
+          description: "Render a portion or a still of a video, 0-9, 50",
+        },
+        {
+          name: "--bundle-cache",
+          description: "Cache webpack bundle, boolean, default true",
+        },
+        {
+          name: "--log",
+          description:
+            'Log level, "error", "warning", "verbose", "info" (default)',
+          args: {
+            default: "info",
+            suggestions: [
+              { name: "error" },
+              { name: "warning" },
+              { name: "verbose" },
+              { name: "info" },
+            ],
+          },
+        },
+        {
+          name: "--port",
+          description: "Custom port to use for the HTTP server",
+        },
+        {
+          name: "--env-file",
+          description: "Specify a location for a dotenv file",
+          args: {
+            template: "filepaths",
+          },
+        },
+      ],
+    },
+    {
+      name: "still",
+      priority: 55,
+      description:
+        "Render a still frame based on the entry point, the composition ID and save it to the output location",
+      args: [
+        {
+          name: "entry",
+          isOptional: false,
+          template: ["filepaths"],
+        },
+        {
+          name: "comp-id",
+          description: "The composition ID",
+          suggestions: [
+            {
+              type: "arg",
+              displayName: "[comp-id]",
+            },
+          ],
+          isOptional: false,
+        },
+        {
+          name: "output",
+          isOptional: false,
+          template: ["filepaths"],
+          suggestions: ["out.mp4"],
+        },
+      ],
+      options: [
+        { name: "--frame", description: "Which frame to render (default 0)" },
+        {
+          name: "--image-format",
+          description: 'Format to render the frames in, "jpeg" or "png"',
+          args: {
+            template: ["filepaths"],
+          },
+        },
+        {
+          name: "--props",
+          description: "Pass input props as filename or as JSON",
+          args: {
+            template: ["filepaths"],
+            suggestions: [
+              {
+                type: "arg",
+                displayName: "[json string]",
+              },
+            ],
+          },
+        },
+        {
+          name: "--config",
+          description: "Custom location for a Remotion config file",
+          args: {
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--quality",
+          description: "Quality for rendered frames, JPEG only, 0-100",
+          args: {
+            default: "80",
+          },
+        },
+        {
+          name: "--overwrite",
+          description: "Overwrite if file exists, default true",
+        },
+        {
+          name: "--browser-executable",
+          description: "Custom path for browser executable",
+          args: {
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--bundle-cache",
+          description: "Cache webpack bundle, boolean, default true",
+        },
+        {
+          name: "--log",
+          description:
+            'Log level, "error", "warning", "verbose", "info" (default)',
+          args: {
+            default: "info",
+            suggestions: [
+              { name: "error" },
+              { name: "warning" },
+              { name: "verbose" },
+              { name: "info" },
+            ],
+          },
+        },
+        {
+          name: "--port",
+          description: "Custom port to use for the HTTP server",
+        },
+        {
+          name: "--env-file",
+          description: "Specify a location for a dotenv file",
+        },
+      ],
+    },
+    {
+      name: "preview",
+      priority: 50,
+      description:
+        "Start the server which allows you to preview the Remotion video",
+      args: {
+        name: "entry",
+        isOptional: false,
+        template: ["filepaths"],
+      },
+      options: [
+        {
+          name: "--propss",
+          description: "Pass input props as filename or as JSON",
+          args: {
+            template: ["filepaths"],
+            suggestions: [
+              {
+                type: "arg",
+                displayName: "[json string]",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      name: "upgrade",
+      description:
+        "Upgrade all Remotion-related dependencies to the newest version",
+    },
+  ],
+  options: [
+    {
+      name: "--help",
+      description: "Prints the list of commands and flags for quick lookup",
+    },
+  ],
+};
+export default completionSpec;

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -4,7 +4,11 @@ import {
   npmSearchGenerator,
 } from "./npm";
 
-const createCLIs = ["create-next-app", "create-react-native-app"];
+const createCLIs = [
+  "create-next-app",
+  "create-react-native-app",
+  "create-video",
+];
 
 export const nodeClis = [
   "vue",
@@ -19,6 +23,7 @@ export const nodeClis = [
   "tsc",
   "typeorm",
   "babel",
+  "remotion",
 ];
 
 type SearchResult = {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This PR add [remotion](https://remotion.dev) autocompletion

- [x] I’ve reduced the length of arguments label from "entry-file" to "entry" in order to fit in fig popup
- [x] `npx remotion render`
- [x] `npx remotion still`
- [x] `npx remotion preview`


