### PR TITLE
feat: add `touch` completion

### DIFF
--- a/src/touch.ts
+++ b/src/touch.ts
@@ -4,6 +4,8 @@ const completionSpec: Fig.Spec = {
   args: {
     name: "file",
     isVariadic: true,
+    template: "folders",
+    suggestCurrentToken: true,
   },
   options: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature.

**What is the current behavior? (You can also link to an open issue here)**
`touch` has no completion for directories. If I am at ~ and want to create a file at ~/myfolder/newfile, there is no completion for myfolder.

**What is the new behavior (if this is a feature change)?**
Add `touch` completion, similar to #852.

**Additional info:**