### PR TITLE
feat(cargo): Add all remaining subcommands

### DIFF
--- a/src/cargo.ts
+++ b/src/cargo.ts
@@ -83,14 +83,15 @@ const targetGenerator: Fig.Generator = {
 };
 
 const rustEditions: Fig.Suggestion[] = [
-  { name: "2015" },
-  { name: "2018" },
-  { name: "2021" },
+  { name: "2015", description: "2015 edition" },
+  { name: "2018", description: "2018 edition" },
+  { name: "2021", description: "2021 edition" },
 ];
 
 const vcsOptions: Fig.Suggestion[] = [
   {
     name: "git",
+    icon: "fig://icon?type=git",
     description: "Initalize with Git",
   },
   {
@@ -103,6 +104,7 @@ const vcsOptions: Fig.Suggestion[] = [
   },
   {
     name: "fossil",
+    icon: "fig://template?color=818181&badge=🦴",
     description: "Initalize with Fossil",
   },
   {
@@ -117,92 +119,186 @@ const completionSpec: Fig.Spec = {
   description: "CLI Interface for Cargo",
   subcommands: [
     {
-      name: ["build", "b"],
-      icon: "📦",
-      description: "Compile local package and dependencies",
+      name: "bench",
+      icon: "📊",
+      description: "Execute all benchmarks of a local package",
       options: [
         {
+          name: "--bin",
+          description: "Benchmark only the specified binary",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--example",
+          description: "Benchmark only the specified example",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--test",
+          description: "Benchmark only the specified test target",
+          isRepeatable: true,
+          args: {
+            name: "test",
+            generators: testList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--bench",
+          description: "Benchmark only the specified bench target",
+          isRepeatable: true,
+          args: {
+            name: "bench",
+            isVariadic: true,
+          },
+        },
+        {
           name: ["-p", "--package"],
-          description: "Package to build (see `cargo help pkgid`)",
-          args: { name: "SPEC" },
-        },
-        {
-          name: "--all",
-          description: "Alias for workspace (deprecated)",
-          hidden: true,
-        },
-        {
-          name: "--workspace",
-          description: "Build all packages in workspace",
+          description: "Package to run benchmarks for",
+          isRepeatable: true,
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
         },
         {
           name: "--exclude",
-          description: "Exclude packages from the build",
-          args: { name: "SPEC" },
+          description: "Exclude packages from the benchmark",
+          isRepeatable: true,
+          args: {
+            name: "exclude",
+          },
         },
         {
           name: ["-j", "--jobs"],
           description: "Number of parallel jobs, defaults to # of CPUs",
-          args: { name: "N" },
-        },
-        {
-          name: "--lib",
-          description: "Build only this package's library",
-        },
-        {
-          name: "--bin",
-          description: "Build only the specified binary",
           args: {
-            name: "NAME",
-            generators: binList,
+            name: "jobs",
           },
-        },
-        {
-          name: "--bins",
-          description: "Build all binaries",
-        },
-        {
-          name: "--example",
-          description: "Build only the specified example",
-          args: { name: "NAME" },
-        },
-        {
-          name: "--examples",
-          description: "Build all examples",
-        },
-        {
-          name: "--test",
-          description: "Build only the specified test target",
-          args: {
-            name: "NAME",
-            generators: testList,
-          },
-        },
-        {
-          name: "--tests",
-          description: "Build all tests",
-        },
-        {
-          name: "--bench",
-          description: "Build only the specified bench target",
-          args: { name: "NAME" },
-        },
-        {
-          name: "--benches",
-          description: "Build all benches",
-        },
-        {
-          name: "--all-targets",
-          description: "Activate all available features",
-        },
-        {
-          name: "--release",
-          description: "Build in release mode, with optimizations",
         },
         {
           name: "--profile",
           description: "Build artifacts with the specified profile",
-          args: { name: "PROFILE-NAME" },
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--target",
+          description: "Build for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["auto", "always", "never"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--lib",
+          description: "Benchmark only this package's library",
+        },
+        {
+          name: "--bins",
+          description: "Benchmark all binaries",
+        },
+        {
+          name: "--examples",
+          description: "Benchmark all examples",
+        },
+        {
+          name: "--tests",
+          description: "Benchmark all tests",
+        },
+        {
+          name: "--benches",
+          description: "Benchmark all benches",
+        },
+        {
+          name: "--all-targets",
+          description: "Benchmark all targets",
+        },
+        {
+          name: "--no-run",
+          description: "Compile, but don't run benchmarks",
+        },
+        {
+          name: "--workspace",
+          description: "Benchmark all packages in the workspace",
+        },
+        {
+          name: "--all",
+          description: "Alias for --workspace (deprecated)",
+          hidden: true,
         },
         {
           name: "--all-features",
@@ -214,8 +310,248 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--ignore-rust-version",
+          description: "Ignore `rust-version` specification in packages",
+        },
+        {
+          name: "--no-fail-fast",
+          description: "Run all benchmarks regardless of failure",
+        },
+        {
+          name: "--unit-graph",
+          description: "Output build graph in JSON (unstable)",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: [
+        {
+          name: "BENCHNAME",
+        },
+        {
+          name: "args",
+          isVariadic: true,
+        },
+      ],
+    },
+    {
+      name: ["build", "b"],
+      icon: "📦",
+      description: "Compile a local package and all of its dependencies",
+      options: [
+        {
+          name: ["-p", "--package"],
+          description: "Package to build (see `cargo help pkgid`)",
+          isRepeatable: true,
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--exclude",
+          description: "Exclude packages from the build",
+          isRepeatable: true,
+          args: {
+            name: "exclude",
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description: "Number of parallel jobs, defaults to # of CPUs",
+          args: {
+            name: "jobs",
+          },
+        },
+        {
+          name: "--bin",
+          description: "Build only the specified binary",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--example",
+          description: "Build only the specified example",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--test",
+          description: "Build only the specified test target",
+          isRepeatable: true,
+          args: {
+            name: "test",
+            generators: testList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--bench",
+          description: "Build only the specified bench target",
+          isRepeatable: true,
+          args: {
+            name: "bench",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--profile",
+          description: "Build artifacts with the specified profile",
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--target",
+          description: "Build for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--out-dir",
+          description: "Copy final artifacts to this directory (unstable)",
+          args: {
+            name: "out-dir",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["auto", "always", "never"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
           description:
-            "Ignore `rust-version` specification in packages (unstable)",
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--workspace",
+          description: "Build all packages in the workspace",
+        },
+        {
+          name: "--all",
+          description: "Alias for --workspace (deprecated)",
+          hidden: true,
+        },
+        {
+          name: "--lib",
+          description: "Build only this package's library",
+        },
+        {
+          name: "--bins",
+          description: "Build all binaries",
+        },
+        {
+          name: "--examples",
+          description: "Build all examples",
+        },
+        {
+          name: "--tests",
+          description: "Build all tests",
+        },
+        {
+          name: "--benches",
+          description: "Build all benches",
+        },
+        {
+          name: "--all-targets",
+          description: "Build all targets",
+        },
+        {
+          name: ["-r", "--release"],
+          description: "Build artifacts in release mode, with optimizations",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--ignore-rust-version",
+          description: "Ignore `rust-version` specification in packages",
         },
         {
           name: "--build-plan",
@@ -228,7 +564,28 @@ const completionSpec: Fig.Spec = {
         {
           name: "--future-incompat-report",
           description:
-            "Outputs a future incompatibility report at the end of the build (unstable)",
+            "Outputs a future incompatibility report at the end of the build",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
         },
       ],
     },
@@ -236,160 +593,184 @@ const completionSpec: Fig.Spec = {
       name: ["check", "c"],
       icon: "🛠",
       description:
-        "Analyze the current package and report errors, but don't build object files",
-    },
-    {
-      name: "clean",
-      icon: "🛠",
-      description: "Remove the target directory",
-    },
-    {
-      name: ["doc", "d"],
-      icon: "📄",
-      description: "Build this package's and its dependencies' documentation",
+        "Check a local package and all of its dependencies for errors",
       options: [
-        {
-          name: "--open",
-          description: "Opens the docs in a browser after the operation",
-        },
-      ],
-    },
-    {
-      name: "new",
-      icon: "📦",
-      description: "Create a new cargo package",
-      args: {
-        name: "path",
-        template: "folders",
-      },
-      options: [
-        {
-          name: "--registry",
-          description: "Registry to use",
-          args: { name: "REGISTRY" },
-        },
-        {
-          name: "--vcs",
-          description:
-            "Initialize a new repository for the given version control system",
-          args: {
-            name: "VCS",
-            suggestions: vcsOptions,
-          },
-        },
-        {
-          name: "--bin",
-          description: "Use a binary (application) template [default]",
-          exclusiveOn: ["--lib"],
-        },
-        {
-          name: "--lib",
-          description: "Use a library template",
-          exclusiveOn: ["--bin"],
-        },
-        {
-          name: "--edition",
-          description: "Edition to set for the crate generated",
-          args: {
-            name: "YEAR",
-            suggestions: rustEditions,
-          },
-        },
-        {
-          name: "--name",
-          description:
-            "Set the resulting package name, defaults to the directory name",
-          args: { name: "NAME" },
-        },
-      ],
-    },
-    {
-      name: "init",
-      icon: "📦",
-      description: "Creates new cargo pkg in directory",
-      options: [
-        {
-          name: "--registry",
-          description: "Registry to use",
-          args: { name: "REGISTRY" },
-        },
-        {
-          name: "--vcs",
-          description:
-            "Initialize a new repository for the given version control system",
-          args: {
-            name: "VCS",
-            suggestions: vcsOptions,
-          },
-        },
-        {
-          name: "--bin",
-          description: "Use a binary (application) template [default]",
-          exclusiveOn: ["--lib"],
-        },
-        {
-          name: "--lib",
-          description: "Use a library template",
-          exclusiveOn: ["--bin"],
-        },
-        {
-          name: "--edition",
-          description: "Edition to set for the crate generated",
-          args: {
-            name: "YEAR",
-            suggestions: rustEditions,
-          },
-        },
-        {
-          name: "--name",
-          description:
-            "Set the resulting package name, defaults to the directory name",
-          args: { name: "NAME" },
-        },
-        {
-          name: "--",
-          description: "Last option before path",
-        },
-      ],
-      args: {
-        template: "folders",
-      },
-    },
-    {
-      name: ["run", "r"],
-      icon: "📦",
-      description: "Run a binary or example of the local package",
-      options: [
-        {
-          name: "--bin",
-          args: {
-            name: "bin",
-            generators: binList,
-          },
-        },
-        {
-          name: "--example",
-          description: "Build only the specified example",
-          args: { name: "NAME" },
-        },
         {
           name: ["-p", "--package"],
-          description: "Package to build (see `cargo help pkgid`)",
-          args: { name: "SPEC" },
+          description: "Package(s) to check",
+          isRepeatable: true,
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--exclude",
+          description: "Exclude packages from the check",
+          isRepeatable: true,
+          args: {
+            name: "exclude",
+          },
         },
         {
           name: ["-j", "--jobs"],
           description: "Number of parallel jobs, defaults to # of CPUs",
-          args: { name: "N" },
+          args: {
+            name: "jobs",
+          },
         },
         {
-          name: "--release",
-          description: "Run in release mode, with optimizations",
+          name: "--bin",
+          description: "Check only the specified binary",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--example",
+          description: "Check only the specified example",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--test",
+          description: "Check only the specified test target",
+          isRepeatable: true,
+          args: {
+            name: "test",
+            generators: testList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--bench",
+          description: "Check only the specified bench target",
+          isRepeatable: true,
+          args: {
+            name: "bench",
+            isVariadic: true,
+          },
         },
         {
           name: "--profile",
-          description: "Build artifacts with the specified profile",
-          args: { name: "PROFILE-NAME" },
+          description: "Check artifacts with the specified profile",
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--target",
+          description: "Check for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["auto", "always", "never"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--workspace",
+          description: "Check all packages in the workspace",
+        },
+        {
+          name: "--all",
+          description: "Alias for --workspace (deprecated)",
+          hidden: true,
+        },
+        {
+          name: "--lib",
+          description: "Check only this package's library",
+        },
+        {
+          name: "--bins",
+          description: "Check all binaries",
+        },
+        {
+          name: "--examples",
+          description: "Check all examples",
+        },
+        {
+          name: "--tests",
+          description: "Check all tests",
+        },
+        {
+          name: "--benches",
+          description: "Check all benches",
+        },
+        {
+          name: "--all-targets",
+          description: "Check all targets",
+        },
+        {
+          name: ["-r", "--release"],
+          description: "Check artifacts in release mode, with optimizations",
         },
         {
           name: "--all-features",
@@ -401,165 +782,501 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--ignore-rust-version",
-          description:
-            "Ignore `rust-version` specification in packages (unstable)",
+          description: "Ignore `rust-version` specification in packages",
         },
         {
           name: "--unit-graph",
           description: "Output build graph in JSON (unstable)",
         },
+        {
+          name: "--future-incompat-report",
+          description:
+            "Outputs a future incompatibility report at the end of the build",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
       ],
     },
     {
-      name: ["test", "t"],
-      icon: "📦",
-      description: "Run tests",
-      args: {
-        name: "test name",
-        generators: testList,
-      },
+      name: "clean",
+      icon: "🛠",
+      description: "Remove artifacts that cargo has generated in the past",
       options: [
-        {
-          name: ["-h", "--h"],
-          description: "Output usage info",
-        },
-        {
-          name: "--release",
-          description: "Test in release mode, with optimizations",
-        },
-      ],
-    },
-    {
-      name: "bench",
-      icon: "📈",
-      description: "Run the benchmarks",
-    },
-    {
-      name: "update",
-      icon: "📦",
-      description: "Update dependencies listed in Cargo.lock",
-      options: [
-        {
-          name: ["-w", "--workspace"],
-          description: "Only update the workspace packages",
-        },
         {
           name: ["-p", "--package"],
-          description: "Package to update",
-          args: { name: "SPEC" },
-        },
-        {
-          name: "--aggressive",
-          description:
-            "Force updating all dependencies of SPEC as well when used with -p",
-        },
-        {
-          name: "--dry-run",
-          description: "Don't actually write the lockfile",
-        },
-      ],
-    },
-    {
-      name: "search",
-      icon: "🔎",
-      description: "Search registry for crates",
-      args: {
-        name: "query",
-        isOptional: true,
-        isVariadic: true,
-      },
-      options: [
-        {
-          name: "--index",
-          description: "Registry index URL to upload the package to",
-          args: { name: "INDEX" },
-        },
-        {
-          name: "--limit",
-          description: "Limit the number of results (default: 10, max: 100)",
-          args: { name: "LIMIT" },
-        },
-        {
-          name: "--registry",
-          description: "Registry to",
-          args: { name: "REGISTRY" },
-        },
-        {
-          name: "--",
-          description: "Last option before query",
-        },
-      ],
-    },
-    {
-      name: "install",
-      icon: "📦",
-      description: "Install a Rust binary",
-      args: {
-        name: "package",
-        isOptional: true,
-        generators: searchGenerator,
-        debounce: true,
-        isVariadic: true,
-      },
-      options: [
-        {
-          name: "--version",
-          description: "Specify a version to install",
-          args: { name: "VERSION" },
-        },
-        {
-          name: "--git",
-          description: "Git URL to install the specified crate from",
-          args: { name: "URL" },
-        },
-        {
-          name: "--branch",
-          description: "Branch to use when installing from git",
-          args: { name: "BRANCH" },
-        },
-        {
-          name: "--tag",
-          description: "Tag to use when installing from git",
-          args: { name: "TAG" },
-        },
-        {
-          name: "--rev",
-          description: "Specific commit to use when installing from git",
-          args: { name: "SHA" },
-        },
-        {
-          name: "--path",
-          description: "Filesystem path to local crate to install",
+          description: "Package to clean artifacts for",
+          isRepeatable: true,
           args: {
-            name: "PATH",
-            template: "folders",
+            name: "package",
+            isVariadic: true,
           },
         },
         {
-          name: "--list",
-          description: "List all installed packages and their versions",
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--target",
+          description: "Target triple to clean output for",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--profile",
+          description: "Clean artifacts of the specified profile",
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["auto", "always", "never"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-r", "--release"],
+          description: "Whether or not to clean release artifacts",
+        },
+        {
+          name: "--doc",
+          description:
+            "Whether or not to clean just the documentation directory",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "config",
+      icon: "⚙️",
+      description: "Inspect configuration values",
+      subcommands: [
+        {
+          name: "get",
+          options: [
+            {
+              name: "--format",
+              description: "Display format",
+              args: {
+                name: "format",
+                suggestions: ["toml", "json", "json-value"],
+              },
+            },
+            {
+              name: "--merged",
+              description: "Whether or not to merge config values",
+              args: {
+                name: "merged",
+
+                suggestions: ["yes", "no"],
+              },
+            },
+            {
+              name: "--color",
+              description: "Coloring: auto, always, never",
+              args: {
+                name: "color",
+                suggestions: ["auto", "always", "never"],
+              },
+            },
+            {
+              name: "--config",
+              description: "Override a configuration value (unstable)",
+              isRepeatable: true,
+              args: {
+                name: "config",
+              },
+            },
+            {
+              name: "-Z",
+              description:
+                "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+              isRepeatable: true,
+              args: {
+                name: "unstable-features",
+              },
+            },
+            {
+              name: "--version",
+              description: "Print version information",
+            },
+            {
+              name: "--show-origin",
+              description: "Display where the config value is defined",
+            },
+            {
+              name: ["-h", "--help"],
+              description: "Print help information",
+            },
+            {
+              name: ["-v", "--verbose"],
+              description:
+                "Use verbose output (-vv very verbose/build.rs output)",
+              isRepeatable: true,
+            },
+            {
+              name: "--frozen",
+              description: "Require Cargo.lock and cache are up to date",
+            },
+            {
+              name: "--locked",
+              description: "Require Cargo.lock is up to date",
+            },
+            {
+              name: "--offline",
+              description: "Run without accessing the network",
+            },
+          ],
+        },
+        {
+          name: "help",
+          description:
+            "Print this message or the help of the given subcommand(s)",
+          options: [
+            {
+              name: "--color",
+              description: "Coloring: auto, always, never",
+              args: {
+                name: "color",
+                suggestions: ["auto", "always", "never"],
+              },
+            },
+            {
+              name: "--config",
+              description: "Override a configuration value (unstable)",
+              isRepeatable: true,
+              args: {
+                name: "config",
+              },
+            },
+            {
+              name: "-Z",
+              description:
+                "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+              isRepeatable: true,
+              args: {
+                name: "unstable-features",
+              },
+            },
+            {
+              name: "--version",
+              description: "Print version information",
+            },
+            {
+              name: ["-h", "--help"],
+              description: "Print help information",
+            },
+            {
+              name: ["-v", "--verbose"],
+              description:
+                "Use verbose output (-vv very verbose/build.rs output)",
+              isRepeatable: true,
+            },
+            {
+              name: "--frozen",
+              description: "Require Cargo.lock and cache are up to date",
+            },
+            {
+              name: "--locked",
+              description: "Require Cargo.lock is up to date",
+            },
+            {
+              name: "--offline",
+              description: "Run without accessing the network",
+            },
+          ],
+          args: {
+            name: "subcommand",
+          },
+        },
+      ],
+      options: [
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["auto", "always", "never"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: ["doc", "d"],
+      icon: "📄",
+      description: "Build a package's documentation",
+      options: [
+        {
+          name: ["-p", "--package"],
+          description: "Package to document",
+          isRepeatable: true,
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--exclude",
+          description: "Exclude packages from the build",
+          isRepeatable: true,
+          args: {
+            name: "exclude",
+          },
         },
         {
           name: ["-j", "--jobs"],
           description: "Number of parallel jobs, defaults to # of CPUs",
-          args: { name: "N" },
+          args: {
+            name: "jobs",
+          },
         },
         {
-          name: ["-f", "--force"],
-          description: "Force overwriting existing crates or binaries",
+          name: "--bin",
+          description: "Document only the specified binary",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
         },
         {
-          name: "--no-track",
-          description: "Do not save tracking",
+          name: "--example",
+          description: "Document only the specified example",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--profile",
+          description: "Build artifacts with the specified profile",
+          args: {
+            name: "profile",
+          },
         },
         {
           name: "--features",
           description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
           args: {
-            name: "FEATURES",
+            name: "features",
             generators: featuresGenerator,
+
             isVariadic: true,
           },
+        },
+        {
+          name: "--target",
+          description: "Build for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--open",
+          description: "Opens the docs in a browser after the operation",
+        },
+        {
+          name: "--workspace",
+          description: "Document all packages in the workspace",
+        },
+        {
+          name: "--all",
+          description: "Alias for --workspace (deprecated)",
+          hidden: true,
+        },
+        {
+          name: "--no-deps",
+          description: "Don't build documentation for dependencies",
+        },
+        {
+          name: "--document-private-items",
+          description: "Document private items",
+        },
+        {
+          name: "--lib",
+          description: "Document only this package's library",
+        },
+        {
+          name: "--bins",
+          description: "Document all binaries",
+        },
+        {
+          name: "--examples",
+          description: "Document all examples",
+        },
+        {
+          name: ["-r", "--release"],
+          description: "Build artifacts in release mode, with optimizations",
         },
         {
           name: "--all-features",
@@ -570,100 +1287,2879 @@ const completionSpec: Fig.Spec = {
           description: "Do not activate the `default` feature",
         },
         {
-          name: "--profile",
-          description: "Install artifacts with the specified profile",
-          args: { name: "PROFILE-NAME" },
+          name: "--ignore-rust-version",
+          description: "Ignore `rust-version` specification in packages",
         },
         {
-          name: "--debug",
-          description: "Build in debug mode instead of release mode",
+          name: "--unit-graph",
+          description: "Output build graph in JSON (unstable)",
         },
         {
-          name: "--bin",
-          description: "Install only the specified binary",
-          args: { name: "NAME" },
+          name: ["-h", "--help"],
+          description: "Print help information",
         },
         {
-          name: "--bins",
-          description: "Install all binaries",
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
         },
         {
-          name: "--example",
-          description: "Install only the specified example",
-          args: { name: "NAME" },
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
         },
         {
-          name: "--examples",
-          description: "Install all examples",
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "fetch",
+      icon: "📦",
+      description: "Fetch dependencies of a package from the network",
+      options: [
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
         },
         {
           name: "--target",
-          description: "Build for the target triple",
-          args: { name: "TRIPLE", generators: targetGenerator },
+          description: "Fetch dependencies for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "fix",
+      icon: "🔧",
+      description: "Automatically fix lint warnings reported by rustc",
+      options: [
+        {
+          name: ["-p", "--package"],
+          description: "Package(s) to fix",
+          isRepeatable: true,
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--exclude",
+          description: "Exclude packages from the fixes",
+          isRepeatable: true,
+          args: {
+            name: "exclude",
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description: "Number of parallel jobs, defaults to # of CPUs",
+          args: {
+            name: "jobs",
+          },
+        },
+        {
+          name: "--bin",
+          description: "Fix only the specified binary",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--example",
+          description: "Fix only the specified example",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--test",
+          description: "Fix only the specified test target",
+          isRepeatable: true,
+          args: {
+            name: "test",
+            generators: testList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--bench",
+          description: "Fix only the specified bench target",
+          isRepeatable: true,
+          args: {
+            name: "bench",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--profile",
+          description: "Build artifacts with the specified profile",
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--target",
+          description: "Fix for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
         },
         {
           name: "--target-dir",
           description: "Directory for all generated artifacts",
           args: {
-            name: "DIRECTORY",
-            template: "folders",
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--workspace",
+          description: "Fix all packages in the workspace",
+        },
+        {
+          name: "--all",
+          description: "Alias for --workspace (deprecated)",
+          hidden: true,
+        },
+        {
+          name: "--lib",
+          description: "Fix only this package's library",
+        },
+        {
+          name: "--bins",
+          description: "Fix all binaries",
+        },
+        {
+          name: "--examples",
+          description: "Fix all examples",
+        },
+        {
+          name: "--tests",
+          description: "Fix all tests",
+        },
+        {
+          name: "--benches",
+          description: "Fix all benches",
+        },
+        {
+          name: "--all-targets",
+          description: "Fix all targets (default)",
+        },
+        {
+          name: ["-r", "--release"],
+          description: "Fix artifacts in release mode, with optimizations",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--broken-code",
+          description: "Fix code even if it already has compiler errors",
+        },
+        {
+          name: "--edition",
+          description: "Fix in preparation for the next edition",
+        },
+        {
+          name: "--edition-idioms",
+          description: "Fix warnings to migrate to the idioms of an edition",
+        },
+        {
+          name: "--allow-no-vcs",
+          description: "Fix code even if a VCS was not detected",
+        },
+        {
+          name: "--allow-dirty",
+          description: "Fix code even if the working directory is dirty",
+        },
+        {
+          name: "--allow-staged",
+          description:
+            "Fix code even if the working directory has staged changes",
+        },
+        {
+          name: "--ignore-rust-version",
+          description: "Ignore `rust-version` specification in packages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "generate-lockfile",
+      icon: "📦",
+      description: "Generate the lockfile for a package",
+      options: [
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "git-checkout",
+      icon: "📦",
+      description: "This subcommand has been removed",
+      hidden: true,
+      options: [
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "init",
+      icon: "📦",
+      description: "Create a new cargo package in an existing directory",
+      options: [
+        {
+          name: "--registry",
+          description: "Registry to use",
+          args: {
+            name: "registry",
+          },
+        },
+        {
+          name: "--vcs",
+          description:
+            "Initialize a new repository for the given version control system (git, hg, pijul, or fossil) or do not initialize any version control at all (none), overriding a global configuration",
+          args: {
+            name: "vcs",
+            suggestions: vcsOptions,
+          },
+        },
+        {
+          name: "--edition",
+          description: "Edition to set for the crate generated",
+          args: {
+            name: "edition",
+            suggestions: rustEditions,
+          },
+        },
+        {
+          name: "--name",
+          description:
+            "Set the resulting package name, defaults to the directory name",
+          args: {
+            name: "name",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--bin",
+          description: "Use a binary (application) template [default]",
+        },
+        {
+          name: "--lib",
+          description: "Use a library template",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "path",
+      },
+    },
+    {
+      name: "install",
+      icon: "📦",
+      description:
+        "Install a Rust binary. Default location is $HOME/.cargo/bin",
+      options: [
+        {
+          name: "--version",
+          description: "Specify a version to install",
+          args: {
+            name: "version",
+          },
+        },
+        {
+          name: "--git",
+          description: "Git URL to install the specified crate from",
+          exclusiveOn: ["--path", "--index", "--registry"],
+          args: {
+            name: "git",
+          },
+        },
+        {
+          name: "--branch",
+          description: "Branch to use when installing from git",
+          args: {
+            name: "branch",
+          },
+        },
+        {
+          name: "--tag",
+          description: "Tag to use when installing from git",
+          args: {
+            name: "tag",
+          },
+        },
+        {
+          name: "--rev",
+          description: "Specific commit to use when installing from git",
+          args: {
+            name: "rev",
+          },
+        },
+        {
+          name: "--path",
+          description: "Filesystem path to local crate to install",
+          exclusiveOn: ["--git", "--index", "--registry"],
+          args: {
+            name: "path",
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description: "Number of parallel jobs, defaults to # of CPUs",
+          args: {
+            name: "jobs",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--profile",
+          description: "Install artifacts with the specified profile",
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--bin",
+          description: "Install only the specified binary",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--example",
+          description: "Install only the specified example",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--target",
+          description: "Build for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
           },
         },
         {
           name: "--root",
           description: "Directory to install packages into",
           args: {
-            name: "DIR",
-            template: "folders",
+            name: "root",
           },
         },
         {
           name: "--index",
           description: "Registry index to install from",
-          args: { name: "INDEX" },
+          exclusiveOn: ["--git", "--path", "--registry"],
+          args: {
+            name: "index",
+          },
         },
         {
-          name: "--",
-          description: "Last option before crates",
+          name: "--registry",
+          description: "Registry to use",
+          exclusiveOn: ["--git", "--path", "--index"],
+          args: {
+            name: "registry",
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--list",
+          description: "List all installed packages and their versions",
+        },
+        {
+          name: ["-f", "--force"],
+          description: "Force overwriting existing crates or binaries",
+        },
+        {
+          name: "--no-track",
+          description: "Do not save tracking information",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--debug",
+          description: "Build in debug mode instead of release mode",
+        },
+        {
+          name: "--bins",
+          description: "Install all binaries",
+        },
+        {
+          name: "--examples",
+          description: "Install all examples",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "crate",
+        generators: searchGenerator,
+        debounce: true,
+        isVariadic: true,
+      },
+    },
+    {
+      name: "locate-project",
+      icon: "📦",
+      description:
+        "Print a JSON representation of a Cargo.toml file's location",
+      options: [
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Output representation [possible values: json, plain]",
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--workspace",
+          description: "Locate Cargo.toml of the workspace root",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
         },
       ],
     },
     {
-      name: "uninstall",
+      name: "login",
       icon: "📦",
-      description: "Uninstall a Rust binary",
-      args: {
-        name: "package",
-        isOptional: true,
-        generators: {
-          script:
-            "cargo install --list | grep -E \"^[a-zA-Z\\-]+\\sv\" | cut -d ' ' -f 1",
-          splitOn: "\n",
-        },
-        isVariadic: true,
-      },
+      description:
+        "Save an api token from the registry locally. If token is not specified, it will be read from stdin",
       options: [
         {
-          name: ["-p", "--package"],
-          description: "Package to uninstall",
-          args: { name: "SPEC" },
-        },
-        {
-          name: "--bin",
-          description: "Only uninstall the binary NAME",
-          args: { name: "NAME" },
-        },
-        {
-          name: "--root",
-          description: "Directory to uninstall packages from",
+          name: "--registry",
+          description: "Registry to use",
           args: {
-            name: "DIR",
-            template: "folders",
+            name: "registry",
           },
         },
         {
-          name: "--",
-          description: "Last option before crates",
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "token",
+      },
+    },
+    {
+      name: "logout",
+      icon: "📦",
+      description: "Remove an API token from the registry locally",
+      options: [
+        {
+          name: "--registry",
+          description: "Registry to use",
+          args: {
+            name: "registry",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "metadata",
+      icon: "📦",
+      description:
+        "Output the resolved dependencies of a package, the concrete used versions including overrides, in machine-readable format",
+      options: [
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--filter-platform",
+          description:
+            "Only include resolve dependencies matching the given target-triple",
+          isRepeatable: true,
+          args: {
+            name: "filter-platform",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--format-version",
+          description: "Format version",
+          args: {
+            name: "format-version",
+            suggestions: ["1"],
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--no-deps",
+          description:
+            "Output information only about the workspace members and don't fetch dependencies",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "new",
+      icon: "📦",
+      description: "Create a new cargo package at <path>",
+      options: [
+        {
+          name: "--registry",
+          description: "Registry to use",
+          args: {
+            name: "registry",
+          },
+        },
+        {
+          name: "--vcs",
+          description:
+            "Initialize a new repository for the given version control system (git, hg, pijul, or fossil) or do not initialize any version control at all (none), overriding a global configuration",
+          args: {
+            name: "vcs",
+            suggestions: vcsOptions,
+          },
+        },
+        {
+          name: "--edition",
+          description: "Edition to set for the crate generated",
+          args: {
+            name: "edition",
+
+            suggestions: rustEditions,
+          },
+        },
+        {
+          name: "--name",
+          description:
+            "Set the resulting package name, defaults to the directory name",
+          args: {
+            name: "name",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--bin",
+          description: "Use a binary (application) template [default]",
+        },
+        {
+          name: "--lib",
+          description: "Use a library template",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "path",
+        template: "folders",
+      },
+    },
+    {
+      name: "owner",
+      icon: "📦",
+      description: "Manage the owners of a crate on the registry",
+      options: [
+        {
+          name: ["-a", "--add"],
+          description: "Name of a user or team to invite as an owner",
+          isRepeatable: true,
+          args: {
+            name: "add",
+          },
+        },
+        {
+          name: ["-r", "--remove"],
+          description: "Name of a user or team to remove as an owner",
+          isRepeatable: true,
+          args: {
+            name: "remove",
+          },
+        },
+        {
+          name: "--index",
+          description: "Registry index to modify owners for",
+          args: {
+            name: "index",
+          },
+        },
+        {
+          name: "--token",
+          description: "API token to use when authenticating",
+          args: {
+            name: "token",
+          },
+        },
+        {
+          name: "--registry",
+          description: "Registry to use",
+          args: {
+            name: "registry",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-l", "--list"],
+          description: "List owners of a crate",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "crate",
+      },
+    },
+    {
+      name: "package",
+      icon: "📦",
+      description: "Assemble the local package into a distributable tarball",
+      options: [
+        {
+          name: "--target",
+          description: "Build for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-p", "--package"],
+          description: "Package(s) to assemble",
+          isRepeatable: true,
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--exclude",
+          description: "Don't assemble specified packages",
+          isRepeatable: true,
+          args: {
+            name: "exclude",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description: "Number of parallel jobs, defaults to # of CPUs",
+          args: {
+            name: "jobs",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-l", "--list"],
+          description: "Print files included in a package without making one",
+        },
+        {
+          name: "--no-verify",
+          description: "Don't verify the contents by building them",
+        },
+        {
+          name: "--no-metadata",
+          description: "Ignore warnings about a lack of human-usable metadata",
+        },
+        {
+          name: "--allow-dirty",
+          description: "Allow dirty working directories to be packaged",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--workspace",
+          description: "Assemble all packages in the workspace",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "pkgid",
+      icon: "📦",
+      description: "Print a fully qualified package specification",
+      options: [
+        {
+          name: ["-p", "--package"],
+          description: "Argument to get the package ID specifier for",
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "spec",
+      },
+    },
+    {
+      name: "publish",
+      icon: "📦",
+      description: "Upload a package to the registry",
+      options: [
+        {
+          name: "--index",
+          description: "Registry index URL to upload the package to",
+          args: {
+            name: "index",
+          },
+        },
+        {
+          name: "--token",
+          description: "Token to use when uploading",
+          args: {
+            name: "token",
+          },
+        },
+        {
+          name: "--target",
+          description: "Build for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: ["-p", "--package"],
+          description: "Package to publish",
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description: "Number of parallel jobs, defaults to # of CPUs",
+          args: {
+            name: "jobs",
+          },
+        },
+        {
+          name: "--registry",
+          description: "Registry to publish to",
+          args: {
+            name: "registry",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--no-verify",
+          description: "Don't verify the contents by building them",
+        },
+        {
+          name: "--allow-dirty",
+          description: "Allow dirty working directories to be packaged",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--dry-run",
+          description: "Perform all checks without uploading",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "read-manifest",
+      icon: "📦",
+      description:
+        "Print a JSON representation of a Cargo.toml manifest. Deprecated, use `cargo metadata --no-deps` instead",
+      hidden: true,
+      options: [
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "report",
+      icon: "📦",
+      description: "Generate and display various kinds of reports",
+      subcommands: [
+        {
+          name: "future-incompatibilities",
+          description:
+            "Reports any crates which will eventually stop compiling",
+          options: [
+            {
+              name: "--id",
+              description:
+                "Identifier of the report generated by a Cargo command invocation",
+              args: {
+                name: "id",
+              },
+            },
+            {
+              name: ["-p", "--package"],
+              description: "Package to display a report for",
+              args: {
+                name: "package",
+                isVariadic: true,
+              },
+            },
+            {
+              name: "--color",
+              description: "Coloring: auto, always, never",
+              args: {
+                name: "color",
+                suggestions: ["always", "never", "auto"],
+              },
+            },
+            {
+              name: "--config",
+              description: "Override a configuration value (unstable)",
+              isRepeatable: true,
+              args: {
+                name: "config",
+              },
+            },
+            {
+              name: "-Z",
+              description:
+                "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+              isRepeatable: true,
+              args: {
+                name: "unstable-features",
+              },
+            },
+            {
+              name: "--version",
+              description: "Print version information",
+            },
+            {
+              name: ["-h", "--help"],
+              description: "Print help information",
+            },
+            {
+              name: ["-v", "--verbose"],
+              description:
+                "Use verbose output (-vv very verbose/build.rs output)",
+              isRepeatable: true,
+            },
+            {
+              name: "--frozen",
+              description: "Require Cargo.lock and cache are up to date",
+            },
+            {
+              name: "--locked",
+              description: "Require Cargo.lock is up to date",
+            },
+            {
+              name: "--offline",
+              description: "Run without accessing the network",
+            },
+          ],
+        },
+        {
+          name: "help",
+          description:
+            "Print this message or the help of the given subcommand(s)",
+          options: [
+            {
+              name: "--color",
+              description: "Coloring: auto, always, never",
+              args: {
+                name: "color",
+                suggestions: ["always", "never", "auto"],
+              },
+            },
+            {
+              name: "--config",
+              description: "Override a configuration value (unstable)",
+              isRepeatable: true,
+              args: {
+                name: "config",
+              },
+            },
+            {
+              name: "-Z",
+              description:
+                "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+              isRepeatable: true,
+              args: {
+                name: "unstable-features",
+              },
+            },
+            {
+              name: "--version",
+              description: "Print version information",
+            },
+            {
+              name: ["-h", "--help"],
+              description: "Print help information",
+            },
+            {
+              name: ["-v", "--verbose"],
+              description:
+                "Use verbose output (-vv very verbose/build.rs output)",
+              isRepeatable: true,
+            },
+            {
+              name: "--frozen",
+              description: "Require Cargo.lock and cache are up to date",
+            },
+            {
+              name: "--locked",
+              description: "Require Cargo.lock is up to date",
+            },
+            {
+              name: "--offline",
+              description: "Run without accessing the network",
+            },
+          ],
+          args: {
+            name: "subcommand",
+          },
+        },
+      ],
+      options: [
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: ["run", "r"],
+      icon: "📦",
+      description: "Run a binary or example of the local package",
+      options: [
+        {
+          name: "--bin",
+          description: "Name of the bin target to run",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--example",
+          description: "Name of the example target to run",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-p", "--package"],
+          description: "Package with the target to run",
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description: "Number of parallel jobs, defaults to # of CPUs",
+          args: {
+            name: "jobs",
+          },
+        },
+        {
+          name: "--profile",
+          description: "Build artifacts with the specified profile",
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--target",
+          description: "Build for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-r", "--release"],
+          description: "Build artifacts in release mode, with optimizations",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--unit-graph",
+          description: "Output build graph in JSON (unstable)",
+        },
+        {
+          name: "--ignore-rust-version",
+          description: "Ignore `rust-version` specification in packages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "args",
+        isVariadic: true,
+      },
+    },
+    {
+      name: "rustc",
+      icon: "📦",
+      description: "Compile a package, and pass extra options to the compiler",
+      options: [
+        {
+          name: ["-p", "--package"],
+          description: "Package to build",
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description: "Number of parallel jobs, defaults to # of CPUs",
+          args: {
+            name: "jobs",
+          },
+        },
+        {
+          name: "--bin",
+          description: "Build only the specified binary",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--example",
+          description: "Build only the specified example",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--test",
+          description: "Build only the specified test target",
+          isRepeatable: true,
+          args: {
+            name: "test",
+            generators: testList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--bench",
+          description: "Build only the specified bench target",
+          isRepeatable: true,
+          args: {
+            name: "bench",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--profile",
+          description: "Build artifacts with the specified profile",
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--target",
+          description: "Target triple which compiles will be for",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--print",
+          description: "Output compiler information without compiling",
+          args: {
+            name: "print",
+          },
+        },
+        {
+          name: "--crate-type",
+          description:
+            "Comma separated list of types of crates for the compiler to emit (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "crate-type",
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--lib",
+          description: "Build only this package's library",
+        },
+        {
+          name: "--bins",
+          description: "Build all binaries",
+        },
+        {
+          name: "--examples",
+          description: "Build all examples",
+        },
+        {
+          name: "--tests",
+          description: "Build all tests",
+        },
+        {
+          name: "--benches",
+          description: "Build all benches",
+        },
+        {
+          name: "--all-targets",
+          description: "Build all targets",
+        },
+        {
+          name: ["-r", "--release"],
+          description: "Build artifacts in release mode, with optimizations",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--unit-graph",
+          description: "Output build graph in JSON (unstable)",
+        },
+        {
+          name: "--ignore-rust-version",
+          description: "Ignore `rust-version` specification in packages",
+        },
+        {
+          name: "--future-incompat-report",
+          description:
+            "Outputs a future incompatibility report at the end of the build",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "args",
+        isVariadic: true,
+      },
+    },
+    {
+      name: "rustdoc",
+      icon: "📦",
+      description:
+        "Build a package's documentation, using specified custom flags",
+      options: [
+        {
+          name: ["-p", "--package"],
+          description: "Package to document",
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description: "Number of parallel jobs, defaults to # of CPUs",
+          args: {
+            name: "jobs",
+          },
+        },
+        {
+          name: "--bin",
+          description: "Build only the specified binary",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--example",
+          description: "Build only the specified example",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--test",
+          description: "Build only the specified test target",
+          isRepeatable: true,
+          args: {
+            name: "test",
+            generators: testList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--bench",
+          description: "Build only the specified bench target",
+          isRepeatable: true,
+          args: {
+            name: "bench",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--profile",
+          description: "Build artifacts with the specified profile",
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--target",
+          description: "Build for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--open",
+          description: "Opens the docs in a browser after the operation",
+        },
+        {
+          name: "--lib",
+          description: "Build only this package's library",
+        },
+        {
+          name: "--bins",
+          description: "Build all binaries",
+        },
+        {
+          name: "--examples",
+          description: "Build all examples",
+        },
+        {
+          name: "--tests",
+          description: "Build all tests",
+        },
+        {
+          name: "--benches",
+          description: "Build all benches",
+        },
+        {
+          name: "--all-targets",
+          description: "Build all targets",
+        },
+        {
+          name: ["-r", "--release"],
+          description: "Build artifacts in release mode, with optimizations",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--unit-graph",
+          description: "Output build graph in JSON (unstable)",
+        },
+        {
+          name: "--ignore-rust-version",
+          description: "Ignore `rust-version` specification in packages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "args",
+        isVariadic: true,
+      },
+    },
+    {
+      name: "search",
+      icon: "🔎",
+      description: "Search packages in crates.io",
+      options: [
+        {
+          name: "--index",
+          description: "Registry index URL to upload the package to",
+          args: {
+            name: "index",
+          },
+        },
+        {
+          name: "--limit",
+          description: "Limit the number of results (default: 10, max: 100)",
+          args: {
+            name: "limit",
+          },
+        },
+        {
+          name: "--registry",
+          description: "Registry to use",
+          args: {
+            name: "registry",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "query",
+        isVariadic: true,
+      },
+    },
+    {
+      name: ["test", "t"],
+      icon: "📦",
+      description:
+        "Execute all unit and integration tests and build examples of a local package",
+      options: [
+        {
+          name: "--bin",
+          description: "Test only the specified binary",
+          isRepeatable: true,
+          args: {
+            name: "bin",
+            generators: binList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--example",
+          description: "Test only the specified example",
+          isRepeatable: true,
+          args: {
+            name: "example",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--test",
+          description: "Test only the specified test target",
+          isRepeatable: true,
+          args: {
+            name: "test",
+            generators: testList,
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--bench",
+          description: "Test only the specified bench target",
+          isRepeatable: true,
+          args: {
+            name: "bench",
+            isVariadic: true,
+          },
+        },
+        {
+          name: ["-p", "--package"],
+          description: "Package to run tests for",
+          isRepeatable: true,
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--exclude",
+          description: "Exclude packages from the test",
+          isRepeatable: true,
+          args: {
+            name: "exclude",
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description: "Number of parallel jobs, defaults to # of CPUs",
+          args: {
+            name: "jobs",
+          },
+        },
+        {
+          name: "--profile",
+          description: "Build artifacts with the specified profile",
+          args: {
+            name: "profile",
+          },
+        },
+        {
+          name: "--features",
+          description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
+          args: {
+            name: "features",
+            generators: featuresGenerator,
+
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--target",
+          description: "Build for the target triple",
+          isRepeatable: true,
+          args: {
+            name: "target",
+            generators: targetGenerator,
+          },
+        },
+        {
+          name: "--target-dir",
+          description: "Directory for all generated artifacts",
+          args: {
+            name: "target-dir",
+          },
+        },
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Error format",
+          isRepeatable: true,
+          args: {
+            name: "message-format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["auto", "always", "never"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Display one character per test instead of one line",
+        },
+        {
+          name: "--lib",
+          description: "Test only this package's library unit tests",
+        },
+        {
+          name: "--bins",
+          description: "Test all binaries",
+        },
+        {
+          name: "--examples",
+          description: "Test all examples",
+        },
+        {
+          name: "--tests",
+          description: "Test all tests",
+        },
+        {
+          name: "--benches",
+          description: "Test all benches",
+        },
+        {
+          name: "--all-targets",
+          description: "Test all targets",
+        },
+        {
+          name: "--doc",
+          description: "Test only this library's documentation",
+        },
+        {
+          name: "--no-run",
+          description: "Compile, but don't run tests",
+        },
+        {
+          name: "--no-fail-fast",
+          description: "Run all tests regardless of failure",
+        },
+        {
+          name: "--workspace",
+          description: "Test all packages in the workspace",
+        },
+        {
+          name: "--all",
+          description: "Alias for --workspace (deprecated)",
+          hidden: true,
+        },
+        {
+          name: ["-r", "--release"],
+          description: "Build artifacts in release mode, with optimizations",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--ignore-rust-version",
+          description: "Ignore `rust-version` specification in packages",
+        },
+        {
+          name: "--unit-graph",
+          description: "Output build graph in JSON (unstable)",
+        },
+        {
+          name: "--future-incompat-report",
+          description:
+            "Outputs a future incompatibility report at the end of the build",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: [
+        {
+          name: "TESTNAME",
+        },
+        {
+          name: "args",
+          isVariadic: true,
         },
       ],
     },
@@ -676,56 +4172,54 @@ const completionSpec: Fig.Spec = {
           name: "--manifest-path",
           description: "Path to Cargo.toml",
           args: {
+            name: "manifest-path",
             generators: filepaths({ equals: "Cargo.toml" }),
           },
         },
         {
           name: ["-p", "--package"],
           description: "Package to be used as the root of the tree",
-          args: { name: "SPEC" },
-        },
-        {
-          name: "--workspace",
-          description: "Display the tree for all packages in the workspace",
+          isRepeatable: true,
+          args: {
+            name: "package",
+            isVariadic: true,
+          },
         },
         {
           name: "--exclude",
           description: "Exclude specific workspace members",
-          args: { name: "SPEC" },
+          isRepeatable: true,
+          args: {
+            name: "exclude",
+          },
         },
         {
           name: "--features",
           description: "Space or comma separated list of features to activate",
+          isRepeatable: true,
           args: {
-            name: "FEATURES",
+            name: "features",
             generators: featuresGenerator,
             isVariadic: true,
           },
         },
         {
-          name: "--all-features",
-          description: "Activate all available features",
-        },
-        {
-          name: "--no-default-features",
-          description: "Do not activate the `default` feature",
-        },
-        {
           name: "--target",
           description:
-            "Filter dependencies matching the given target-triple (default host platform)",
+            "Filter dependencies matching the given target-triple (default host platform). Pass `all` to include all targets",
+          isRepeatable: true,
           args: {
-            name: "TRIPLE",
-            suggestions: ["all"],
+            name: "target",
             generators: targetGenerator,
-            isVariadic: true,
           },
         },
         {
           name: ["-e", "--edges"],
-          description: "The kinds of dependencies to display",
+          description:
+            "The kinds of dependencies to display (features, normal, build, dev, all, no-normal, no-build, no-dev, no-proc-macro)",
+          isRepeatable: true,
           args: {
-            name: "KINDS",
+            name: "edges",
             suggestions: [
               "features",
               "normal",
@@ -737,31 +4231,113 @@ const completionSpec: Fig.Spec = {
               "no-dev",
               "no-proc-macro",
             ],
-            isVariadic: true,
           },
         },
         {
           name: ["-i", "--invert"],
           description:
             "Invert the tree direction and focus on the given package",
-          args: { name: "SPEC", isVariadic: true },
+          isRepeatable: true,
+          args: {
+            name: "invert",
+            isVariadic: true,
+          },
         },
         {
           name: "--prune",
           description:
             "Prune the given package from the display of the dependency tree",
-          args: { name: "SPEC", isVariadic: true },
+          isRepeatable: true,
+          args: {
+            name: "prune",
+          },
         },
         {
           name: "--depth",
           description: "Maximum display depth of the dependency tree",
-          args: { name: "DEPTH", isVariadic: true },
+          args: {
+            name: "depth",
+          },
         },
         {
           name: "--prefix",
           description:
             "Change the prefix (indentation) of how each entry is displayed",
-          args: { name: "PREFIX", suggestions: ["depth", "indent", "none"] },
+          args: {
+            name: "prefix",
+            suggestions: ["depth", "indent", "none"],
+          },
+        },
+        {
+          name: "--charset",
+          description: "Character set to use in output: utf8, ascii",
+          args: {
+            name: "charset",
+            suggestions: ["utf8", "ascii"],
+          },
+        },
+        {
+          name: ["-f", "--format"],
+          description: "Format string used for printing dependencies",
+          args: {
+            name: "format",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["auto", "always", "never"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--workspace",
+          description: "Display the tree for all packages in the workspace",
+        },
+        {
+          name: ["-a", "--all"],
+        },
+        {
+          name: "--all-targets",
+        },
+        {
+          name: "--all-features",
+          description: "Activate all available features",
+        },
+        {
+          name: "--no-default-features",
+          description: "Do not activate the `default` feature",
+        },
+        {
+          name: "--no-dev-dependencies",
+        },
+        {
+          name: "--no-indent",
+        },
+        {
+          name: "--prefix-depth",
         },
         {
           name: "--no-dedupe",
@@ -773,560 +4349,652 @@ const completionSpec: Fig.Spec = {
             "Show only dependencies which come in multiple versions (implies -i)",
         },
         {
-          name: "--charset",
-          description: "Character set to use in output",
-          args: { name: "CHARSET", suggestions: ["utf8", "ascii"] },
+          name: ["-V", "--version"],
         },
         {
-          name: ["-f", "--format"],
-          description: "Format string used for printing dependencies",
-          args: { name: "FORMAT" },
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
         },
       ],
     },
     {
-      name: "rustc",
-      description:
-        "Compile a package, and pass extra options to the compiler format cargo rustc [options] -- [flags to pass]",
-      subcommands: [
-        {
-          name: "--",
-          description: "Placed before defining flags passed from rustc",
-          options: [
-            {
-              name: ["-h", "--help"],
-              description: "Prints out help info",
-            },
-            {
-              name: "--cfg",
-              description: "Configures compilation settings",
-              args: {
-                name: "Spec",
-                description: `Ex: verbose' or 'feature="serde"'`,
-              },
-            },
-
-            {
-              name: "-L",
-              description: "Adds a directory to the library search path",
-              args: [
-                {
-                  name: "kind",
-                  description: "The kind of search path",
-                  suggestions: [
-                    {
-                      name: "dependency",
-                      insertValue: "KIND=dependency",
-                      description:
-                        "Only search for transitive dependencies in this directory",
-                    },
-                    {
-                      name: "crate",
-                      insertValue: "KIND=crate",
-                      description:
-                        "Only search for this crate's direct dependencies in this directory",
-                    },
-                    {
-                      name: "native",
-                      insertValue: "KIND=native",
-                      description:
-                        "Only search for native libraries in this directory",
-                    },
-                    {
-                      name: "framework",
-                      insertValue: "KIND=framework",
-                      description:
-                        "Only search for macOS frameworks in this directory",
-                    },
-                    {
-                      name: "all",
-                      insertValue: "KIND=all",
-                      description:
-                        "Search for all library kinds in this directory",
-                    },
-                  ],
-                  isOptional: true,
-                },
-                {
-                  name: "path",
-                  description:
-                    "Path to search for external crates and libraries",
-                  template: "folders",
-                },
-              ],
-            },
-            {
-              name: "--l",
-              description: "Links the generated crate to a native library",
-              args: [
-                {
-                  name: "kind",
-                  description: "Kind of library",
-                  suggestions: [
-                    {
-                      name: "dylib",
-                      insertValue: "KIND=dylib",
-                      description: "A native dynamic library",
-                    },
-                    {
-                      name: "static",
-                      insertValue: "KIND=static",
-                      description: "A native static library",
-                    },
-                    {
-                      name: "framework",
-                      insertValue: "KIND=framework",
-                      description: "A macOS framework",
-                    },
-                  ],
-                  isOptional: true,
-                },
-                {
-                  name: "Name",
-                  description: "Native library name",
-                },
-              ],
-            },
-            {
-              name: "--crate-type",
-              description: "Specify types of crates for the compiler to emit",
-              args: {
-                name: "type",
-                description: "Type of crates",
-                suggestions: [
-                  { name: "bin", description: "A runnable executable program" },
-                  {
-                    name: "lib",
-                    description:
-                      "Generates a library kind preferred by the compiler",
-                  },
-                  { name: "rlib", description: "A Rust static library" },
-                  { name: "dylib", description: "A native dynamic library" },
-                  { name: "cdylib", description: "A native static library" },
-                  { name: "staticlib", description: "A macOS framework" },
-                  {
-                    name: "proc-macro",
-                    description:
-                      "Generates a format suitable for a procedural macro library that may be loaded by the compiler",
-                  },
-                ],
-              },
-            },
-            {
-              name: "--crate-name",
-              description: "Specify the name of the crate being built",
-              args: {
-                name: "Name",
-              },
-            },
-            {
-              name: "--edition",
-              description: "Specify the edition to use",
-              args: {
-                name: "edition",
-                suggestions: rustEditions,
-              },
-            },
-            {
-              name: "--emit",
-              description: "Specify the types of output files to generate",
-              args: {
-                name: "type",
-                suggestions: [
-                  {
-                    name: "asm",
-                    description:
-                      "Generates a file with the crate's assembly code",
-                  },
-                  {
-                    name: "llvm-bc",
-                    description:
-                      "Generates a binary file containing the LLVM bitcode",
-                  },
-                  {
-                    name: "llvm-ir",
-                    description: "Generates a file containing LLVM IR",
-                  },
-                  {
-                    name: "obj",
-                    description: "Generates a native object file",
-                  },
-                  {
-                    name: "metadata",
-                    description:
-                      "Generates a file containing metadata about the crate",
-                  },
-                  {
-                    name: "link",
-                    description:
-                      "Generates the crates specified by --crate-type",
-                  },
-                  {
-                    name: "dep-info",
-                    description:
-                      "Generates a file with Makefile syntax that indicates all the source files that were loaded to generate the crate",
-                  },
-                  {
-                    name: "mir",
-                    description:
-                      "Generates a file containing rustc's mid-level intermediate representation",
-                  },
-                ],
-              },
-            },
-            {
-              name: "--print",
-              description: "Prints compiler info",
-              args: {
-                name: "type",
-                suggestions: [
-                  { name: "crate-name", description: "The name of the crate" },
-                  {
-                    name: "file-names",
-                    description:
-                      "The names of the files created by the link emit kind",
-                  },
-                  { name: "sysroot", description: "Path to the sysroot" },
-                  {
-                    name: "target-libdir",
-                    description: "Path to the target libdir",
-                  },
-                  { name: "cfg", description: "List of cfg values" },
-                  {
-                    name: "target-list",
-                    description:
-                      "List of known targets. The target may be selected with the --target flag",
-                  },
-                  {
-                    name: "target-cpus",
-                    description:
-                      "List of available CPU values for the current target",
-                  },
-                  {
-                    name: "target-features",
-                    description:
-                      "List of available target features for the current target",
-                  },
-                  {
-                    name: "relocation-models",
-                    description:
-                      "List of relocation models. Relocation models may be selected with the -C relocation-model=val flag",
-                  },
-                  { name: "code-models", description: "List of code models" },
-                  {
-                    name: "tls-models",
-                    description:
-                      "List of Thread Local Storage models supported",
-                  },
-                  { name: "target-spec-json" },
-                  {
-                    name: "native-static-libs",
-                    description:
-                      "This may be used when creating a staticlib crate type",
-                  },
-                ],
-              },
-            },
-            {
-              name: "-g",
-              description: "Synonym for -C debuginfo=2",
-            },
-            {
-              name: "-O",
-              description: "Synonym for -C opt-level=2",
-            },
-            {
-              name: "-o",
-              description: "Specify the filename to write output",
-              args: {
-                name: "filename",
-              },
-            },
-            {
-              name: "--out-dir",
-              description: "Specify directory to write output",
-              args: {
-                name: "dir",
-              },
-            },
-            {
-              name: "--explain",
-              description:
-                "Provides a detailed explanation of an error message",
-              args: {
-                name: "Error Code",
-              },
-            },
-            {
-              name: "--test",
-              description: "Builds a test harness",
-            },
-            {
-              name: "--target",
-              description: "Selects a target triple to build",
-              args: {
-                name: "Target",
-              },
-            },
-            {
-              name: ["-W", "--warn"],
-              description: "Sets lint warnings",
-              args: {
-                name: "OPT",
-              },
-            },
-            {
-              name: ["-A", "--allow"],
-              description: "Set lint allowed",
-              args: {
-                name: "OPT",
-              },
-            },
-            {
-              name: ["-D", "--deny"],
-              description: "Set lint denied",
-              args: {
-                name: "OPT",
-              },
-            },
-            {
-              name: ["-F", "--forbid"],
-              description: "Set lint forbid",
-              args: {
-                name: "Opt",
-              },
-            },
-            {
-              name: "--cap-lints",
-              description: "Set the most restrictive lint level",
-              args: {
-                name: "Level",
-              },
-            },
-            {
-              name: ["-C", "--codegen"],
-              description: "Set a codegen option",
-              args: {
-                name: "option",
-              },
-            },
-            {
-              name: "-Z",
-              description: "Set unstable options",
-              args: {
-                name: "option",
-                description: "Unstable options to pass to rustc",
-              },
-            },
-            {
-              name: ["-V", "--version"],
-              description: "Prints version",
-            },
-            {
-              name: ["-v", "--verbose"],
-              description: "Use verbose output",
-            },
-            {
-              name: "--extern",
-              description: "Specify where an external library is located",
-              args: {
-                name: "Path",
-                description: "Path where crate(s) can be found",
-                template: "folders",
-              },
-            },
-            {
-              name: "--sysroot",
-              description: "Overrides the system root",
-              isDangerous: true,
-              args: {
-                name: "directory",
-              },
-            },
-            {
-              name: "--error-format",
-              description: "Controls how errors are produced",
-              args: {
-                name: "format",
-                suggestions: ["human", "json", "short"],
-              },
-            },
-            {
-              name: "--color",
-              description: "Configures coloring of output",
-              args: {
-                name: "color",
-                suggestions: ["auto", "always", "never"],
-              },
-            },
-          ],
-        },
-      ],
+      name: "uninstall",
+      icon: "📦",
+      description: "Remove a Rust binary",
       options: [
         {
           name: ["-p", "--package"],
-          description: "Package to build",
+          description: "Package to uninstall",
+          isRepeatable: true,
           args: {
-            name: "spec",
+            name: "package",
+            isVariadic: true,
           },
-        },
-        {
-          name: ["-j", "--jobs"],
-          description: "Number of parallel jobs, defaults to # of CPUs",
-          args: {
-            name: "Number",
-          },
-        },
-        {
-          name: "--lib",
-          description: "Builds only this package's library",
         },
         {
           name: "--bin",
-          description: "Builds only the specified binary",
+          description: "Only uninstall the binary NAME",
+          isRepeatable: true,
           args: {
-            name: "Name",
-            description: "Name of the binary",
+            name: "bin",
           },
         },
         {
-          name: "--bins",
-          description: "Builds all binaries",
-        },
-        {
-          name: "--example",
-          description: "Builds only the specified example",
+          name: "--root",
+          description: "Directory to uninstall packages from",
           args: {
-            name: "Name",
+            name: "root",
           },
         },
         {
-          name: "--examples",
-          description: "Builds all examples",
-        },
-        {
-          name: "--test",
-          description: "Builds only the specified test target",
+          name: "--color",
+          description: "Coloring: auto, always, never",
           args: {
-            name: "Name",
+            name: "color",
+            suggestions: ["auto", "always", "never"],
           },
         },
         {
-          name: "--tests",
-          description: "Builds all tests",
-        },
-        {
-          name: "--bench",
-          description: "Builds only the specified bench target",
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
           args: {
-            name: "Name",
+            name: "config",
           },
         },
         {
-          name: "--benches",
-          description: "Builds all benches",
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
           args: {
-            name: "Name",
+            name: "unstable-features",
           },
         },
         {
-          name: "--all-targets",
-          description: "Builds all targets",
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "spec",
+        generators: {
+          script:
+            "cargo install --list | grep -E \"^[a-zA-Z\\-]+\\sv\" | cut -d ' ' -f 1",
+          splitOn: "\n",
+        },
+        isVariadic: true,
+      },
+    },
+    {
+      name: "update",
+      icon: "📦",
+      description: "Update dependencies as recorded in the local lock file",
+      options: [
+        {
+          name: ["-p", "--package"],
+          description: "Package to update",
+          isRepeatable: true,
           args: {
-            name: "Name",
+            name: "package",
+            isVariadic: true,
           },
         },
         {
-          name: "--release",
-          description: "Builds artifacts in release mode with optimizations",
-        },
-        {
-          name: "--no-default-features",
-          description: "Do not activate the `default` feature",
-        },
-        {
-          name: "--target",
-          description: "Target triple which compiles will be for",
+          name: "--precise",
+          description:
+            "Update a single dependency to exactly PRECISE when used with -p",
           args: {
-            name: "Triple",
-            generators: targetGenerator,
-          },
-        },
-        {
-          name: "--print",
-          description: "Outputs compiler information without compiling",
-          args: {
-            name: "Info",
-          },
-        },
-        {
-          name: "--target-dir",
-          description: "Directory for all generated artifacts",
-          args: {
-            name: "Directory",
-            template: "folders",
+            name: "precise",
           },
         },
         {
           name: "--manifest-path",
           description: "Path to Cargo.toml",
           args: {
-            name: "Path",
-            template: ["folders", "filepaths"],
+            name: "manifest-path",
+            generators: filepaths({ equals: "Cargo.toml" }),
           },
         },
         {
-          name: "--message-format",
-          description: "Error format",
+          name: "--color",
+          description: "Coloring: auto, always, never",
           args: {
-            name: "Format",
-            suggestions: [
-              {
-                name: "human",
-                description: "Human readable, conflicts with short and json",
-              },
-              {
-                name: "short",
-                description:
-                  "Emits shorter, human-readable text messages, conflicts with human and json",
-              },
-              {
-                name: "json",
-                description:
-                  "Emits JSON messages to stdout, Conflicts with human and short",
-              },
-              {
-                name: "json-diagnostic-short",
-                description:
-                  "Ensures the rendered field of JSON messages contains the 'short' rendering from rustc",
-              },
-              {
-                name: "json-diagnostic-rendered-ansi",
-                description:
-                  "Ensures the rendered field of JSON messages contains embedded ANSI color codes for respecting rustc's default color scheme",
-              },
-              {
-                name: "json-render-diagnostics",
-                description:
-                  "Instructs Cargo to not include rustc diagnostics in in JSON messages printed, but instead Cargo itself should render the JSON diagnostics coming from rustc",
-              },
-            ],
+            name: "color",
+            suggestions: ["always", "never", "auto"],
           },
         },
         {
-          name: "--unit-graph",
-          description: "Outputs build graph in JSON",
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
         },
         {
-          name: "--ignore-rust-version",
-          description: "Ignores `rust-version` specification in packages",
-        },
-        {
-          name: "--future-incompat-report",
+          name: "-Z",
           description:
-            "Ouputs a future incompatibility report at the end of the build",
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-w", "--workspace"],
+          description: "Only update the workspace packages",
+        },
+        {
+          name: "--aggressive",
+          description:
+            "Force updating all dependencies of SPEC as well when used with -p",
+        },
+        {
+          name: "--dry-run",
+          description: "Don't actually write the lockfile",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
         },
       ],
+    },
+    {
+      name: "vendor",
+      icon: "📦",
+      description: "Vendor all dependencies for a project locally",
+      options: [
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: ["-s", "--sync"],
+          description: "Additional `Cargo.toml` to sync and vendor",
+          isRepeatable: true,
+          args: {
+            name: "tomls",
+            isVariadic: true,
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--no-delete",
+          description: "Don't delete older crates in the vendor directory",
+        },
+        {
+          name: "--respect-source-config",
+          description: "Respect `[source]` config in `.cargo/config`",
+          isRepeatable: true,
+        },
+        {
+          name: "--versioned-dirs",
+          description: "Always include version in subdir name",
+        },
+        {
+          name: "--no-merge-sources",
+        },
+        {
+          name: "--relative-path",
+        },
+        {
+          name: "--only-git-deps",
+        },
+        {
+          name: "--disallow-duplicates",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "path",
+      },
+    },
+    {
+      name: "verify-project",
+      icon: "📦",
+      description: "Check correctness of crate manifest",
+      options: [
+        {
+          name: "--manifest-path",
+          description: "Path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+
+            generators: filepaths({ equals: "Cargo.toml" }),
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "version",
+      icon: "📦",
+      description: "Show version information",
+      options: [
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+    },
+    {
+      name: "yank",
+      icon: "📦",
+      description: "Remove a pushed crate from the index",
+      options: [
+        {
+          name: "--vers",
+          description: "The version to yank or un-yank",
+          args: {
+            name: "vers",
+          },
+        },
+        {
+          name: "--index",
+          description: "Registry index to yank from",
+          args: {
+            name: "index",
+          },
+        },
+        {
+          name: "--token",
+          description: "API token to use when authenticating",
+          args: {
+            name: "token",
+          },
+        },
+        {
+          name: "--registry",
+          description: "Registry to use",
+          args: {
+            name: "registry",
+          },
+        },
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Do not print cargo log messages",
+        },
+        {
+          name: "--undo",
+          description: "Undo a yank, putting a version back into the index",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "crate",
+      },
+    },
+    {
+      name: "help",
+      icon: "📦",
+      description: "Print this message or the help of the given subcommand(s)",
+      options: [
+        {
+          name: "--color",
+          description: "Coloring: auto, always, never",
+          args: {
+            name: "color",
+            suggestions: ["always", "never", "auto"],
+          },
+        },
+        {
+          name: "--config",
+          description: "Override a configuration value (unstable)",
+          isRepeatable: true,
+          args: {
+            name: "config",
+          },
+        },
+        {
+          name: "-Z",
+          description:
+            "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+          isRepeatable: true,
+          args: {
+            name: "unstable-features",
+          },
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output (-vv very verbose/build.rs output)",
+          isRepeatable: true,
+        },
+        {
+          name: "--frozen",
+          description: "Require Cargo.lock and cache are up to date",
+        },
+        {
+          name: "--locked",
+          description: "Require Cargo.lock is up to date",
+        },
+        {
+          name: "--offline",
+          description: "Run without accessing the network",
+        },
+      ],
+      args: {
+        name: "subcommand",
+      },
+    },
+  ],
+  options: [
+    {
+      name: "--explain",
+      description: "Run `rustc --explain CODE`",
+      args: {
+        name: "explain",
+      },
+    },
+    {
+      name: "--color",
+      description: "Coloring: auto, always, never",
+      args: {
+        name: "color",
+        suggestions: ["always", "never", "auto"],
+      },
+    },
+    {
+      name: "--config",
+      description: "Override a configuration value (unstable)",
+      isRepeatable: true,
+      args: {
+        name: "config",
+      },
+    },
+    {
+      name: "-Z",
+      description:
+        "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+      isRepeatable: true,
+      args: {
+        name: "unstable-features",
+      },
+    },
+    {
+      name: ["-h", "--help"],
+      description: "Print help information",
+    },
+    {
+      name: ["-V", "--version"],
+      description: "Print version info and exit",
+    },
+    {
+      name: "--list",
+      description: "List installed commands",
+    },
+    {
+      name: ["-v", "--verbose"],
+      description: "Use verbose output (-vv very verbose/build.rs output)",
+      isRepeatable: true,
+    },
+    {
+      name: ["-q", "--quiet"],
+      description: "Do not print cargo log messages",
+    },
+    {
+      name: "--frozen",
+      description: "Require Cargo.lock and cache are up to date",
+    },
+    {
+      name: "--locked",
+      description: "Require Cargo.lock is up to date",
+    },
+    {
+      name: "--offline",
+      description: "Run without accessing the network",
     },
   ],
   generateSpec: async (_tokens, executeShellCommand) => {
@@ -1417,7 +5085,45 @@ const completionSpec: Fig.Spec = {
             "Format all packages, and also their local path-based dependencies",
         },
         {
-          name: "--quiet",
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "No output printed to stdout",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Use verbose output",
+        },
+        {
+          name: "--version",
+          description: "Print rustfmt version and exit",
+        },
+        {
+          name: "--manifest-path",
+          description: "Specify path to Cargo.toml",
+          args: {
+            name: "manifest-path",
+            generators: filepaths({
+              equals: ["Cargo.toml"],
+            }),
+          },
+        },
+        {
+          name: "--message-format",
+          description: "Specify message-format",
+          args: {
+            name: "message-format",
+            suggestions: ["short", "json", "human"],
+          },
+        },
+        {
+          name: ["-p", "--package"],
+          description: "Specify package to format",
+          args: {
+            name: "package",
+          },
         },
       ],
     };
@@ -1612,71 +5318,6 @@ const completionSpec: Fig.Spec = {
       subcommands,
     };
   },
-  options: [
-    {
-      name: ["-V", "--version"],
-      description: "The current version",
-    },
-    {
-      name: "--list",
-      description: "List installed commands",
-    },
-    {
-      name: ["-h", "--help"],
-      description: "Prints help information",
-      isPersistent: true,
-    },
-    {
-      name: ["-q", "--quiet"],
-      description: "No output printed to stdout",
-      isPersistent: true,
-    },
-    {
-      name: ["-v", "--verbose"],
-      description: "Use verbose output (-vv very verbose/build.rs output)",
-      isRepeatable: 2,
-      isPersistent: true,
-    },
-    {
-      name: "--color",
-      description: "Coloring: auto, always, never",
-      args: {
-        name: "WHEN",
-        suggestions: ["auto", "always", "never"],
-      },
-      isPersistent: true,
-    },
-    {
-      name: "--frozen",
-      description: "Require Cargo.lock and cache are up to date",
-      isPersistent: true,
-    },
-    {
-      name: "--locked",
-      description: "Require Cargo.lock is up to date",
-      isPersistent: true,
-    },
-    {
-      name: "--offline",
-      description: "Run without accessing the network",
-      isPersistent: true,
-    },
-    {
-      name: "--config",
-      description: "Override a configuration value (unstable)",
-      args: { name: "KEY=VALUE" },
-      isRepeatable: true,
-      isPersistent: true,
-    },
-    {
-      name: "-Z",
-      description:
-        "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
-      args: { name: "FLAG" },
-      isRepeatable: true,
-      isPersistent: true,
-    },
-  ],
 };
 
 export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This adds all the remaining subcommands to cargo, thankfully cargo is based on clap 3 which I just recently improved.

What is missing still from cargo spec:
* All the current generators could be improved, most are slow and not get functionally
* Still missing tons of plugins (cargo-outdated, cargo-edit, etc.)