### PR TITLE
feat(eb): add `use` subcommand

### DIFF
--- a/src/eb.ts
+++ b/src/eb.ts
@@ -273,6 +273,16 @@ const completionSpec: Fig.Spec = {
         name: "environment-name",
         description: "The name of the environment to use",
       },
+      options: [
+        {
+          name: ["-r", "--region"],
+          description: "Change the region in which you create environments",
+          args: {
+            name: "region",
+            description: "The region to use",
+          },
+        },
+      ],
     },
   ],
 };

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -282,6 +282,14 @@ const completionSpec: Fig.Spec = {
             description: "The region to use",
           },
         },
+        {
+          name: "--source codecommit/",
+          description: "CodeCommit repository and branch",
+          args: {
+            name: "repository-name/repository-branch",
+            description: "The name of the CodeCommit repository and branch",
+          },
+        },
       ],
     },
   ],

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -283,10 +283,10 @@ const completionSpec: Fig.Spec = {
           },
         },
         {
-          name: "--source codecommit/",
+          name: "--source",
           description: "CodeCommit repository and branch",
           args: {
-            name: "repository-name/repository-branch",
+            name: "codecommit/repository-name/repository-branch",
             description: "The name of the CodeCommit repository and branch",
           },
         },

--- a/src/eb.ts
+++ b/src/eb.ts
@@ -266,6 +266,14 @@ const completionSpec: Fig.Spec = {
         },
       ],
     },
+    {
+      name: "use",
+      description: "Sets the specified environment as the default environment",
+      args: {
+        name: "environment-name",
+        description: "The name of the environment to use",
+      },
+    },
   ],
 };
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feat

**What is the current behavior? (You can also link to an open issue here)**
It doesn't support all `eb` commands from AWS

**What is the new behavior (if this is a feature change)?**
Now supports `use` subcommands and all of the options and args

**Additional info:**
None.