### PR TITLE
feat(aws/apprunner): add spec

### DIFF
--- a/src/aws/apprunner.ts
+++ b/src/aws/apprunner.ts
@@ -5,6 +5,16 @@ const completionSpec: Fig.Spec = {
     {
       name: "create-connection",
       description: "Create an app runner connection resource",
+      options: [
+        {
+          name: "--connection-name",
+          description: "Name for the new connection",
+          args: {
+            name: "name",
+            description: "Name of the connection to be created",
+          },
+        },
+      ],
     },
   ],
 };

--- a/src/aws/apprunner.ts
+++ b/src/aws/apprunner.ts
@@ -39,6 +39,11 @@ const completionSpec: Fig.Spec = {
           name: "--cli-input-yaml",
           description: "Reads arguments from the YAML string provided",
         },
+        {
+          name: "--generate-cli-skeleton",
+          description:
+            "Prints a JSON skeleton to standard output without sending an API request",
+        },
       ],
     },
   ],

--- a/src/aws/apprunner.ts
+++ b/src/aws/apprunner.ts
@@ -31,6 +31,14 @@ const completionSpec: Fig.Spec = {
             description: "A key-value pair",
           },
         },
+        {
+          name: "--cli-input-json",
+          description: "Reads arguments from the JSON string provided",
+        },
+        {
+          name: "--cli-input-yaml",
+          description: "Reads arguments from the YAML string provided",
+        },
       ],
     },
   ],

--- a/src/aws/apprunner.ts
+++ b/src/aws/apprunner.ts
@@ -1,0 +1,6 @@
+const completionSpec: Fig.Spec = {
+  name: "apprunner",
+  description: "AWS apprunner commands",
+};
+
+export default completionSpec;

--- a/src/aws/apprunner.ts
+++ b/src/aws/apprunner.ts
@@ -1,6 +1,12 @@
 const completionSpec: Fig.Spec = {
   name: "apprunner",
   description: "AWS apprunner commands",
+  subcommands: [
+    {
+      name: "create-connection",
+      description: "Create an app runner connection resource",
+    },
+  ],
 };
 
 export default completionSpec;

--- a/src/aws/apprunner.ts
+++ b/src/aws/apprunner.ts
@@ -22,6 +22,15 @@ const completionSpec: Fig.Spec = {
             description: "Repository provider",
           },
         },
+        {
+          name: "--tags",
+          description:
+            "A list of metadata items that you can associate with your connection resource. A tag is a key-value pair",
+          args: {
+            name: "key=value",
+            description: "A key-value pair",
+          },
+        },
       ],
     },
   ],

--- a/src/aws/apprunner.ts
+++ b/src/aws/apprunner.ts
@@ -14,6 +14,14 @@ const completionSpec: Fig.Spec = {
             description: "Name of the connection to be created",
           },
         },
+        {
+          name: "--provider-type",
+          description: "The source repository provider",
+          args: {
+            name: "provider",
+            description: "Repository provider",
+          },
+        },
       ],
     },
   ],


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feat

**What is the current behavior? (You can also link to an open issue here)**
It doesn't support any of `aws apprunner` commands

**What is the new behavior (if this is a feature change)?**
Now `aws apprunner create-connection` and all of its options are supported

**Additional info:**