### PR TITLE
feat(yarn): add `react-native` to CLIs

### DIFF
--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -7,6 +7,7 @@ import {
 export const nodeClis = [
   "vue",
   "nuxt",
+  "react-native",
   "expo",
   "jest",
   "next",

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -388,6 +388,7 @@ const completionSpec: Fig.Spec = {
     generators: npmScriptsGenerator,
     parserDirectives: npmParserDirectives,
     isOptional: true,
+    isCommand: true,
   },
   options: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
2 Features:
- Add `react-native` as a CLI;
- Add the `isCommand` flag to `yarn`

**What is the current behavior? (You can also link to an open issue here)**
Today, `react-native` is not considered a CLI and thus does not autocomplete. Also, we don't get autocomplete for our `package.json` scripts.

##### Screenshots
<p align="center">
	<img width="408" alt="image" src="https://user-images.githubusercontent.com/9873486/154749531-51d3c07e-5010-407d-84ac-89c3796c6d90.png">
</p>

And for the script:

```json
"android": "react-native run-android",
```  
<p align="center">
	<img width="364" alt="image" src="https://user-images.githubusercontent.com/9873486/154749690-3eaac0e1-2dab-45cd-a2c8-4ca1084453a4.png">
</p>

**What is the new behavior (if this is a feature change)?**

<p align="center">
  <img width="407" alt="image" src="https://user-images.githubusercontent.com/9873486/154750061-f473d2c6-83f7-4493-83ba-3930a82dbfff.png">
  <img width="448" alt="image" src="https://user-images.githubusercontent.com/9873486/154750036-bfd9b97d-dcc6-421f-ba9b-0b1ac64f7555.png">
</p>