### PR TITLE
fix(build): target `ES6`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "outDir": "./build",
-    "target": "ESNext",
+    "target": "ES6",
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
     "noImplicitAny": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,6 @@
     "baseUrl": "./",
     "types": ["@withfig/autocomplete-types"]
   },
+  "exclude": ["node_modules/"],
   "include": ["./src/**/*", "dangerfile.ts"]
 }


### PR DESCRIPTION
This should fix issues concerning JS features that are not yet supported by safari or that are not supported by old safari versions.