### PR TITLE
Added npm 'run' parser directives to yarn

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -143,6 +143,17 @@ export const npmScriptsGenerator: Fig.Generator = {
   },
 };
 
+export const npmParserDirectives: Fig.Arg["parserDirectives"] = {
+  alias: async (token, executeShellCommand) => {
+    const out = await executeShellCommand("cat $(npm prefix)/package.json");
+    const script: string = JSON.parse(out).scripts?.[token];
+    if (!script) {
+      throw new Error(`Script not found: '${token}'`);
+    }
+    return script;
+  },
+};
+
 const workSpaceOptions: Fig.Option[] = [
   {
     name: "-wl--workspace",
@@ -369,20 +380,9 @@ const completionSpec: Fig.Spec = {
       ],
       args: {
         name: "script",
-        description: "Run scripts from your package.json",
+        description: "Script to run from your package.json",
         generators: npmScriptsGenerator,
-        parserDirectives: {
-          alias: async (token, executeShellCommand) => {
-            const out = await executeShellCommand(
-              "cat $(npm prefix)/package.json"
-            );
-            const script: string = JSON.parse(out).scripts?.[token];
-            if (!script) {
-              throw new Error("Alias not found");
-            }
-            return script;
-          },
-        },
+        parserDirectives: npmParserDirectives,
         isCommand: true,
       },
     },

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1,4 +1,8 @@
-import { npmScriptsGenerator, npmSearchGenerator } from "./npm";
+import {
+  npmParserDirectives,
+  npmScriptsGenerator,
+  npmSearchGenerator,
+} from "./npm";
 
 export const nodeClis = [
   "vue",
@@ -382,6 +386,7 @@ const completionSpec: Fig.Spec = {
   },
   args: {
     generators: npmScriptsGenerator,
+    parserDirectives: npmParserDirectives,
     isOptional: true,
   },
   options: [
@@ -1230,28 +1235,17 @@ const completionSpec: Fig.Spec = {
         { name: ["-h", "--help"], description: "Output usage information" },
       ],
       args: [
-        // TODO get this generator to work and combine the logic of both of these
-        //     {
-        //         generators: {
-        //            script: "ls -1 $(yarn bin)", // ISSUE: this runs in /bin/sh, yarn may not be defined in sh PATH
-        //            splitOn: "\n",
-        //            postProcess: function (out) {
-        //                try {
-        //                    if (out) {
-        //                        return out
-        //                    }
-        //                } catch(e) { }
-        //                return []
-        //            }
-        //           }
-        //     },
         {
+          name: "script",
+          description: "Script to run from your package.json",
           generators: npmScriptsGenerator,
+          parserDirectives: npmParserDirectives,
+          isCommand: true,
         },
         {
           name: "env",
           suggestions: ["env"],
-          description: "Lists enviornment variables available to scripts",
+          description: "Lists environment variables available to scripts",
           isOptional: true,
         },
       ],


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature

**What is the current behavior? (You can also link to an open issue here)**

Fixes #718 

**What is the new behavior (if this is a feature change)?**

Adds the same npm parser directives to `yarn` and `yarn run` in its completion spec. They're now exported and reused as `npmParserDirectives`.

**Additional info:**

- [ ] ~Add me as codeowner of new files (you will be added as a codeowner of the files added in this PR)~ 👎 

I didn't see any existing unit tests for these files to add to. Is there more testing you'd like me to commit?