### PR TITLE
feat: add assimp completion spec

### DIFF
--- a/src/assimp.ts
+++ b/src/assimp.ts
@@ -226,7 +226,7 @@ const completionSpec: Fig.Spec = {
           template: "filepaths",
         },
       ],
-      options: [...helpOptions],
+      options: helpOptions,
     },
     {
       name: "version",


### PR DESCRIPTION
This adds an autocomplete spec for [assimp](https://github.com/assimp/assimp).