### PR TITLE
feat(limactl): add show-ssh subcommand

### DIFF
--- a/src/limactl.ts
+++ b/src/limactl.ts
@@ -159,6 +159,38 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
+      name: "show-ssh",
+      description: "Show the ssh command line",
+      args: {
+        name: "INSTANCE",
+        generators: instanceNameGenerator(),
+      },
+      options: [
+        ...generateGlobalFlags("show-ssh"),
+        {
+          name: ["-f", "--format"],
+          description: 'Format: cmd, args, options, config (default "cmd")',
+          args: {
+            name: "string",
+            default: "cmd",
+            suggestions: [
+              {
+                name: "cmd",
+                description: "Full ssh command line",
+              },
+              {
+                name: "args",
+                description:
+                  'Similar to the cmd format but omits "ssh" and the destination address',
+              },
+              { name: "options", description: "Ssh option key value pairs" },
+              { name: "config", description: "~/.ssh/config format" },
+            ],
+          },
+        },
+      ],
+    },
+    {
       name: "start",
       description:
         'Start an instance of Lima. If the instance does not exist, open an editor for creating new one, with name "default"',


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature (or Fix?)

**What is the current behavior? (You can also link to an open issue here)**
[lima v0.7.2](https://github.com/lima-vm/lima/releases/tag/v0.7.2) has been released, and the [`show-ssh` subcommand](https://github.com/lima-vm/lima/pull/338) has been added to `limactl`. But, `show-ssh` is not auto-completed.

**What is the new behavior (if this is a feature change)?**
`show-ssh` subcommand will be auto-completed.

**Additional info:**