### PR TITLE
feat(ansible-playbook): update generators to use `.yml` files instead of hostname pattern

### DIFF
--- a/src/ansible-playbook.ts
+++ b/src/ansible-playbook.ts
@@ -3,7 +3,7 @@ import { filepaths } from "@fig/autocomplete-generators";
 const completionSpec: Fig.Spec = {
   name: "ansible-playbook",
   description:
-    "Tuns Ansible playbooks, executing the defined tasks on the targeted hosts",
+    "Runs Ansible playbooks, executing the defined tasks on the targeted hosts",
   args: {
     name: "playbook",
     description: "Playbook(s)",

--- a/src/ansible-playbook.ts
+++ b/src/ansible-playbook.ts
@@ -1,10 +1,14 @@
+import { filepaths } from "@fig/autocomplete-generators";
+
 const completionSpec: Fig.Spec = {
   name: "ansible-playbook",
   description:
     "Tuns Ansible playbooks, executing the defined tasks on the targeted hosts",
   args: {
-    name: "pattern",
-    description: "Host pattern",
+    name: "playbook",
+    description: "Playbook(s)",
+    isVariadic: true,
+    generators: filepaths({ extensions: ["yml", "yaml"] }),
   },
   options: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
Old spec incorrectly expects a hostname pattern 

**What is the new behavior?**
New spec autocompletes `.yml` file(s) according to the [official Ansible Docs for the CLI](https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html)