### PR TITLE
Config --global fix

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -894,19 +894,26 @@ const completionSpec: Fig.Spec = {
           name: "--global",
           description:
             "For writing options: write to global ~/.gitconfig file rather than the repository .git/config",
-          args: {
-            isVariadic: true,
-            suggestions: [
-              {
-                name: "user.name",
-                description: "Config for username",
-              },
-              {
-                name: "user.email",
-                description: "Config for email",
-              },
-            ],
-          },
+          args: [
+            {
+              name: "key",
+              isVariadic: true,
+              suggestions: [
+                {
+                  name: "user.name",
+                  description: "Config for username",
+                },
+                {
+                  name: "user.email",
+                  description: "Config for email",
+                },
+              ],
+            },
+            {
+              name: "value",
+              isOptional: true,
+            },
+          ],
         },
         {
           name: "--replace-all",


### PR DESCRIPTION
config --global takes 2 args by default <key> <value>
It only takes 1 arg if used in conjunction with --get

The 2nd arg should be optional to accommodate for this