### PR TITLE
fix: -f option definition for docker volume rm

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -5344,7 +5344,7 @@ const completionSpec: Fig.Spec = {
           },
           options: [
             {
-              name: "-f, --force",
+              name: ["-f", "--force"],
               description: "Force the removal of one or more volumes",
             },
           ],


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
When you type `docker volume rm`, Fig auto-suggests to use the `-f, --force` flag as expected. However, when you select that option from the autocompletion menu, you get `docker volume rm -f,\ --force` instead of `docker volume rm -f` as expected.

**What is the new behavior (if this is a feature change)?**
Fig inserts the correct value for the `-f` option: `docker volume rm -f`

**Additional info:**
 \-