### PR TITLE
Set `valet link` argument as optional

### DIFF
--- a/src/valet.ts
+++ b/src/valet.ts
@@ -202,6 +202,7 @@ const completionSpec: Fig.Spec = {
       description: "Link the current working directory to Valet",
       args: {
         name: "name",
+        isOptional: true,
       },
       options: [
         global_option_secure,


### PR DESCRIPTION
In response to an email.

The `valet link` hostname argument is optional: https://laravel.com/docs/8.x/valet#the-link-command