### PR TITLE
feat: add `mdfind` completion spec

### DIFF
--- a/src/mdfind.ts
+++ b/src/mdfind.ts
@@ -1,6 +1,6 @@
 const smartFolderGenerator: Fig.Generator = {
   // `mdfind -s` only accepts smart folders in ~/Library/Saved\ Searches/
-  script: `ls -1A ~/Library/Saved\\ Searches/*.savedSearch | xargs -I '{}' echo {}`,
+  script: `ls -1A ~/Library/Saved\\ Searches/*.savedSearch`,
   postProcess: function (files) {
     return files.split("\n").map((path) => {
       const components = path.split("/");

--- a/src/mdfind.ts
+++ b/src/mdfind.ts
@@ -1,0 +1,70 @@
+const completionSpec: Fig.Spec = {
+  name: "mdfind",
+  description: "Finds files matching a given query",
+  parserDirectives: {
+    flagsArePosixNoncompliant: true,
+  },
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for mdfind",
+    },
+    {
+      name: "-0",
+      description: "Prints an ASCII NUL character after each result path",
+    },
+    {
+      name: "-live",
+      description:
+        "Provide live-updates to the number of files matching the query",
+    },
+    {
+      name: "-count",
+      description:
+        "Output the total number of matches, instead of the path to the matching items",
+    },
+    {
+      name: "-onlyin",
+      description: "Limit the scope of the search to <dir>",
+      args: {
+        name: "dir",
+        description: "Directory",
+        template: "folders",
+      },
+    },
+    {
+      name: "-name",
+      description: "Search for matching file names to <filename> only",
+      args: {
+        name: "filename",
+      },
+    },
+    {
+      name: "-reprint",
+      description: "Reprint results on live update",
+    },
+    {
+      name: "-s",
+      description: "Show contents of smart folder <folder>",
+      args: {
+        name: "folder",
+        description: "Smart folder",
+        template: "folders", // should ideally be a generator that only shows smart folders
+      },
+    },
+    {
+      name: "-literal",
+      description:
+        "Force the provided query string to be taken as a literal query string, without interpretation",
+    },
+    {
+      name: "-interpret",
+      description:
+        "Force the provided query string to be interpreted as if it had been typed into the Spotlight menu",
+    },
+  ],
+  args: {
+    name: "query",
+  },
+};
+export default completionSpec;

--- a/src/mdfind.ts
+++ b/src/mdfind.ts
@@ -1,3 +1,21 @@
+const smartFolderGenerator: Fig.Generator = {
+  // `mdfind -s` only accepts smart folders in ~/Library/Saved\ Searches/
+  script: `ls -1A ~/Library/Saved\\ Searches/*.savedSearch | xargs -I '{}' echo {}`,
+  postProcess: function (files) {
+    return files.split("\n").map((path) => {
+      const components = path.split("/");
+      const filename = components[components.length - 1];
+      return {
+        name: filename.substring(0, filename.indexOf(".")), // .savedSearch automatically added to the query, so remove it
+        displayName: filename,
+        icon: "fig://" + path,
+        description: "Smart folder",
+      };
+    });
+  },
+  trigger: "/",
+};
+
 const completionSpec: Fig.Spec = {
   name: "mdfind",
   description: "Finds files matching a given query",
@@ -45,11 +63,12 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "-s",
-      description: "Show contents of smart folder <folder>",
+      description:
+        "Show contents of smart folder ~/Library/Saved Searches/<folder>.savedSearch",
       args: {
         name: "folder",
-        description: "Smart folder",
-        template: "folders", // should ideally be a generator that only shows smart folders
+        description: "Smart folder in  ~/Library/Saved Searches",
+        generators: smartFolderGenerator,
       },
     },
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature

**What is the current behavior? (You can also link to an open issue here)**
Completion spec does not exist #940 

**What is the new behavior (if this is a feature change)?**
Add completion spec

**Additional info:**
Completion spec for [mdfind](https://ss64.com/osx/mdfind.html)
Basic generator for smart folder option `mdfind -s`