### PR TITLE
docs: fix link to contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Yes! We are participating in Hacktoberfest and would love your contributions! Yo
 * any other completion spec for CLI tools you use regularly
 * generators for existing specs
 
-Never submitted a PR before? Check out our [How to Contribute](https://fig.io/docs/tutorials/contributing-to-public-specs) guide. Many of Fig's 100+ contributors made their first open source contribution to Fig too!
+Never submitted a PR before? Check out our [How to Contribute](https://fig.io/docs/getting-started/contributing) guide. Many of Fig's 100+ contributors made their first open source contribution to Fig too!
 
 ## 😊 Need Help?
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix the link to the contribution guide in README.md.

**What is the current behavior? (You can also link to an open issue here)**
Click "[How to Contribute](https://github.com/withfig/autocomplete/tree/d4c316da967b75c4b75cfc8373b751616901d5c8#-hacktoberfest)" in "README.md" to reach [the 404 page](https://fig.io/docs/tutorials/contributing-to-public-specs).

<img width="500" alt="スクリーンショット 2021-10-15 22 19 24" src="https://user-images.githubusercontent.com/20027695/137493417-58aff0cf-9615-4993-b344-87813edce404.png">

**What is the new behavior (if this is a feature change)?**
We can successfully reach the contribution guide.

**Additional info:**