### PR TITLE
Add DOM to tsconfig lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "./build",
     "target": "ESNext",
     "module": "ESNext",
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "noImplicitAny": false,
     "allowSyntheticDefaultImports": true,
     "baseUrl": "./",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds `"DOM"` to the `lib` array in tsconfig.json

**What is the current behavior? (You can also link to an open issue here)**
Lots of specs use `console` to log information and errors, but because it's part of the DOM API it's a type error because TS hasn't been told that it's valid in this context. It doesn't fail at build time.

**What is the new behavior (if this is a feature change)?**
Using `console` is no longer a type error, so you can `log` away in peace. Be free from accidentally auto-importing `isConstructorDeclaration`!