### PR TITLE
Add `git checkout -` to git autocomplete

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -525,6 +525,10 @@ const completionSpec: Fig.Spec = {
       description: "Output help",
     },
     {
+      name: "-",
+      description: "Check out the previous branch",
+    },
+    {
       name: "-C",
 
       args: {


### PR DESCRIPTION
Fixes #728

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Git has a handy alias `git checkout -` that can switch to the previous branch. From the Git 1.6.2 docs:

`* "git checkout -" is a shorthand for "git checkout @{-1}".`

**What is the current behavior? (You can also link to an open issue here)**

It's not suggested by Fig. Fig suggests I might want `--conflict` instead. But I am feeling `--conflict`-avoidant.

**What is the new behavior (if this is a feature change)?**

Fig suggests this handy alias, because switching between two branches is great.

**Additional info:**

https://github.com/git/git/blob/master/Documentation/RelNotes/1.6.2.txt#L85