### PR TITLE
feat: add yank completion spec

### DIFF
--- a/src/yank.ts
+++ b/src/yank.ts
@@ -1,0 +1,43 @@
+const completionSpec: Fig.Spec = {
+  name: "yank",
+  description: "Yank terminal output to clipboard",
+  options: [
+    {
+      name: "-i",
+      description: "Ignore case differences between pattern and the input",
+    },
+    { name: "-l", description: "Use the default delimiters except for space" },
+    { name: "-x", description: "Use alternate screen" },
+    { name: "-v", description: "Print the version" },
+    {
+      name: "-d",
+      description:
+        "All input characters not present in delim will be recognized as fields",
+      args: {
+        name: "delim",
+        description: "Custom delimiters",
+        isOptional: false,
+      },
+    },
+    {
+      name: "-g",
+      description: "Use pattern to recognize fields",
+      args: {
+        name: "pattern",
+        description: "Pattern to recognize fields",
+        isOptional: false,
+      },
+    },
+    {
+      name: "--",
+      description: "Use a command as the yank command",
+      args: {
+        name: "command",
+        description: "Command to use as the yank command",
+        isOptional: false,
+        isVariadic: true,
+      },
+    },
+  ],
+};
+export default completionSpec;

--- a/src/yank.ts
+++ b/src/yank.ts
@@ -16,7 +16,6 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "delim",
         description: "Custom delimiters",
-        isOptional: false,
       },
     },
     {
@@ -25,7 +24,6 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "pattern",
         description: "Pattern to recognize fields",
-        isOptional: false,
       },
     },
     {
@@ -34,7 +32,6 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "command",
         description: "Command to use as the yank command",
-        isOptional: false,
         isVariadic: true,
       },
     },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature: add support for the [`yank`](https://github.com/mptre/yank) command line tool.

**What is the current behavior? (You can also link to an open issue here)**

There is no current behavior.

**What is the new behavior (if this is a feature change)?**

New behavior is support for the `yank` command line tool.

**Additional info:**

Please let me know if there are any changes desired by the maintainers.