### PR TITLE
feat: add basic `date` completion spec

### DIFF
--- a/src/date.ts
+++ b/src/date.ts
@@ -1,0 +1,80 @@
+const completionSpec: Fig.Spec = {
+  name: "date",
+  description: "Display or set date and time",
+  options: [
+    {
+      name: "-d",
+      description: "Set the kernel's value for daylight saving time",
+      args: {
+        name: "dst",
+      },
+    },
+    {
+      name: "-f",
+      description:
+        "Use specified format for input instead of the default [[[mm]dd]HH]MM[[cc]yy][.ss] format",
+      args: [
+        {
+          name: "input_fmt",
+          description: "The format with which to parse the new date value",
+        },
+        {
+          name: "new_date",
+          description: "The new date to set",
+        },
+      ],
+    },
+    {
+      name: "-j",
+      description: "Don't try to set the date",
+    },
+    {
+      name: "-n",
+      description:
+        "Only set time on the current machine, instead of all machines in the local group",
+    },
+    {
+      name: "-R",
+      description: "Use RFC 2822 date and time output format",
+    },
+    {
+      name: "-r",
+      description:
+        "Print the date and time represented by the specified number of seconds since the Epoch",
+      args: {
+        name: "seconds",
+        descrption:
+          "Number of seconds since the Epoch (00:00:00 UTC, January 1, 1970).",
+      },
+    },
+    {
+      name: "-t",
+      description: "Set the system's value for minutes west of GMT",
+      args: {
+        name: "minutes_west",
+      },
+    },
+    {
+      name: "-u",
+      description:
+        "Display or set the date in UTC (Coordinated Universal) time",
+    },
+    {
+      name: "-v",
+      description:
+        "Adjust and print (but don't set) the second, minute, hour, month day, week day, month, or year according to val",
+      args: {
+        name: "val",
+        descrption: "[+|-]val[ymwdHMS]",
+      },
+    },
+  ],
+  args: {
+    name: "new_time OR output_fmt",
+    description:
+      "New_time: [[[mm]dd]HH]MM[[cc]yy][.ss], output_fmt: '+' followed by user-defined format string",
+    isOptional: true,
+    isDangerous: true,
+  },
+};
+export default completionSpec;

--- a/src/date.ts
+++ b/src/date.ts
@@ -43,7 +43,7 @@ const completionSpec: Fig.Spec = {
         "Print the date and time represented by the specified number of seconds since the Epoch",
       args: {
         name: "seconds",
-        descrption:
+        description:
           "Number of seconds since the Epoch (00:00:00 UTC, January 1, 1970).",
       },
     },
@@ -65,7 +65,7 @@ const completionSpec: Fig.Spec = {
         "Adjust and print (but don't set) the second, minute, hour, month day, week day, month, or year according to val",
       args: {
         name: "val",
-        descrption: "[+|-]val[ymwdHMS]",
+        description: "[+|-]val[ymwdHMS]",
       },
     },
   ],


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

New completion spec

**What is the current behavior? (You can also link to an open issue here)**

No completion for unix `date` command

**What is the new behavior (if this is a feature change)?**

Completion for unix `date` command

**Additional info:**

This basically works. The `date` command has some weird structure so I had to create an argument with two potential options for what it does, and document them both in the same argument object in the spec (see https://github.com/qubist/autocomplete/blob/198754849ded82b92df96a9465710de510556a25/src/date.ts#L72-L78). If anyone knows how to do this differently, I'd be happy to learn and implement it: Ideally, `fig` would decide (like `date` does) which interpretation of its one argument to use based on whether it starts with a `+` character or not.