### PR TITLE
feat: add `meteor` spec

### DIFF
--- a/src/meteor.ts
+++ b/src/meteor.ts
@@ -1,0 +1,16 @@
+import npm from "./npm";
+
+const completionSpec: Fig.Spec = {
+  name: "meteor",
+  description: "",
+  subcommands: [npm],
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for meteor",
+    },
+  ],
+  // Only uncomment if meteor takes an argument
+  // args: {}
+};
+export default completionSpec;

--- a/src/meteor.ts
+++ b/src/meteor.ts
@@ -2,7 +2,7 @@ import npm from "./npm";
 
 const completionSpec: Fig.Spec = {
   name: "meteor",
-  description: "",
+  description: "`meteor` command-line tool",
   subcommands: [npm],
   options: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adding Meteor to the autocomplete suggestions but specifically the `npm subcommand`

**What is the current behavior? (You can also link to an open issue here)**

It does not suggest it because it is not in there.

**What is the new behavior (if this is a feature change)?**

It now suggests at least Meteor npm suggestions

**Additional info:**