### PR TITLE
feat: add brew command 'postinstall'

### DIFF
--- a/src/brew.ts
+++ b/src/brew.ts
@@ -742,6 +742,31 @@ const completionSpec: Fig.Spec = {
       description: "Show Homebrew and system configuration info",
     },
     {
+      name: "postinstall",
+      description: "Postinstall <formula>",
+      options: [
+        {
+          name: ["-d", "--debug"],
+          description: "Display any debugging information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Make some output more verbose",
+        },
+
+        {
+          name: ["-q", "--quiet"],
+          description: "Make some output more quiet",
+        },
+        { name: ["-h", "--help"], description: "Show this message" },
+      ],
+      args: {
+        isVariadic: true,
+        name: "formula",
+        generators: formulaeGenerator,
+      },
+    },
+    {
       name: "install",
       description: "Install <formula>",
       options: [

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -743,7 +743,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "postinstall",
-      description: "Postinstall <formula>",
+      description: "Rerun the post install step for formula",
       options: [
         {
           name: ["-d", "--debug"],


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

it fixes a missing `brew` command: `brew postinstall`.




**What is the current behavior? (You can also link to an open issue here)**

autocomplete is missing this command




**What is the new behavior (if this is a feature change)?**

`brew postinstall` is shown in autocomplete 




**Additional info:**

screenshot of missing command `--help`
![](https://i.imgur.com/Nc7FDwn.png)
