### PR TITLE
feat: add `Remix` to autocomplete

### DIFF
--- a/src/npx.ts
+++ b/src/npx.ts
@@ -71,6 +71,10 @@ const suggestions: Fig.Suggestion[] = [
     icon:
       "https://raw.githubusercontent.com/remotion-dev/remotion/main/packages/docs/static/img/logo-small.png",
   },
+  {
+    name: "remix",
+    icon: "https://remix.run/favicon-light.1.png",
+  },
 ];
 
 const completionSpec: Fig.Spec = {

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -1,0 +1,61 @@
+const icon = "https://remix.run/favicon-light.1.png";
+
+const dirArgument: Fig.Arg = {
+  name: "dir",
+  description: "Represent the directory of the Remix application",
+  template: "folders",
+  isOptional: true,
+};
+
+const completionSpec: Fig.Spec = {
+  name: "remix",
+  description: "Remix CLI to start, build and export your application",
+  options: [
+    {
+      name: "--help",
+      description: "Output usage information",
+    },
+    {
+      name: ["-v", "--version"],
+      description: "Output the version number",
+    },
+  ],
+  subcommands: [
+    {
+      name: "build",
+      description: "Create an optimized production build of your application",
+      icon,
+      args: dirArgument,
+      options: [
+        {
+          name: "--sourcemap",
+          description: "Enables production sourcemap",
+        },
+      ],
+    },
+    {
+      name: "dev",
+      description: "Start the application in development mode",
+      icon,
+      args: dirArgument,
+    },
+    {
+      name: "setup",
+      description:
+        "Prepare node_modules/remix folder (after installation of packages)",
+      icon,
+      args: dirArgument,
+    },
+    {
+      name: "routes",
+      description: "Generate the route config of the application",
+      icon,
+      args: dirArgument,
+      options: [
+        { name: "--json", description: "Print the route config as JSON" },
+      ],
+    },
+  ],
+};
+
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature add [Remix](https://remix.run/)

**What is the current behavior? (You can also link to an open issue here)**

No autocomplete for Remix CLI

**What is the new behavior (if this is a feature change)?**

Add's autocomplete for Remix CLI

**Additional info:**

[Discord discussion](https://discord.com/channels/837809111248535583/839904572993568820/915308587746725968)