### PR TITLE
Lowercase "dbt" in dbt completion spec

### DIFF
--- a/src/dbt.ts
+++ b/src/dbt.ts
@@ -1,6 +1,6 @@
 const completionSpec: Fig.Spec = {
   name: "dbt",
-  description: "CLI for DBT - Data Build Tool",
+  description: "CLI for dbt - Data Build Tool",
   subcommands: [
     {
       name: "build",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update - updates the description of a completion spec

**What is the current behavior? (You can also link to an open issue here)**
dbt appears in uppercase as "DBT".

**What is the new behavior (if this is a feature change)?**
dbt should appear in lowercase, per [the brand guidelines](https://www.getdbt.com/brand-guidelines/)

**Additional info:**
Not trying to be pedantic! I am an engineer at dbt Labs, and a huge fan of Fig! Just noticed this in the completion spec and thought I'd propose a quick change!