### PR TITLE
[wranger] Fix for publish arg

### DIFF
--- a/src/wrangler.ts
+++ b/src/wrangler.ts
@@ -344,6 +344,7 @@ const completionSpec: Fig.Spec = {
         name: "output",
         suggestions: ["json"],
         description: "[possible values: json]",
+        isOptional: true,
       },
       options: [
         OPTION_CONFIG,


### PR DESCRIPTION
The arg for `wrangler publish` should be optional. You don't need to supply output in order to run the command.