### PR TITLE
chore(deps): bump `typescript` to `4.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "pretty-quick": "^3.1.0",
     "progress": "^2.0.3",
     "ts-node": "^9.1.1",
-    "typescript": "~4.5.0"
+    "typescript": "^4.5.5"
   },
   "dependencies": {
     "@types/glob": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "pretty-quick": "^3.1.0",
     "progress": "^2.0.3",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.3"
+    "typescript": "~4.5.0"
   },
   "dependencies": {
     "@types/glob": "^7.2.0",


### PR DESCRIPTION
Changes:

1. upgrade typescript to 4.5.0
2. Use tilde instread of caret when specify typescript dependency, because upgrade typescript minor version will introduce breaking change

