### PR TITLE
feat: add `create-remix` to autocomplete

### DIFF
--- a/src/create-remix.ts
+++ b/src/create-remix.ts
@@ -1,0 +1,16 @@
+const completionSpec: Fig.Spec = {
+  name: "create-remix",
+  icon: "https://remix.run/favicon-light.1.png",
+  options: [
+    {
+      name: ["-h", "--help"],
+      description: "Display help for command",
+    },
+    {
+      name: ["-v", "--version"],
+      description: "Display version for command",
+    },
+  ],
+};
+
+export default completionSpec;

--- a/src/npx.ts
+++ b/src/npx.ts
@@ -72,6 +72,10 @@ const suggestions: Fig.Suggestion[] = [
       "https://raw.githubusercontent.com/remotion-dev/remotion/main/packages/docs/static/img/logo-small.png",
   },
   {
+    name: "create-remix",
+    icon: "https://remix.run/favicon-light.1.png",
+  },
+  {
     name: "remix",
     icon: "https://remix.run/favicon-light.1.png",
   },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature add [create-remix](https://remix.run/)

**What is the current behavior? (You can also link to an open issue here)**

No autocomplete for `create-remix`

**What is the new behavior (if this is a feature change)?**

Add autocomplete to `create-remix`