### PR TITLE
typo: fix link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ A few things to keep in mind when writing your spec:
 
 - Ensure that the argument field is filled for subcommands and options when an argument is required.
 - Make sure all generators are written with valid JavaScript.
-- [Test your spec](https://fig.io/docs/autocomplete#testing-your-first-completion-spec) before submitting a pull request.
+- [Test your spec](https://fig.io/docs/getting-started#testing-your-first-completion-spec) before submitting a pull request.
 
 **Git Commit Messages**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ A few things to keep in mind when writing your spec:
 
 - Ensure that the argument field is filled for subcommands and options when an argument is required.
 - Make sure all generators are written with valid JavaScript.
-- [Test your spec](https://fig.io/docs/autocomplete#testing-your-completion-spec) before submitting a pull request.
+- [Test your spec](https://fig.io/docs/autocomplete#testing-your-first-completion-spec) before submitting a pull request.
 
 **Git Commit Messages**
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs typo.

**What is the current behavior? (You can also link to an open issue here)**

The link does not exist.

**What is the new behavior (if this is a feature change)?**

This new link is what the old heading was renamed to.

**Additional info:**

- [ ] ~Add me as codeowner of new files (you will be added as a codeowner of the files added in this PR)~ 👎 