### PR TITLE
feat(eb): add `clone` subcommand

### DIFF
--- a/src/eb.ts
+++ b/src/eb.ts
@@ -166,6 +166,15 @@ const completionSpec: Fig.Spec = {
             description: "Number of instances",
           },
         },
+        {
+          name: "--tags",
+          description:
+            "Tags for the resources in your environment in a comma-separated list with the format name=value",
+          args: {
+            name: "name=value",
+            description: "Tags for the resources in your environment",
+          },
+        },
       ],
     },
     {

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -130,6 +130,24 @@ const completionSpec: Fig.Spec = {
         name: "environment-name",
         description: "The name of the environment to clone",
       },
+      options: [
+        {
+          name: ["-n", "--clone_name"],
+          description: "Desired name for the cloned environment",
+          args: {
+            name: "string",
+            description: "The name for the cloned environment",
+          },
+        },
+        {
+          name: ["-c", "--cname"],
+          description: "Desired CNAME prefix for the cloned environment",
+          args: {
+            name: "cname",
+            description: "CNAME prefix",
+          },
+        },
+      ],
     },
     {
       name: "open",

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -157,6 +157,15 @@ const completionSpec: Fig.Spec = {
           description:
             "Prevents Elastic Beanstalk from updating the solution stack version for the new clone environment to the most recent version available",
         },
+        {
+          name: "--scale",
+          description:
+            "The number of instances to run in the clone environment when it is launched",
+          args: {
+            name: "number",
+            description: "Number of instances",
+          },
+        },
       ],
     },
     {

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -175,6 +175,10 @@ const completionSpec: Fig.Spec = {
             description: "Tags for the resources in your environment",
           },
         },
+        {
+          name: "--timeout",
+          description: "The number of minutes before the command times out",
+        },
       ],
     },
     {

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -152,6 +152,11 @@ const completionSpec: Fig.Spec = {
           description:
             "Environment properties in a comma-separated list with the format name=value",
         },
+        {
+          name: "--exact",
+          description:
+            "Prevents Elastic Beanstalk from updating the solution stack version for the new clone environment to the most recent version available",
+        },
       ],
     },
     {

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -131,6 +131,15 @@ const completionSpec: Fig.Spec = {
         description: "The name of the environment to clone",
       },
     },
+    {
+      name: "open",
+      description:
+        "Opens the public URL of your website in the default browser",
+      args: {
+        name: "environment-name",
+        description: "The name of the environment to open",
+      },
+    },
   ],
 };
 

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -122,6 +122,15 @@ const completionSpec: Fig.Spec = {
       name: "abort",
       description: "Abort the current running process",
     },
+    {
+      name: "clone",
+      description:
+        "Clones an environment to a new environment so that both have identical environment settings",
+      args: {
+        name: "environment-name",
+        description: "The name of the environment to clone",
+      },
+    },
   ],
 };
 

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -147,6 +147,11 @@ const completionSpec: Fig.Spec = {
             description: "CNAME prefix",
           },
         },
+        {
+          name: "--envvars",
+          description:
+            "Environment properties in a comma-separated list with the format name=value",
+        },
       ],
     },
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
It doesn't support all the `eb` commands of AWS

**What is the new behavior (if this is a feature change)?**
Now fig supports `clone` subcommands and all it's options. Also, `open` subcommand was added

**Additional info:**
I will be working to add all the commands of `eb`