### PR TITLE
fix(git): correct behavior of treeish with reset

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -176,7 +176,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
 
   treeish: {
     script: "git --no-optional-locks diff --cached --name-only",
-    postProcess: function (out) {
+    postProcess: function (out, tokens) {
       const output = filterMessages(out);
 
       if (output.startsWith("fatal:")) {
@@ -186,7 +186,7 @@ const gitGenerators: Record<string, Fig.Generator> = {
       return output.split("\n").map((file) => {
         return {
           name: file,
-          insertValue: "-- " + file,
+          insertValue: !tokens.includes("--") ? "-- " : "" + file,
           icon: `fig://icon?type=file`,
           description: "Staged file",
         };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

Fixes #776

**What is the new behavior (if this is a feature change)?**

When using `git reset ...` subcommand, examine whether the string
includes the `--` before adding it again.

**Additional info:**