### PR TITLE
fix: tailwindcss icon

### DIFF
--- a/src/tailwindcss.ts
+++ b/src/tailwindcss.ts
@@ -57,7 +57,7 @@ const buildOptions: Fig.Option[] = [
 const completionSpec: Fig.Spec = {
   name: "tailwindcss",
   description: "Tailwindcss CLI tools",
-  icon: "https://tailwindcss.com/favicon-32x32.png",
+  icon: "https://tailwindcss.com/favicons/favicon-32x32.png",
   options: buildOptions,
   subcommands: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

- bug fix

**What is the current behavior? (You can also link to an open issue here)**

- current `tailwindcss` icon prop throws 404
