### PR TITLE
Add prisma to the list of pip packages

### DIFF
--- a/src/pip.ts
+++ b/src/pip.ts
@@ -16019,6 +16019,10 @@ export const packageList: Array<Fig.Suggestion> = [
     name: "pytest-replay",
     icon: "📦",
   },
+  {
+    name: "prisma",
+    icon: "📦",
+  },
 ];
 
 const completionSpec: Fig.Spec = {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

**What is the current behavior? (You can also link to an open issue here)**

N/A

**What is the new behavior (if this is a feature change)?**

Suggests `prisma` when using `pip install`

**Additional info:**

The https://pypi.org/project/prisma/ package comes bundled with the `prisma` CLI which already has autocomplete support!

Full disclosure, I am the creator of the PyPi package, source code: https://github.com/RobertCraigie/prisma-client-py