### PR TITLE
Add xed spec

### DIFF
--- a/src/xed.ts
+++ b/src/xed.ts
@@ -33,6 +33,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["--help", "-h"],
       description: "Show help for xed",
+      exclusiveOn: ["-x", "-c", "-w", "-l", "-b", "-v"],
     },
     {
       name: ["--version", "-v"],

--- a/src/xed.ts
+++ b/src/xed.ts
@@ -1,0 +1,52 @@
+const completionSpec: Fig.Spec = {
+  name: "xed",
+  description: "Xcode text editor invocation tool",
+  options: [
+    {
+      name: ["--launch", "-x"],
+      description: "Launches Xcode, opening a new empty unsaved file",
+    },
+    {
+      name: ["--create", "-c"],
+      description:
+        "Creates any non-existent files in the file list. If used without --launch, standard input will be read and piped to the last file created",
+    },
+    {
+      name: ["--wait", "-w"],
+      description:
+        "Wait for the files to be closed before exiting. xed will idle and will only terminate when all files are closed",
+    },
+    {
+      name: ["--line", "-l"],
+      description: "Selects the given line in the last file opened",
+      args: {
+        name: "number",
+        description: "The line number to select",
+        isOptional: false,
+      },
+    },
+    {
+      name: ["--background", "-b"],
+      description:
+        "Opens Xcode without activating it; the process that invoked xed remains in front",
+    },
+    {
+      name: ["--help", "-h"],
+      description: "Show help for xed",
+    },
+    {
+      name: ["--version", "-v"],
+      description: "Prints the version number of xed",
+    },
+  ],
+  args: {
+    name: "file",
+    description:
+      "A list of file paths. If no files are passed, then standard input will \
+      be read and piped into a new untitled document",
+    isVariadic: true,
+    isOptional: true,
+    template: "filepaths",
+  },
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This PR adds a spec for the `xed` xcode invocation command.

**Additional info:**
I checked the [contribution guidelines](https://fig.io/docs/getting-started/contributing) but didn't see any PR template.

For the most part, this is just a rip from the xed man page. Some of the command descriptions were a little more verbose there, so I tried to summarize as best as I could.

Hopefully this works!

Thanks, looking forward to the review 😎

man page:
<img width="1080" alt="image" src="https://user-images.githubusercontent.com/26192517/148478995-950aa93b-e2f3-4101-afd6-c33121219d9f.png">
