### PR TITLE
feat(git): add missing flag to `git tag`

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -5454,6 +5454,15 @@ const completionSpec: Fig.Spec = {
           description: "Tag message",
           args: { name: "message" },
         },
+        {
+          name: "--points-at",
+          description: "List tags of the given object",
+          args: {
+            name: "object",
+            generators: gitGenerators.commits,
+            suggestions: headSuggestions,
+          },
+        },
       ],
       args: {
         name: "tagname",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature
**What is the current behavior? (You can also link to an open issue here)**
Closes #987 
**What is the new behavior (if this is a feature change)?**
added a new flag to command: `git tag --points-at`
**Additional info:**
