### PR TITLE
Ignore index.d.ts when linting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+build/index.d.ts


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix
**What is the current behavior? (You can also link to an open issue here)**
See description https://github.com/withfig/autocomplete/pull/825
**What is the new behavior (if this is a feature change)?**
Linting no longer fails
**Additional info:**