### PR TITLE
feat: add limactl completion spec

### DIFF
--- a/src/lima.ts
+++ b/src/lima.ts
@@ -7,7 +7,6 @@ const completionSpec: Fig.Spec = {
     isOptional: true,
     isCommand: true,
   },
-
   options: [
     {
       name: ["-h", "--help"],


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
No autocompletion for `limactl` (#672)

**What is the new behavior (if this is a feature change)?**
Adds autocomplete support for limactl.

**Additional info:**
It also supports auto-completion of the `lima` command, which is an alias for `limactl shell`.