### PR TITLE
chore: update terminals in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Never submitted a PR before? Check out our [How to Contribute](https://fig.io/do
 
 #### What terminals does Fig work with?
 
-Fig works with [iTerm](https://iterm2.com/), [Tabby](https://tabby.sh), the native MacOS Terminal app, Hyper and the [integrated terminal in VSCode](https://code.visualstudio.com/docs/editor/integrated-terminal).
+Fig works with the native MacOS Terminal app, [iTerm](https://iterm2.com/), [Tabby](https://tabby.sh), [Hyper](https://hyper.is) and the [integrated terminal in VSCode](https://code.visualstudio.com/docs/editor/integrated-terminal).
 
 #### How does Fig work?
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Never submitted a PR before? Check out our [How to Contribute](https://fig.io/do
 
 #### What terminals does Fig work with?
 
-Fig works with iTerm, [Tabby](https://tabby.sh), the native MacOS Terminal app, Hyper and the integrated terminal in VSCode.
+Fig works with [iTerm](https://iterm2.com/), [Tabby](https://tabby.sh), the native MacOS Terminal app, Hyper and the [integrated terminal in VSCode](https://code.visualstudio.com/docs/editor/integrated-terminal).
 
 #### How does Fig work?
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Never submitted a PR before? Check out our [How to Contribute](https://fig.io/do
 
 #### What terminals does Fig work with?
 
-Fig works with iTerm, the native MacOS Terminal app, Hyper and the integrated terminal in VSCode.
+Fig works with iTerm, [Tabby](https://tabby.sh), the native MacOS Terminal app, Hyper and the integrated terminal in VSCode.
 
 #### How does Fig work?
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Doc update 

updated the readme to include [Tabby](https://tabby.sh) as supported terminal
