### PR TITLE
feat: add `killall` spec

### DIFF
--- a/src/killall.ts
+++ b/src/killall.ts
@@ -1,3 +1,5 @@
+// Linux incompatible
+
 const signals = [
   "hup",
   "int",
@@ -35,7 +37,7 @@ const signals = [
 
 const completionSpec: Fig.Spec = {
   name: "killall",
-  description: "",
+  description: "Kill processes by name",
   args: {
     name: "process_name",
     isVariadic: true,
@@ -55,7 +57,10 @@ const completionSpec: Fig.Spec = {
             return {
               name,
               description: path,
-              priority: !badChars.some((char) => nameChars.has(char)) ? 51 : 40,
+              priority:
+                !badChars.some((char) => nameChars.has(char)) && isApp
+                  ? 51
+                  : 40,
               icon: isApp
                 ? "fig://" + path.slice(0, appExtIndex + 4)
                 : "fig://icon?type=gear",

--- a/src/killall.ts
+++ b/src/killall.ts
@@ -1,0 +1,148 @@
+const signals = [
+  "hup",
+  "int",
+  "quit",
+  "ill",
+  "trap",
+  "abrt",
+  "emt",
+  "fpe",
+  "kill",
+  "bus",
+  "segv",
+  "sys",
+  "pipe",
+  "alrm",
+  // This is the default signal
+  // "term",
+  "urg",
+  "stop",
+  "tstp",
+  "cont",
+  "chld",
+  "ttin",
+  "ttou",
+  "io",
+  "xcpu",
+  "xfsz",
+  "vtalrm",
+  "prof",
+  "winch",
+  "info",
+  "usr1",
+  "usr2",
+];
+
+const completionSpec: Fig.Spec = {
+  name: "killall",
+  description: "",
+  args: {
+    name: "process_name",
+    isVariadic: true,
+    generators: {
+      // All processes, only display the path
+      script: "ps -A -o comm | sort -u",
+      postProcess: (out) =>
+        out
+          .trim()
+          .split("\n")
+          .map((path) => {
+            const appExtIndex = path.indexOf(".app/");
+            const isApp = appExtIndex !== -1;
+            const name = path.slice(path.lastIndexOf("/") + 1);
+            const nameChars = new Set(name);
+            const badChars = ["(", "_", "."];
+            return {
+              name,
+              description: path,
+              priority: !badChars.some((char) => nameChars.has(char)) ? 51 : 40,
+              icon: isApp
+                ? "fig://" + path.slice(0, appExtIndex + 4)
+                : "fig://icon?type=gear",
+            };
+          }),
+    },
+  },
+  options: [
+    {
+      name: "-d",
+      description: "Be verbose (dry run) and display number of user processes",
+    },
+    {
+      name: "-e",
+      description:
+        "Use the effective user ID instead of the real user ID for matching processes with -u",
+    },
+    {
+      name: "-help",
+      description: "Display help and exit",
+    },
+    {
+      name: "-I",
+      description: "Request confirmation before killing each process",
+    },
+    {
+      name: "-l",
+      description: "List the names of the available signals and exit",
+    },
+    {
+      name: "-m",
+      description: "Match the process name as a regular expression",
+    },
+    {
+      name: "-v",
+      description: "Be verbose",
+    },
+    {
+      name: "-s",
+      description: "Be verbose (dry run)",
+    },
+    ...signals.map((signal) => ({
+      name: "-SIG" + signal.toUpperCase(),
+      description: `Send ${signal.toUpperCase()} instead of TERM`,
+    })),
+    {
+      name: "-u",
+      description:
+        "Limit potentially matching processes to those belonging to the user",
+      args: {
+        name: "user",
+        generators: {
+          script: "dscl . -list /Users | grep -v '^_'",
+          postProcess: (out) =>
+            out
+              .trim()
+              .split("\n")
+              .map((username) => ({
+                name: username,
+                icon: "fig://template?badge=👤",
+              })),
+        },
+      },
+    },
+    {
+      name: "-t",
+      description:
+        "Limit matching processes to those running on the specified TTY",
+      args: {
+        name: "tty",
+      },
+    },
+    {
+      name: "-c",
+      description: "Limit matching processes to those matching the given name",
+      args: {
+        name: "name",
+      },
+    },
+    {
+      name: "-q",
+      description: "Suppress error message if no processes are matched",
+    },
+    {
+      name: "-z",
+      description: "Do not skip zombies",
+    },
+  ],
+};
+export default completionSpec;


### PR DESCRIPTION
Includes generators for process names and users. Both are not linux-compatible. Listing users uses dscl, process names checks for ".app"

<img width="400" alt="CleanShot 2022-02-19 at 02 09 15@2x" src="https://user-images.githubusercontent.com/52195359/154708926-969b8c6f-9d11-4b5e-af43-433ce1e9c00e.png">
<img width="400" alt="CleanShot 2022-02-19 at 02 09 28@2x" src="https://user-images.githubusercontent.com/52195359/154709089-621b0cf7-ce94-459a-8668-b2228f5ea9ca.png">

Next up is updating deno to 1.19