### PR TITLE
feat: add task completion spec

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -1,5 +1,35 @@
-// build out the project suggestions
-const handleProjectFilters = (tasks) => {
+const RECURRING_STRINGS = [
+  "daily",
+  "day",
+  "1da",
+  "2da",
+  "weekdays",
+  "weekly",
+  "1wk",
+  "2wk",
+  "biweekly",
+  "fortnight",
+  "monthly",
+  "month",
+  "1mo",
+  "2mo",
+  "quarterly",
+  "1qtr",
+  "3qtr",
+  "semiannual",
+  "annual",
+  "yearly",
+  "1yr",
+  "2yrs",
+];
+
+// build out the available recurring strings
+const buildRecurringSuggestions = () => {
+  return RECURRING_STRINGS.map((recur) => `recur:${recur}`);
+};
+
+// build out the available project suggestions
+const buildProjectSuggestions = (tasks) => {
   const projects = tasks
     .filter((task) => task.status !== "completed")
     .reduce((acc, task) => {
@@ -55,8 +85,19 @@ const DEFAULT_TAGS = [
   "WEEK",
 ];
 
-// build the tag suggestions
-const handleTagFilters = (tasks) => {
+// build out list of the default tags for the filters
+const buildDefaultTagSuggestions = () => {
+  return DEFAULT_TAGS.map((tag) => {
+    return {
+      name: `+${tag}`,
+      displayName: `Tag: ${tag}`,
+      icon: "🏷",
+    };
+  });
+};
+
+// build the available tag suggestions
+const buildTagSuggestions = (tasks) => {
   const tags = [
     ...new Set(
       tasks
@@ -66,7 +107,7 @@ const handleTagFilters = (tasks) => {
     ),
   ];
 
-  return [...DEFAULT_TAGS, ...tags].map((tag) => {
+  return tags.map((tag) => {
     return {
       name: `+${tag}`,
       displayName: `Tag: ${tag}`,
@@ -75,8 +116,28 @@ const handleTagFilters = (tasks) => {
   });
 };
 
+// build the available untag suggestions
+const buildUnTagSuggestions = (tasks) => {
+  const tags = [
+    ...new Set(
+      tasks
+        .filter((task) => task.hasOwnProperty("tags"))
+        .map((task) => task.tags)
+        .flat()
+    ),
+  ];
+
+  return tags.map((tag) => {
+    return {
+      name: `-${tag}`,
+      displayName: `Untag: ${tag}`,
+      icon: "❌",
+    };
+  });
+};
+
 // build out the task suggestions
-const handleIdFilters = (tasks) => {
+const buildTaskSuggestions = (tasks) => {
   return tasks
     .filter((task) => task.status !== "completed")
     .map((task) => {
@@ -89,7 +150,8 @@ const handleIdFilters = (tasks) => {
     });
 };
 
-const DATES = [
+// taskwarrior default date strings
+const DATE_STRINGS = [
   "now",
   "today",
   "sod",
@@ -130,24 +192,40 @@ const DATES = [
   "eoww",
 ];
 
-// build the due type filters
-const dueArray = () => {
+// build the date suggestion attributes
+const buildDateSuggestions = () => {
   return [
-    ...DATES.map((date) => `due:${date}`),
-    ...DATES.map((date) => `due.by:${date}`),
-    ...DATES.map((date) => `due.before:${date}`),
-    ...DATES.map((date) => `due.after:${date}`),
+    ...DATE_STRINGS.map((date) => `due:${date}`),
+    ...DATE_STRINGS.map((date) => `due.by:${date}`),
+    ...DATE_STRINGS.map((date) => `due.before:${date}`),
+    ...DATE_STRINGS.map((date) => `due.after:${date}`),
+    ...DATE_STRINGS.map((date) => `scheduled:${date}`),
+    ...DATE_STRINGS.map((date) => `scheduled.by:${date}`),
+    ...DATE_STRINGS.map((date) => `scheduled.before:${date}`),
+    ...DATE_STRINGS.map((date) => `scheduled.after:${date}`),
+    ...DATE_STRINGS.map((date) => `until:${date}`),
+    ...DATE_STRINGS.map((date) => `until.by:${date}`),
+    ...DATE_STRINGS.map((date) => `until.before:${date}`),
+    ...DATE_STRINGS.map((date) => `until.after:${date}`),
+    ...DATE_STRINGS.map((date) => `wait:${date}`),
+    ...DATE_STRINGS.map((date) => `wait.by:${date}`),
+    ...DATE_STRINGS.map((date) => `wait.before:${date}`),
+    ...DATE_STRINGS.map((date) => `wait.after:${date}`),
+    ...DATE_STRINGS.map((date) => `entry:${date}`),
+    ...DATE_STRINGS.map((date) => `entry.by:${date}`),
+    ...DATE_STRINGS.map((date) => `entry.before:${date}`),
+    ...DATE_STRINGS.map((date) => `entry.after:${date}`),
   ];
 };
 
-const PRIORITES = ["H", "M", "L"];
+const PRIORITIES = ["H", "M", "L"];
 
 // build the avilable priorites
-const prioritesArray = () => {
+const buildPrioritiesSuggestions = () => {
   return [
-    ...PRIORITES.map((pr) => `priority:${pr}`),
-    ...PRIORITES.map((pr) => `priority.is:${pr}`),
-    ...PRIORITES.map((pr) => `priority.not:${pr}`),
+    ...PRIORITIES.map((pr) => `priority:${pr}`),
+    ...PRIORITIES.map((pr) => `priority.is:${pr}`),
+    ...PRIORITIES.map((pr) => `priority.not:${pr}`),
     "priority.none:",
   ];
 };
@@ -160,11 +238,12 @@ const filtersWithTasks: Fig.Generator = {
   postProcess: (output) => {
     const tasks = JSON.parse(output);
     const filters = [
-      ...handleIdFilters(tasks),
-      ...handleProjectFilters(tasks),
-      ...handleTagFilters(tasks),
-      ...prioritesArray(),
-      ...dueArray(),
+      ...buildTaskSuggestions(tasks),
+      ...buildProjectSuggestions(tasks),
+      ...buildTagSuggestions(tasks),
+      ...buildDefaultTagSuggestions(),
+      ...buildPrioritiesSuggestions(),
+      ...buildDateSuggestions(),
     ];
     return filters;
   },
@@ -177,10 +256,11 @@ const listTasks: Fig.Generator = {
   },
   postProcess: (output) => {
     const tasks = JSON.parse(output);
-    return handleIdFilters(tasks);
+    return buildTaskSuggestions(tasks);
   },
 };
 
+// build filter suggestions
 const filters: Fig.Generator = {
   script: function (context) {
     return `task export`;
@@ -188,8 +268,31 @@ const filters: Fig.Generator = {
   postProcess: (output) => {
     const tasks = JSON.parse(output);
     const filters = [
-      ...handleProjectFilters(tasks),
-      ...handleTagFilters(tasks),
+      ...buildProjectSuggestions(tasks),
+      ...buildTagSuggestions(tasks),
+      ...buildDefaultTagSuggestions(),
+      ...buildPrioritiesSuggestions(),
+      ...buildDateSuggestions(),
+    ];
+    return filters;
+  },
+};
+
+// build modifications suggestions
+const modifications: Fig.Generator = {
+  script: function (context) {
+    return `task export`;
+  },
+  postProcess: (output) => {
+    const tasks = JSON.parse(output);
+    const filters = [
+      ...buildProjectSuggestions(tasks),
+      ...buildTagSuggestions(tasks),
+      ...buildUnTagSuggestions(tasks),
+      ...buildDefaultTagSuggestions(),
+      ...buildPrioritiesSuggestions(),
+      ...buildDateSuggestions(),
+      ...buildRecurringSuggestions(),
     ];
     return filters;
   },
@@ -202,6 +305,7 @@ const completionSpec: Fig.Spec = {
     name: "filters",
     description: "Search criteria that select tasks",
     isOptional: true,
+    isVariadic: true,
     generators: filtersWithTasks,
   },
   subcommands: [
@@ -213,6 +317,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -224,6 +329,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -235,6 +341,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -246,6 +353,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -257,6 +365,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -268,6 +377,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -279,6 +389,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -290,16 +401,19 @@ const completionSpec: Fig.Spec = {
           name: "year",
           description: "The year number",
           isOptional: true,
+          isVariadic: true,
         },
         {
           name: "month",
           description: "The year number",
           isOptional: true,
+          isVariadic: true,
         },
         {
           name: "due",
           description: "Show tasks that are due",
           isOptional: true,
+          isVariadic: true,
         },
       ],
     },
@@ -333,6 +447,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -344,6 +459,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -354,6 +470,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -364,6 +481,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -374,6 +492,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -384,6 +503,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -394,6 +514,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -408,6 +529,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -418,6 +540,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -428,6 +551,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -438,6 +562,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -449,6 +574,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -460,6 +586,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -475,6 +602,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -486,6 +614,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -496,6 +625,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -506,6 +636,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -516,6 +647,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -527,6 +659,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -538,6 +671,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -548,6 +682,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -559,6 +694,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -570,6 +706,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -580,6 +717,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -591,6 +729,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -601,6 +740,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -611,7 +751,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: filters,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -621,7 +762,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: filters,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -631,7 +773,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: filters,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -641,7 +784,8 @@ const completionSpec: Fig.Spec = {
         name: "Task",
         description: "The task to delete",
         isOptional: false,
-        generators: listTasks,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -651,7 +795,7 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: filtersWithTasks,
+        generators: modifications,
       },
     },
     {
@@ -661,7 +805,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: filtersWithTasks,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -671,7 +816,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: filtersWithTasks,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -693,7 +839,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: filters,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -703,7 +850,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: filtersWithTasks,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -713,7 +861,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: listTasks,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -724,7 +873,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: filters,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -734,7 +884,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: listTasks,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -744,7 +895,8 @@ const completionSpec: Fig.Spec = {
         name: "mods",
         description: "Changes to apply to the selected tasks",
         isOptional: true,
-        generators: listTasks,
+        isVariadic: true,
+        generators: modifications,
       },
     },
     {
@@ -757,6 +909,7 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "name",
             isOptional: false,
+            isVariadic: true,
           },
         },
         {
@@ -767,11 +920,13 @@ const completionSpec: Fig.Spec = {
             {
               name: "name",
               isOptional: false,
+              isVariadic: true,
             },
             {
               name: "mods",
               description: "Changes to apply to the selected tasks",
               isOptional: true,
+              isVariadic: true,
               generators: filters,
             },
           ],
@@ -794,6 +949,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "name",
         isOptional: false,
+        isVariadic: true,
       },
     },
     {
@@ -803,6 +959,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -813,6 +970,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -823,6 +981,7 @@ const completionSpec: Fig.Spec = {
         name: "filters",
         description: "Task search criteria",
         isOptional: true,
+        isVariadic: true,
         generators: filters,
       },
     },
@@ -832,6 +991,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "weeks",
         isOptional: true,
+        isVariadic: true,
       },
     },
     {

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,0 +1,854 @@
+// build out the project suggestions
+const handleProjectFilters = (tasks) => {
+  const projects = tasks
+    .filter((task) => task.status !== "completed")
+    .reduce((acc, task) => {
+      return (
+        acc[task.project] ? ++acc[task.project] : (acc[task.project] = 1), acc
+      );
+    }, {});
+
+  const projectFilters = [];
+  for (var project in projects) {
+    projectFilters.push({
+      name: `project:${project}`,
+      displayName: `Project: ${project}`,
+      description: `${projects[project]} tasks`,
+      icon: "🗂",
+    });
+  }
+  return projectFilters;
+};
+
+const DEFAULT_TAGS = [
+  "ACTIVE",
+  "COMPLETED",
+  "LATEST",
+  "PENDING",
+  "SCHEDULED",
+  "UDA",
+  "YEAR",
+  "ANNOTATED",
+  "DELETED",
+  "MONTH",
+  "PRIORITY",
+  "TAGGED",
+  "UNBLOCKED",
+  "YESTERDAY",
+  "BLOCKED",
+  "DUE",
+  "ORPHAN",
+  "PROJECT",
+  "TEMPLATE",
+  "UNTIL",
+  "BLOCKING",
+  "DUETODAY",
+  "OVERDUE",
+  "QUARTER",
+  "TODAY",
+  "WAITING",
+  "CHILD",
+  "INSTANCE",
+  "PARENT",
+  "READY",
+  "TOMORROW",
+  "WEEK",
+];
+
+// build the tag suggestions
+const handleTagFilters = (tasks) => {
+  const tags = [
+    ...new Set(
+      tasks
+        .filter((task) => task.hasOwnProperty("tags"))
+        .map((task) => task.tags)
+        .flat()
+    ),
+  ];
+
+  return [...DEFAULT_TAGS, ...tags].map((tag) => {
+    return {
+      name: `+${tag}`,
+      displayName: `Tag: ${tag}`,
+      icon: "🏷",
+    };
+  });
+};
+
+// build out the task suggestions
+const handleIdFilters = (tasks) => {
+  return tasks
+    .filter((task) => task.status !== "completed")
+    .map((task) => {
+      return {
+        name: `${task.id}`,
+        displayName: `${task.id} - ${task.description}`,
+        description: `${task.description}`,
+        icon: "☑️",
+      };
+    });
+};
+
+const DATES = [
+  "now",
+  "today",
+  "sod",
+  "eod",
+  "yesterday",
+  "tomorrow",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+  "january",
+  "february",
+  "march",
+  "april",
+  "may",
+  "june",
+  "july",
+  "august",
+  "september",
+  "october",
+  "november",
+  "december",
+  "soy",
+  "eoy",
+  "eoq",
+  "som",
+  "socm",
+  "eom",
+  "ecom",
+  "sow",
+  "socw",
+  "eow",
+  "eocw",
+  "soww",
+  "eoww",
+];
+
+// build the due type filters
+const dueArray = () => {
+  return [
+    ...DATES.map((date) => `due:${date}`),
+    ...DATES.map((date) => `due.by:${date}`),
+    ...DATES.map((date) => `due.before:${date}`),
+    ...DATES.map((date) => `due.after:${date}`),
+  ];
+};
+
+const PRIORITES = ["H", "M", "L"];
+
+// build the avilable priorites
+const prioritesArray = () => {
+  return [
+    ...PRIORITES.map((pr) => `priority:${pr}`),
+    ...PRIORITES.map((pr) => `priority.is:${pr}`),
+    ...PRIORITES.map((pr) => `priority.not:${pr}`),
+    "priority.none:",
+  ];
+};
+
+// build the filter list with tasks
+const filtersWithTasks: Fig.Generator = {
+  script: function () {
+    return `task export`;
+  },
+  postProcess: (output) => {
+    const tasks = JSON.parse(output);
+    const filters = [
+      ...handleIdFilters(tasks),
+      ...handleProjectFilters(tasks),
+      ...handleTagFilters(tasks),
+      ...prioritesArray(),
+      ...dueArray(),
+    ];
+    return filters;
+  },
+};
+
+// build tasks list
+const listTasks: Fig.Generator = {
+  script: function (context) {
+    return `task export`;
+  },
+  postProcess: (output) => {
+    const tasks = JSON.parse(output);
+    return handleIdFilters(tasks);
+  },
+};
+
+const filters: Fig.Generator = {
+  script: function (context) {
+    return `task export`;
+  },
+  postProcess: (output) => {
+    const tasks = JSON.parse(output);
+    const filters = [
+      ...handleProjectFilters(tasks),
+      ...handleTagFilters(tasks),
+    ];
+    return filters;
+  },
+};
+
+const completionSpec: Fig.Spec = {
+  name: "task",
+  description: "A command line todo manager",
+  args: {
+    name: "filters",
+    description: "Search criteria that select tasks",
+    isOptional: true,
+    generators: filtersWithTasks,
+  },
+  subcommands: [
+    {
+      name: "active",
+      description:
+        "Shows all tasks matching the filter, that are started but not completed",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "all",
+      description:
+        "Shows all tasks matching the filter, including parents of recurring tasks",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "blocked",
+      description:
+        "Shows all tasks matching the filter, that are currently blocked by other tasks",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "blocking",
+      description:
+        "Shows all tasks matching the filter, that block other tasks",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "burndown.daily",
+      description:
+        "Shows a graphical burndown chart, by day. Is affected by the context",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "burndown.weekly",
+      description:
+        "Shows a graphical burndown chart, by week.  Note that 'burndown' is an alias to the 'burndown.weekly' report. Is affected by the context",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "burndown.monthly",
+      description:
+        "Shows a graphical burndown chart, by month. Is affected by the context",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "calendar",
+      description: "Shows a monthly calendar with due tasks marked",
+      args: [
+        {
+          name: "year",
+          description: "The year number",
+          isOptional: true,
+        },
+        {
+          name: "month",
+          description: "The year number",
+          isOptional: true,
+        },
+        {
+          name: "due",
+          description: "Show tasks that are due",
+          isOptional: true,
+        },
+      ],
+    },
+    {
+      name: "commands",
+      description:
+        "Shows all the supported commands, with some details of each",
+    },
+    {
+      name: "diagnostics",
+      description:
+        "Shows diagnostic information, of the kind needed when reporting a problem",
+    },
+    {
+      name: "logo",
+      description: "Displays the Taskwarrior logo",
+    },
+    {
+      name: "news",
+      description:
+        "Guides the user through important release notes anytime a new version of Taskwarrior is installed",
+    },
+    {
+      name: "reports",
+      description: "Lists all supported reports",
+    },
+    {
+      name: "completed",
+      description: "Shows all tasks matching the filter that are completed",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "count",
+      description:
+        "Display only a count of tasks matching the filter. Is affected by the context",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "export",
+      description: "Exports all tasks in the JSON format matching the filter",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "ghistory.annual",
+      description: "Shows a graphical report of task status by year",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "ghistory.monthly",
+      description: "Shows a graphical report of task status by month",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "ghistory.weekly",
+      description: "Shows a graphical report of task status by week",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "ghistory.daily",
+      description: "Shows a graphical report of task status by day",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "help",
+      description: "Shows the long usage text",
+    },
+    {
+      name: "history.annual",
+      description: "Shows a report of task history by year",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "history.monthly",
+      description: "Shows a report of task history by month",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "history.weekly",
+      description: "Shows a report of task history by week",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "history.daily",
+      description: "Shows a report of task history by day",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "ids",
+      description:
+        "Applies the filter then extracts only the task IDs and presents them as a space-seperated list",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "uuids",
+      description:
+        "Applies the filter on all tasks (even deleted and completed tasks) then extracts only the task UUIDs and presents them as a space-seperated list",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "udas",
+      description:
+        "Shows a list of UDAs that are defined, including their name, type, label, and allowed values",
+    },
+    {
+      name: "information",
+      description: "Shows all data and metadata for the specified tasks",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "long",
+      description:
+        "Provides the most detailed listing of tasks matching the filter",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "ls",
+      description: "Provides a short listing of tasks matching the filter",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "minimal",
+      description: "Provides a minimal listing of tasks matching the filter",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "newest",
+      description: "Shows the newest tasks matching the filter",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "next",
+      description:
+        "Shows a page of the most urgent tasks, sorted by urgency, which is a calculated value",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "ready",
+      description:
+        "Shows a page of the most urgent ready tasks, sorted by urgency with started tasks first",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "oldest",
+      description: "Shows the oldest tasks matching the filter",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "overdue",
+      description:
+        "Shows all incomplete tasks matching the fitler that are beyond their due date",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "projects",
+      description:
+        "Lists all project names that are current used by pending tasks, and the number of tasks for each",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "recurring",
+      description: "Shows all recurring tasks matching the fitler",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "unblocked",
+      description:
+        "Shows all tasks that are not currently blocked by other tasks, matching the filter",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "waiting",
+      description: "Shows all waiting tasks matching the filter",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "add",
+      description: "Adds a new pending task to the task list",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "annotate",
+      description: "Adds an annotation to an existing task",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "append",
+      description: "Appends description text to an existing task",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: ["delete", "rm"],
+      description: "Deletes the specified task from the task list",
+      args: {
+        name: "Task",
+        description: "The task to delete",
+        isOptional: false,
+        generators: listTasks,
+      },
+    },
+    {
+      name: "denotate",
+      description: "Deletes an annotation for the specified task",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: filtersWithTasks,
+      },
+    },
+    {
+      name: "done",
+      description: "Marks the specified task as done",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: filtersWithTasks,
+      },
+    },
+    {
+      name: "duplicate",
+      description: "Duplicates the specified task and allows modifications",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: filtersWithTasks,
+      },
+    },
+    {
+      name: "edit",
+      description:
+        "Launches a text editor to let you modify all aspects of a task directly",
+      args: {
+        name: "Task",
+        description: "The task to edit",
+        isOptional: false,
+        generators: listTasks,
+      },
+    },
+    {
+      name: "log",
+      description:
+        "Adds a new task that is already completed, to the task list",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "modify",
+      description: "Modifies the existing task with provided information",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: filtersWithTasks,
+      },
+    },
+    {
+      name: "prepend",
+      description: "Prepends description text to and existing task",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: listTasks,
+      },
+    },
+    {
+      name: "purge",
+      description:
+        "Permanently removes the specified tasks from the data files",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "start",
+      description: "Marks the specified tasks as started",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: listTasks,
+      },
+    },
+    {
+      name: "stop",
+      description: "Removes the start time from the specified task",
+      args: {
+        name: "mods",
+        description: "Changes to apply to the selected tasks",
+        isOptional: true,
+        generators: listTasks,
+      },
+    },
+    {
+      name: "context",
+      description: "Sets the currently active context",
+      subcommands: [
+        {
+          name: "delete",
+          description: "Deletes the context with the name",
+          args: {
+            name: "name",
+            isOptional: false,
+          },
+        },
+        {
+          name: "define",
+          description:
+            "Defines a new context with the name and definition filter",
+          args: [
+            {
+              name: "name",
+              isOptional: false,
+            },
+            {
+              name: "mods",
+              description: "Changes to apply to the selected tasks",
+              isOptional: true,
+              generators: filters,
+            },
+          ],
+        },
+        {
+          name: "list",
+          description:
+            "Outputs a list of available contexts along with their definitions",
+        },
+        {
+          name: "none",
+          description: "Clears the currently active context, if any was set",
+        },
+        {
+          name: "show",
+          description:
+            "Shows the currently active context, along with its definition",
+        },
+      ],
+      args: {
+        name: "name",
+        isOptional: false,
+      },
+    },
+    {
+      name: "stats",
+      description: "Shows statistics of the tasks defined by the filter",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "summary",
+      description: "Shows a report of aggregated task status by project",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "tags",
+      description: "Show a list of all tags used",
+      args: {
+        name: "filters",
+        description: "Task search criteria",
+        isOptional: true,
+        generators: filters,
+      },
+    },
+    {
+      name: "timesheet",
+      description: "Shows a weekly report of tasks completed and started",
+      args: {
+        name: "weeks",
+        isOptional: true,
+      },
+    },
+    {
+      name: "undo",
+      description: "Reverts the most recent action",
+    },
+    {
+      name: "version",
+      description: "Shows the Taskwarrior version number",
+    },
+  ],
+  options: [
+    {
+      name: "--version",
+      description:
+        "This is the only conventional command line argument that Taskwarrior supports, and is intended for add-on scripts to verify the version number of an installed Taskwarrior without invoking the mechanisms that create default files",
+    },
+  ],
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
New featture: Added the [task - Taskwarrior](https://taskwarrior.org/) completion spec

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**
Task warrior is a **HUGE** command line application to help manage your TODOs in the terminal.  There are lots of filters and modifications and that can be done within Taskwarrior.  This spec is not feature complete with all the filters and modifications but provides a very good start to providing users with many of the most useful and frequently used options.  Additional help would be greatly appreciated and code review to optimize handling filter suggestions and modifications.

Update - attaching a cheatsheet of the available commands in Taskwarrior.  Looking for advice on how to go about doing a better job suggesting some of the filters.  At the moment I'm currently just suggesting filters as a main argument, and also suggesting filtering to sub commands on need basis. 

<img width="870" alt="ref230" src="https://user-images.githubusercontent.com/868190/150365025-7b77e2bc-4779-4325-8466-ee161ebafad0.png">

