### PR TITLE
fix(yarn): workspace subcommand showns right packages

### DIFF
--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -1,11 +1,7 @@
 // GENERATORS
 
-import {
-  dependenciesGenerator,
-  npmScriptsGenerator,
-  npmSearchGenerator,
-} from "./npm";
-import { nodeClis } from "./yarn";
+import { npmScriptsGenerator, npmSearchGenerator } from "./npm";
+import { dependenciesGenerator, nodeClis } from "./yarn";
 
 const filterMessages = (out: string): string => {
   return out.startsWith("warning:") || out.startsWith("error:")


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix

**What is the current behavior? (You can also link to an open issue here)**
`yarn workspace <name> ...` is only working with `packages/*`, and didn't output the right package name

**What is the new behavior (if this is a feature change)?**
`yarn workspace <name> ...` now works with `packages/*` & `packages/my-package, packages/other-package` syntax, and output the right package name for both (which was the folder name, and is now the package name)

Also fixes `yarn/pnpm <package> ...` which was broken after https://github.com/withfig/autocomplete/pull/619

**Additional info:**

With this syntax:
```json
  "workspaces": [
    "packages/autocomplete-tools",
    "packages/autocomplete-types",
    "packages/eslint-plugin-fig-linter",
    "packages/oclif",
    "packages/commander"
  ],
```
![Screenshot 2021-10-16 at 11 33 51](https://user-images.githubusercontent.com/43268759/137582589-65cc888f-8fac-46cc-ab07-0e95192f6f0e.png)

With this syntax:
```json
  "workspaces": [
    "packages/*"
  ]
```
![Screenshot 2021-10-16 at 11 34 12](https://user-images.githubusercontent.com/43268759/137582610-b7db9419-c15a-4049-892f-6d7fd24bdd0e.png)


