### PR TITLE
fix: link to themes repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ We would love contributions for:
 * errors with existing completion specs (e.g. missing subcomannds, options, or arguments)
 * [generators](https://fig.io/docs/getting-started/generating-argument-suggestions) for argument suggestions
 * better descriptions, icons etc
-* [themes](https://github.com/withfig/theme)!
+* [themes](https://github.com/withfig/themes)!
 
 If you aren't able to contribute, please feel free to open an [issue](https://github.com/withfig/autocomplete/issues/new/choose). Most people think that contributing will be too hard, but you'd be surprised, we have deliberately made contributing very very easy. Give it a go! 
 


### PR DESCRIPTION
fix: link to themes repository

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fix

**What is the current behavior? (You can also link to an open issue here)**
Link not working

**What is the new behavior (if this is a feature change)?**
Link working

**Additional info:**