### PR TITLE
Add Exercism support

### DIFF
--- a/src/exercism.ts
+++ b/src/exercism.ts
@@ -1,0 +1,173 @@
+const helpOption: Fig.Option[] = [
+  {
+    name: ["-h", "--help"],
+    description: "More information about command",
+  },
+];
+
+const completionSpec: Fig.Spec = {
+  name: "exercism",
+  description: "Solve coding exercises in your chosen programming languages",
+  subcommands: [
+    {
+      name: ["configure", "c"],
+      description: "Configure the command-line client",
+      options: [
+        ...helpOption,
+        {
+          name: ["-a", "--api"],
+          description: "API base url",
+          args: {
+            name: "url",
+            isOptional: false,
+          },
+        },
+        {
+          name: "--no-verify",
+          description: "Skip online token authorization check",
+        },
+        {
+          name: ["-s", "--show"],
+          description: "Show the current configuration",
+        },
+        {
+          name: ["-t", "--token"],
+          description: "Auth token used to connect to the site",
+          args: {
+            name: "token",
+            isOptional: false,
+          },
+        },
+        {
+          name: ["-w", "--workspace"],
+          description: "Directory for exercism exercises",
+          args: {
+            name: "path",
+            template: "folders",
+            isOptional: false,
+          },
+        },
+      ],
+    },
+    {
+      name: ["download", "d"],
+      description: "Download an exercise",
+      options: [
+        ...helpOption,
+        {
+          name: ["-e", "--exercise"],
+          description: "The exercise slug",
+          args: {
+            name: "exercise",
+            isOptional: false,
+          },
+        },
+        {
+          name: ["-T", "--team"],
+          description: "The team slug",
+          args: {
+            name: "team",
+            isOptional: false,
+          },
+        },
+        {
+          name: ["-t", "--track"],
+          description: "The track ID",
+          args: {
+            name: "track",
+            isOptional: false,
+          },
+        },
+        {
+          name: ["-u", "--uuid"],
+          description: "The solution UUID",
+          args: {
+            name: "uuid",
+            isOptional: false,
+          },
+        },
+      ],
+    },
+    {
+      name: "help",
+      description: "Help about any command",
+      options: [...helpOption],
+    },
+    {
+      name: ["open", "o"],
+      description: "Open an exercise on the website",
+      options: [...helpOption],
+      args: {
+        name: "path",
+        template: "folders",
+        isOptional: false,
+      },
+    },
+    {
+      name: ["prepare", "p"],
+      description: "Prepare does setup for Exercism and its tracks",
+      options: [...helpOption],
+    },
+    {
+      name: ["submit", "s"],
+      description: "Submit your solution to an exercise",
+      args: {
+        name: "file",
+        description: "The files you want to submit",
+        template: "filepaths",
+        isOptional: false,
+        isVariadic: true,
+      },
+      options: [...helpOption],
+    },
+    {
+      name: ["troubleshoot", "t", "debug"],
+      description: "Troubleshoot does a diagnostic self-check",
+      options: [
+        ...helpOption,
+        {
+          name: ["-f", "--full-api-key"],
+          description: "Display the user's full API key",
+        },
+      ],
+    },
+    {
+      name: ["upgrade", "u"],
+      description: "Upgrade to the latest version of the CLI",
+      options: [...helpOption],
+    },
+    {
+      name: ["version", "v"],
+      description: "Version outputs the version of CLI",
+      options: [...helpOption],
+    },
+    {
+      name: ["workspace", "w"],
+      description: "Print out the path to your Exercism workspace",
+      options: [...helpOption],
+    },
+  ],
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for exercism",
+    },
+    {
+      name: "--timeout",
+      description: "Override the default HTTP timeout",
+      args: {
+        name: "value",
+        isOptional: false,
+      },
+    },
+    {
+      name: "--unmask-token",
+      description: "Will unmask the API during a request/response dump",
+    },
+    {
+      name: ["--verbose", "-v"],
+      description: "Verbose output",
+    },
+  ],
+};
+export default completionSpec;

--- a/src/exercism.ts
+++ b/src/exercism.ts
@@ -1,10 +1,3 @@
-const helpOption: Fig.Option[] = [
-  {
-    name: ["-h", "--help"],
-    description: "More information about command",
-  },
-];
-
 const completionSpec: Fig.Spec = {
   name: "exercism",
   description: "Solve coding exercises in your chosen programming languages",
@@ -13,7 +6,6 @@ const completionSpec: Fig.Spec = {
       name: ["configure", "c"],
       description: "Configure the command-line client",
       options: [
-        ...helpOption,
         {
           name: ["-a", "--api"],
           description: "API base url",
@@ -53,7 +45,6 @@ const completionSpec: Fig.Spec = {
       name: ["download", "d"],
       description: "Download an exercise",
       options: [
-        ...helpOption,
         {
           name: ["-e", "--exercise"],
           description: "The exercise slug",
@@ -91,12 +82,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "help",
       description: "Help about any command",
-      options: [...helpOption],
     },
     {
       name: ["open", "o"],
       description: "Open an exercise on the website",
-      options: [...helpOption],
       args: {
         name: "path",
         template: "folders",
@@ -106,7 +95,6 @@ const completionSpec: Fig.Spec = {
     {
       name: ["prepare", "p"],
       description: "Prepare does setup for Exercism and its tracks",
-      options: [...helpOption],
     },
     {
       name: ["submit", "s"],
@@ -118,13 +106,11 @@ const completionSpec: Fig.Spec = {
         isOptional: false,
         isVariadic: true,
       },
-      options: [...helpOption],
     },
     {
       name: ["troubleshoot", "t", "debug"],
       description: "Troubleshoot does a diagnostic self-check",
       options: [
-        ...helpOption,
         {
           name: ["-f", "--full-api-key"],
           description: "Display the user's full API key",
@@ -134,27 +120,26 @@ const completionSpec: Fig.Spec = {
     {
       name: ["upgrade", "u"],
       description: "Upgrade to the latest version of the CLI",
-      options: [...helpOption],
     },
     {
       name: ["version", "v"],
       description: "Version outputs the version of CLI",
-      options: [...helpOption],
     },
     {
       name: ["workspace", "w"],
       description: "Print out the path to your Exercism workspace",
-      options: [...helpOption],
     },
   ],
   options: [
     {
       name: ["--help", "-h"],
-      description: "Show help for exercism",
+      description: "Help for this command",
+      isPersistent: true,
     },
     {
       name: "--timeout",
       description: "Override the default HTTP timeout",
+      isPersistent: true,
       args: {
         name: "value",
         isOptional: false,
@@ -163,11 +148,14 @@ const completionSpec: Fig.Spec = {
     {
       name: "--unmask-token",
       description: "Will unmask the API during a request/response dump",
+      isPersistent: true,
     },
     {
       name: ["--verbose", "-v"],
       description: "Verbose output",
+      isPersistent: true,
     },
   ],
 };
+
 export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature: Add completion spec for Exercism CLI

**What is the current behavior? (You can also link to an open issue here)**
Currently, there are no completion options for the `exercism` command.

**What is the new behavior (if this is a feature change)?**
There will be completion options available for the `exercism` command.

**Additional info:**
https://exercism.org/docs/using/solving-exercises/working-locally