### PR TITLE
feat: add rmdir completion

### DIFF
--- a/src/rmdir.ts
+++ b/src/rmdir.ts
@@ -1,0 +1,18 @@
+const completionSpec: Fig.Spec = {
+  name: "rmdir",
+  description: "Remove directories",
+  args: {
+    isVariadic: true,
+    template: "folders",
+  },
+
+  options: [
+    {
+      name: "-p",
+      description: "Remove each directory of path",
+      isDangerous: true,
+    },
+  ],
+};
+
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature.

**What is the current behavior? (You can also link to an open issue here)**
`rmdir` has no completion.

**What is the new behavior (if this is a feature change)?**
Adds completion to `rmdir`.

**Additional info:**
I initially created a new generator for this that filters out all of the non-empty folders, but using the folders template makes more sense. Using the initial method, we would not get completion for `path1` in `rmdir path1/path2/`.