### PR TITLE
fix: search double quotes in rails dynamic generator

### DIFF
--- a/src/rails.ts
+++ b/src/rails.ts
@@ -604,7 +604,7 @@ const checkRailsInstalled = async (
   executeShellCommand: Fig.ExecuteShellCommandFunction
 ): Promise<boolean> => {
   const gemfileMatch = await executeShellCommand(
-    `until [[ -f Gemfile ]] || [[ $PWD = '/' ]]; do cd ..; done; if [ -f Gemfile ]; then cat Gemfile | \grep "gem 'rails'"; else echo ""; fi`
+    `until [[ -f Gemfile ]] || [[ $PWD = '/' ]]; do cd ..; done; if [ -f Gemfile ]; then cat Gemfile | \grep "gem ['\"]rails['\"]"; else echo ""; fi`
   );
   const isRails = !!gemfileMatch;
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix

**What is the current behavior? (You can also link to an open issue here)**
Currently, the rails completion spec checks if rails is in the Gemfile, if there isn't a gemfile or if rails isn't in it the only completion for rails will be `new`.

The problem, is that it checks for rails using `\grep "gem 'rails'"`. The problem with this is that it only matches when 'single-quotes' are used, if "double-quotes" are used, grep won't match anything and only `new` will be suggested.

Fixes #870

**What is the new behavior (if this is a feature change)?**
This commit makes it match double and single quotes using `\grep "gem ['\"]rails['\"]"`.