### PR TITLE
fix(man): update suggestions for new token

### DIFF
--- a/src/man.ts
+++ b/src/man.ts
@@ -53,6 +53,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       generators: generateManualPages,
+      isOptional: true,
     },
   ],
   options: [


### PR DESCRIPTION
The autocomplete engine doesn't re-run generators for different tokens if the argument is the same (only affects variadic args).

`trigger: " "` doesn't work because spaces aren't included in the token unless they're escaped.
`trigger: ""` would work but re-runs the generator on each keystroke. Not great performance.

The best solution I found was to simply make a new argument. _Technically_ this is incorrect, since `man` can take multiple pages to look up, but it's not a big deal since (as far as I know) nobody uses it to do that.

Is there another solution? Would love to implement that instead 🙂