### PR TITLE
feat: add options for `pyenv versions`

### DIFF
--- a/src/pyenv.ts
+++ b/src/pyenv.ts
@@ -136,6 +136,16 @@ const completionSpec: Fig.Spec = {
       name: "versions",
       description:
         "Lists all Python versions known to pyenv, and shows an asterisk next to the currently active version",
+      options: [
+        {
+          name: "--bare",
+          description: "Print only the version names, one per line",
+        },
+        {
+          name: "--skip-aliases",
+          description: "Skip printing aliases",
+        },
+      ],
     },
     {
       name: "which",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

**What is the current behavior? (You can also link to an open issue here)**

No options are displayed for `pyenv versions`

**What is the new behavior (if this is a feature change)?**

<img width="455" alt="Screen Shot 2021-12-17 at 9 56 01 PM" src="https://user-images.githubusercontent.com/529516/146626698-e7a380bb-ced9-43a9-b3d6-b6845d689886.png">

**Additional info:**