### PR TITLE
Support for elm cli

### DIFF
--- a/src/elm.ts
+++ b/src/elm.ts
@@ -1,0 +1,181 @@
+const packageList: Fig.Generator = {
+  script:
+    "curl -sH 'accept-encoding: gzip' https://package.elm-lang.org/search.json | gunzip",
+  cache: {
+    ttl: 100 * 24 * 60 * 60 * 3, // 3 days
+  },
+  postProcess: (output) => {
+    return JSON.parse(output).map((package_) => ({
+      name: package_.name,
+      description: package_.summary,
+    }));
+  },
+};
+
+const completionSpec: Fig.Spec = {
+  name: "elm",
+  description: "Fig spec for the Elm language cli",
+  subcommands: [
+    {
+      name: "init",
+      description: "Initialize a new Elm project",
+      options: [
+        {
+          name: "--help",
+          description: "Show help for elm init",
+        },
+      ],
+    },
+    {
+      name: "repl",
+      description: "Start an Elm repl",
+      options: [
+        {
+          name: "--no-colors",
+          description: "Turn off colors in the repl",
+        },
+        {
+          name: "--interpreter",
+          description:
+            "Path to an alternate JS interpreter, such as Node or Deno",
+          args: {
+            name: "interpreter",
+            isOptional: false,
+          },
+        },
+        {
+          name: "--help",
+          description: "Show help for elm repl",
+        },
+      ],
+    },
+    {
+      name: "reactor",
+      description: "Start an Elm development server",
+      options: [
+        {
+          name: "--port",
+          description: "The port to access the development server on",
+          args: {
+            name: "port",
+            description: "The port number",
+            isOptional: false,
+          },
+        },
+        {
+          name: "--help",
+          description: "Show help for elm reactor",
+        },
+      ],
+    },
+    {
+      name: "install",
+      description: "Install an Elm dependency",
+      args: {
+        name: "package",
+        description: "The name of the package to install",
+        isOptional: false,
+        debounce: true,
+        isVariadic: false,
+        generators: packageList,
+      },
+      options: [
+        {
+          name: "--help",
+          description: "Show help for elm install",
+        },
+      ],
+    },
+    {
+      name: "make",
+      description: "Build your Elm code",
+      args: {
+        template: "filepaths",
+        name: "source files",
+        description: "The source files to compile",
+        isOptional: false,
+      },
+      options: [
+        {
+          name: "--help",
+          description: "Show help for elm make",
+        },
+        {
+          name: "--debug",
+          description: "Compile in debug mode",
+        },
+        {
+          name: "--optimize",
+          description: "Compile in production mode",
+        },
+        {
+          name: "--output",
+          description: "Where to output the compiled code",
+          args: {
+            name: "output file",
+            description: "Name and location of output",
+            isOptional: false,
+          },
+        },
+        {
+          name: "--docs",
+          description: "Generate a JSON file of documentation",
+          args: {
+            name: "output json",
+            description: "Name and location of output",
+            isOptional: false,
+          },
+        },
+      ],
+    },
+    {
+      name: "bump",
+      description: "Bump the version of your package",
+      options: [
+        {
+          name: "--help",
+          description: "Show help for elm bump",
+        },
+      ],
+    },
+    {
+      name: "diff",
+      description: "See what changed between versions of a package",
+      options: [
+        {
+          name: "--help",
+          description: "Show help for elm diff",
+        },
+      ],
+      args: [
+        {
+          name: "package",
+          isOptional: true,
+          isVariadic: false,
+        },
+        {
+          name: "version",
+          isOptional: true,
+          isVariadic: true,
+        },
+      ],
+    },
+    {
+      name: "publish",
+      description: "Publish your package",
+      options: [
+        {
+          name: "--help",
+          description: "Show help for elm publish",
+        },
+      ],
+    },
+  ],
+  options: [
+    {
+      name: "--help",
+      description: "Show help for elm",
+    },
+  ],
+};
+export default completionSpec;

--- a/src/elm.ts
+++ b/src/elm.ts
@@ -40,7 +40,6 @@ const completionSpec: Fig.Spec = {
             "Path to an alternate JS interpreter, such as Node or Deno",
           args: {
             name: "interpreter",
-            isOptional: false,
           },
         },
         {
@@ -59,7 +58,6 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "port",
             description: "The port number",
-            isOptional: false,
           },
         },
         {
@@ -74,7 +72,6 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "package",
         description: "The name of the package to install",
-        isOptional: false,
         debounce: true,
         isVariadic: false,
         generators: packageList,
@@ -93,7 +90,6 @@ const completionSpec: Fig.Spec = {
         template: "filepaths",
         name: "source files",
         description: "The source files to compile",
-        isOptional: false,
       },
       options: [
         {
@@ -114,7 +110,6 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "output file",
             description: "Name and location of output",
-            isOptional: false,
           },
         },
         {
@@ -123,7 +118,6 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "output json",
             description: "Name and location of output",
-            isOptional: false,
           },
         },
       ],


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature: Support for [Elm](https://elm-lang.org/)'s cli

**What is the new behavior (if this is a feature change)?**
Support all of the `elm` cli commands:
- `elm repl`
- `elm init`
- `elm reactor`
- `elm make`
- `elm install`
- `elm bump`
- `elm diff`
- `elm publish`

Includes suggestions for the packages that can be installed as well.

**Additional info:**
Recording of the install suggestions:
https://user-images.githubusercontent.com/1542461/142098308-65a6b161-d8de-4de3-b187-8499d7ac9c49.mp4
