### PR TITLE
chore: add bugs url to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   ],
   "author": "",
   "license": "ISC",
+  "bugs": "https://github.com/withfig/autocomplete/issues",
   "devDependencies": {
     "@fig/autocomplete-generators": "^1.0.0",
     "@types/inquirer": "^7.3.1",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Updates package metadata

**What is the current behavior? (You can also link to an open issue here)**
https://github.com/withfig/autocomplete/issues/993

`npm bugs` from the repo would open the url `https://www.npmjs.com/package/@withfig/autocomplete` in browser

`npm bugs --browser false` will print the following output 

```
@withfig/autocomplete bug list available at the following URL:
 https://www.npmjs.com/package/@withfig/autocomplete
```


**What is the new behavior (if this is a feature change)?**
`npm bugs` from the repo would open the url `https://github.com/withfig/autocomplete/issues` in browser

`npm bugs --browser false` will print the following output 

```
@withfig/autocomplete bug list available at the following URL:
 https://github.com/withfig/autocomplete/issues
```

**Additional info:**