### PR TITLE
feat(okteto): add generators for `ns` and `ctx`

### DIFF
--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -1,8 +1,7 @@
 const contexts: Fig.Generator = {
   script: "okteto context list",
   postProcess: (output) => {
-    return output.split("\n").map((context, ind) => {
-      if (ind == 0) return;
+    return output.split("\n").slice(1).map((context, ind) => {
       context = context.split(" ")[0];
       return {
         name: context.replace("*", "").trim(),

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -1,5 +1,8 @@
 const contexts: Fig.Generator = {
   script: "okteto context list",
+  cache: {
+    ttl: 1000 * 60 * 30, // 30 minutes
+  },
   postProcess: (output) => {
     return output.split("\n").slice(1).map((context, ind) => {
       context = context.split(" ")[0];
@@ -14,6 +17,9 @@ const contexts: Fig.Generator = {
 
 const namespaces: Fig.Generator = {
   script: "okteto namespace list",
+  cache: {
+    ttl: 1000 * 60 * 30, // 30 minutes
+  },
   postProcess: (output) => {
     return output.split("\n").slice(1).map((namespace, ind) => {
       namespace = namespace.split(" ")[0];

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -15,8 +15,7 @@ const contexts: Fig.Generator = {
 const namespaces: Fig.Generator = {
   script: "okteto namespace list",
   postProcess: (output) => {
-    return output.split("\n").map((namespace, ind) => {
-      if (ind == 0) return;
+    return output.split("\n").slice(1).map((namespace, ind) => {
       namespace = namespace.split(" ")[0];
       return {
         name: namespace.replace("*", "").trim(),

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -4,14 +4,17 @@ const contexts: Fig.Generator = {
     ttl: 1000 * 60 * 30, // 30 minutes
   },
   postProcess: (output) => {
-    return output.split("\n").slice(1).map((context, ind) => {
-      context = context.split(" ")[0];
-      return {
-        name: context.replace("*", "").trim(),
-        description: "Context",
-        icon: "fig://icon?type=okteto",
-      };
-    });
+    return output
+      .split("\n")
+      .slice(1)
+      .map((context, ind) => {
+        context = context.split(" ")[0];
+        return {
+          name: context.replace("*", "").trim(),
+          description: "Context",
+          icon: "fig://icon?type=okteto",
+        };
+      });
   },
 };
 
@@ -21,14 +24,17 @@ const namespaces: Fig.Generator = {
     ttl: 1000 * 60 * 30, // 30 minutes
   },
   postProcess: (output) => {
-    return output.split("\n").slice(1).map((namespace, ind) => {
-      namespace = namespace.split(" ")[0];
-      return {
-        name: namespace.replace("*", "").trim(),
-        description: "Namespace",
-        icon: "fig://icon?type=okteto",
-      };
-    });
+    return output
+      .split("\n")
+      .slice(1)
+      .map((namespace, ind) => {
+        namespace = namespace.split(" ")[0];
+        return {
+          name: namespace.replace("*", "").trim(),
+          description: "Namespace",
+          icon: "fig://icon?type=okteto",
+        };
+      });
   },
 };
 

--- a/src/okteto.ts
+++ b/src/okteto.ts
@@ -1,3 +1,33 @@
+const contexts: Fig.Generator = {
+  script: "okteto context list",
+  postProcess: (output) => {
+    return output.split("\n").map((context, ind) => {
+      if (ind == 0) return;
+      context = context.split(" ")[0];
+      return {
+        name: context.replace("*", "").trim(),
+        description: "Context",
+        icon: "fig://icon?type=okteto",
+      };
+    });
+  },
+};
+
+const namespaces: Fig.Generator = {
+  script: "okteto namespace list",
+  postProcess: (output) => {
+    return output.split("\n").map((namespace, ind) => {
+      if (ind == 0) return;
+      namespace = namespace.split(" ")[0];
+      return {
+        name: namespace.replace("*", "").trim(),
+        description: "Namespace",
+        icon: "fig://icon?type=okteto",
+      };
+    });
+  },
+};
+
 const completionSpec: Fig.Spec = {
   name: "okteto",
   description: "Okteto - Remote Development Environments powered by Kubernetes",
@@ -263,6 +293,9 @@ const completionSpec: Fig.Spec = {
         {
           name: "delete",
           description: "Delete a context",
+          args: {
+            generators: contexts,
+          },
           options: [
             {
               name: ["--loglevel", "-l"],
@@ -335,6 +368,9 @@ const completionSpec: Fig.Spec = {
         {
           name: "use",
           description: "Set the default context",
+          args: {
+            generators: contexts,
+          },
           options: [
             {
               name: ["--loglevel", "-l"],
@@ -666,6 +702,9 @@ const completionSpec: Fig.Spec = {
         {
           name: "delete",
           description: "Delete a namespace",
+          args: {
+            generators: namespaces,
+          },
           options: [
             {
               name: ["--loglevel", "-l"],
@@ -715,6 +754,9 @@ const completionSpec: Fig.Spec = {
         {
           name: ["ns", "use"],
           description: "Configure the current namespace of the okteto context",
+          args: {
+            generators: namespaces,
+          },
           options: [
             {
               name: ["--loglevel", "-l"],


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds generators for `okteto ns use/delete` and `okteto ctx use/delete`

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/okteto/okteto/issues/1998

**What is the new behavior (if this is a feature change)?**


https://user-images.githubusercontent.com/56963264/152126700-1bd8d582-044f-4fe4-b5c7-4b84a72f1373.mov


**Additional info:**

A couple of questions:

- where do we upload the Okteto logo so that we can use `fig://icon?type=okteto`?
- as seen in the demo, there is a bit of delay showing the namespaces when doing `okteto ns use/delete` - is there a way to do some sort of caching to speed this up?
- is it possible to show the generated results in fig at the top of the list, that is, above the flag suggestions?

Thanks in advance!

cc @rberrelleza 