### PR TITLE
feat: improve git diff

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -2616,10 +2616,21 @@ const completionSpec: Fig.Spec = {
             name: "[=< width >[,< name-width >[,< count >]]]",
           },
         },
+        {
+          name: "--",
+          description: "Separates paths from options for disambiguation purposes",
+          args: {
+            isVariadic: true,
+            optionsCanBreakVariadicArg: false,
+            template: "filepaths",
+            name: "[< path >...]",
+          },
+        },
       ],
       args: {
         name: "commit or file",
         isOptional: true,
+        isVariadic: true,
         suggestions: headSuggestions,
         generators: [
           gitGenerators.commits,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix
**What is the current behavior? (You can also link to an open issue here)**
#901
- Autocomplete ignores '--' in `git diff`.

- Autocomplete only suggests one commit when you can provide as many as 
you want.

**What is the new behavior (if this is a feature change)?**

- Autocomplete recognises '--' and provides `filepath` suggestions.

- `git diff` now uses `isVariadic` to suggest many arguments.