### PR TITLE
fix(brew): duplicated formulae/cask

### DIFF
--- a/src/brew.ts
+++ b/src/brew.ts
@@ -54,19 +54,16 @@ const brewInfo = (name: string): Fig.Subcommand => ({
     generators: {
       script:
         "HBPATH=$(brew --repository); ls -1 $HBPATH/Library/Taps/homebrew/homebrew-core/Formula $HBPATH/Library/Taps/homebrew/homebrew-cask/Casks",
-      postProcess: function (out) {
-        return out.split("\n").map((formula) => {
-          return {
-            name: formula.replace(".rb", ""),
-            description: "Formula",
-            icon: "🍺",
-            priority:
-              (formula[0] >= "0" && formula[0] <= "9") || formula[0] == "/"
-                ? 0
-                : 51,
-          };
-        });
-      },
+      postProcess: (out) =>
+        [...new Set(out.split("\n"))].map((formula) => ({
+          name: formula.replace(".rb", ""),
+          description: "Formula",
+          icon: "🍺",
+          priority:
+            (formula[0] >= "0" && formula[0] <= "9") || formula[0] == "/"
+              ? 0
+              : 51,
+        })),
     },
   },
   options: [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Closes #647

**What is the current behavior? (You can also link to an open issue here)**
> Looks like the issue is due to homebrew (I've run the script command executed in the spec's generator, with a grep to `handbrake `), as you can see there are two instances of `handbrake`. I'm going to fix this asap
>
> ![Screenshot 2021-10-14 at 18 15 06](https://user-images.githubusercontent.com/43268759/137356605-1908a258-b127-42d3-9d6f-a88a91904d45.png)
>
> _Originally posted by @QuiiBz in https://github.com/withfig/autocomplete/issues/647#issuecomment-943510458_

**What is the new behavior (if this is a feature change)?**
Filter the output to remove duplicated entries

**Additional info:**

![Screenshot 2021-10-16 at 12 20 11](https://user-images.githubusercontent.com/43268759/137583708-9e32dfae-5b8c-42c0-8e35-8a16c3e6f3dd.png)

