### PR TITLE
feat: add `julia` completion spec 

### DIFF
--- a/src/julia.ts
+++ b/src/julia.ts
@@ -264,6 +264,14 @@ const completionSpec: Fig.Spec = {
       },
     },
     {
+      name: "--polly",
+      description:
+        "Enable or disable the polyhedral optimizer Polly (overrides @polly declaration)",
+      args: {
+        suggestions: [{ name: "yes" }, { name: "no" }],
+      },
+    },
+    {
       name: "--math-mode",
       description:
         "Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature: add autocompletion for [`julia`](https://github.com/JuliaLang/julia/).

**What is the current behavior? (You can also link to an open issue here)**
No autocompletion for `julia`.

**What is the new behavior (if this is a feature change)?**
Add autocompletion for `julia`.

**Additional info:**
[Reference of options](https://github.com/JuliaLang/julia/blob/master/src/jloptions.c#L87).
