### PR TITLE
feat: update mkdir completion

### DIFF
--- a/src/mkdir.ts
+++ b/src/mkdir.ts
@@ -3,6 +3,7 @@ const completionSpec: Fig.Spec = {
   description: "Make directories",
   args: {
     name: "directory name",
+    template: "folders",
   },
   options: [
     {

--- a/src/mkdir.ts
+++ b/src/mkdir.ts
@@ -4,6 +4,7 @@ const completionSpec: Fig.Spec = {
   args: {
     name: "directory name",
     template: "folders",
+    suggestCurrentToken: true,
   },
   options: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds folder completion to the `mkdir` command.

**What is the current behavior? (You can also link to an open issue here)**
Currently, if I’m at ~ and I’m trying to make a new folder in ~/Desktop/work/, I have to manually type in `mkdir Desktop/work/<folder name>`. There is no autocomplete for “Desktop/work/”.

**What is the new behavior (if this is a feature change)?**
If I am at ~ and I’m trying to make a new folder in ~/Desktop/work/, I will see my list of folders in the cwd as soon as I type `mkdir `. Then I will be able to autocomplete Desktop/ and same for work/.

**Additional info:**