### PR TITLE
fix: add `{cursor}` to options that insert an `=`

### DIFF
--- a/src/cmake.ts
+++ b/src/cmake.ts
@@ -652,6 +652,7 @@ const completion: Fig.Spec = {
       name: "-Werror",
       description: "Enable the type of warnings",
       insertValue: "-Werror={cursor}",
+      requiresEquals: true,
       args: {
         name: "type",
         suggestions: [
@@ -670,6 +671,7 @@ const completion: Fig.Spec = {
       name: "-Wno-error",
       description: "Disable the type of warnings",
       insertValue: "-Wno-error={cursor}",
+      requiresEquals: true,
       args: {
         name: "type",
         suggestions: [

--- a/src/exa.ts
+++ b/src/exa.ts
@@ -47,6 +47,7 @@ const completionSpec: Fig.Spec = {
       description: "When to use terminal colours (always, auto, never)",
       name: ["--colour", "--color"],
       insertValue: "--colour={cursor}",
+      requiresEquals: true,
       args: {
         name: "when",
         suggestions: [

--- a/src/exa.ts
+++ b/src/exa.ts
@@ -46,7 +46,7 @@ const completionSpec: Fig.Spec = {
     {
       description: "When to use terminal colours (always, auto, never)",
       name: ["--colour", "--color"],
-      insertValue: "--colour=",
+      insertValue: "--colour={cursor}",
       args: {
         name: "when",
         suggestions: [

--- a/src/git.ts
+++ b/src/git.ts
@@ -461,6 +461,7 @@ const addOptions: Fig.Option[] = [
     description:
       "Override the executable bit of the added files. The executable bit is only changed in the index, the files on disk are left unchanged",
     insertValue: "--chmod={cursor}",
+    requiresEquals: true,
     args: {
       suggestions: ["+x", "-x"],
     },
@@ -827,6 +828,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--abbrev",
           insertValue: "--abbrev={cursor}",
+          requiresEquals: true,
           description: "Use <n> digits to display object names",
           args: {
             name: "n",
@@ -2027,6 +2029,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--repo",
           insertValue: "--repo={cursor}",
+          requiresEquals: true,
           description:
             "This option is equivalent to the <repository> argument. If both are specified, the command-line argument takes precedence",
           args: {
@@ -2074,6 +2077,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--recurse-submodules",
           insertValue: "--recurse-submodules={cursor}",
+          requiresEquals: true,
           description:
             "May be used to make sure all submodule commits used by the revisions to be pushed are available on a remote-tracking branch. If check is used Git will verify that all submodule commits that changed in the revisions to be pushed are available on at least one remote of the submodule. If any commits are missing the push will be aborted and exit with non-zero status. If on-demand is used all submodules that changed in the revisions to be pushed will be pushed. If on-demand was not able to push all necessary revisions it will also be aborted and exit with non-zero status. If only is used all submodules will be recursively pushed while the superproject is left unpushed. A value of no or using --no-recurse-submodules can be used to override the push.recurseSubmodules configuration variable when no submodule recursion is required",
           args: {
@@ -2197,6 +2201,7 @@ const completionSpec: Fig.Spec = {
           description:
             "This option determines how the merge message will be cleaned up before committing. See git-commit[1] for more details. In addition, if the <mode> is given a value of scissors, scissors will be appended to MERGE_MSG before being passed on to the commit machinery in the case of a merge conflict",
           insertValue: "--cleanup={cursor}",
+          requiresEquals: true,
           args: {
             name: "mode",
             suggestions: [
@@ -2404,6 +2409,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--depth",
           insertValue: "--depth={cursor}",
+          requiresEquals: true,
           args: {
             name: "depth",
           },
@@ -2413,6 +2419,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--deepen",
           insertValue: "--deepen={cursor}",
+          requiresEquals: true,
           args: {
             name: "depth",
           },
@@ -2422,6 +2429,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--shallow-since",
           insertValue: "--shallow-since={cursor}",
+          requiresEquals: true,
           args: {
             name: "date",
           },
@@ -2431,6 +2439,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--shallow-exclude",
           insertValue: "--shallow-exclude={cursor}",
+          requiresEquals: true,
           args: {
             name: "revision",
           },
@@ -2450,6 +2459,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--negotiation-tip",
           insertValue: "--negotiation-tip={cursor}",
+          requiresEquals: true,
           args: {
             name: "commit|glob",
             generators: gitGenerators.commits,
@@ -2487,6 +2497,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--refmap",
           insertValue: "--refmap={cursor}",
+          requiresEquals: true,
           args: {
             name: "refspec",
           },
@@ -2501,6 +2512,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--recurse-submodules",
           insertValue: "--recurse-submodules={cursor}",
+          requiresEquals: true,
           args: {
             name: "mode",
             isOptional: true,
@@ -2687,6 +2699,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--pathspec-from-file",
           insertValue: "--pathspec-from-file={cursor}",
+          requiresEquals: true,
           description:
             "Pathspec is passed in file <file> instead of commandline args",
           args: {
@@ -2752,6 +2765,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Search for commits with a commit message that matches <pattern>",
           insertValue: "--grep={cursor}",
+          requiresEquals: true,
           args: {
             name: "pattern",
           },
@@ -2760,6 +2774,7 @@ const completionSpec: Fig.Spec = {
           name: "--author",
           description: "Search for commits by a particular author",
           insertValue: "--author={cursor}",
+          requiresEquals: true,
           args: {
             name: "pattern",
           },
@@ -2824,6 +2839,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--mirror",
               insertValue: "--mirror={cursor}",
+              requiresEquals: true,
               description: "Create fetch or push mirror",
               args: {
                 suggestions: ["fetch", "push"],
@@ -3050,6 +3066,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--depth",
           insertValue: "--depth={cursor}",
+          requiresEquals: true,
           args: {
             name: "depth",
           },
@@ -3059,6 +3076,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--deepen",
           insertValue: "--deepen={cursor}",
+          requiresEquals: true,
           args: {
             name: "depth",
           },
@@ -3068,6 +3086,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--shallow-since",
           insertValue: "--shallow-since={cursor}",
+          requiresEquals: true,
           args: {
             name: "date",
           },
@@ -3077,6 +3096,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--shallow-exclude",
           insertValue: "--shallow-exclude={cursor}",
+          requiresEquals: true,
           args: {
             name: "revision",
           },
@@ -3096,6 +3116,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--negotiation-tip",
           insertValue: "--negotiation-tip={cursor}",
+          requiresEquals: true,
           args: {
             name: "commit|glob",
             generators: gitGenerators.commits,
@@ -3167,6 +3188,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--refmap",
           insertValue: "--refmap={cursor}",
+          requiresEquals: true,
           args: {
             name: "refspec",
           },
@@ -3181,6 +3203,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--recurse-submodules",
           insertValue: "--recurse-submodules={cursor}",
+          requiresEquals: true,
           args: {
             name: "mode",
             isOptional: true,
@@ -3210,6 +3233,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--submodule-prefix",
           insertValue: "--submodule-prefix={cursor}",
+          requiresEquals: true,
           args: {
             name: "path",
           },
@@ -3219,6 +3243,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--recurse-submodules-default",
           insertValue: "--recurse-submodules-default={cursor}",
+          requiresEquals: true,
           args: {
             name: "mode",
             isOptional: true,
@@ -3594,6 +3619,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Transmit the given string to the server when communicating using protocol version 2. The given string must not contain a NUL or LF character. The server’s handling of server options, including unknown ones, is server-specific. When multiple --server-option=<option> are given, they are all sent to the other side in the order listed on the command line",
           insertValue: "--server-option={cursor}",
+          requiresEquals: true,
           args: {
             name: "option",
           },
@@ -3618,6 +3644,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Use the partial clone feature and request that the server sends a subset of reachable objects according to a given object filter. When using --filter, the supplied <filter-spec> is used for the partial clone filter. For example, --filter=blob:none will filter out all blobs (file contents) until needed by Git. Also, --filter=blob:limit=<size> will filter out all blobs of size at least <size>. For more details on filter specifications, see the --filter option in git-rev-list[1]",
           insertValue: "--filter={cursor}",
+          requiresEquals: true,
           args: { name: "filter spec" },
         },
         {
@@ -3650,6 +3677,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Specify the directory from which templates will be used",
           insertValue: "--template={cursor}",
+          requiresEquals: true,
           args: {
             name: "template directory",
           },
@@ -3673,6 +3701,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Create a shallow clone with a history after the specified time",
           insertValue: "--shallow-since={cursor}",
+          requiresEquals: true,
           args: {
             name: "date",
           },
@@ -3682,6 +3711,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Create a shallow clone with a history, excluding commits reachable from a specified remote branch or tag. This option can be specified multiple times",
           insertValue: "--shallow-exclude={cursor}",
+          requiresEquals: true,
           args: {
             name: "revision",
           },
@@ -3743,6 +3773,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Instead of placing the cloned repository where it is supposed to be, place the cloned repository at the specified directory, then make a filesystem-agnostic Git symbolic link to there. The result is Git repository can be separated from working tree",
           insertValue: "--separate-git-dir={cursor}",
+          requiresEquals: true,
           args: {
             name: "git dir",
           },
@@ -4467,6 +4498,7 @@ const completionSpec: Fig.Spec = {
           description:
             "The same as --merge option above, but changes the way the conflicting hunks are presented, overriding the merge.conflictStyle configuration variable. Possible values are 'merge' (default) and 'diff3' (in addition to what is shown by 'merge' style, shows the original contents)",
           insertValue: "--conflict={cursor}",
+          requiresEquals: true,
           args: {
             isOptional: true,
             suggestions: ["merge", "diff3"],
@@ -5159,6 +5191,7 @@ const completionSpec: Fig.Spec = {
           description:
             "This option determines how the merge message will be cleaned up before committing. See git-commit[1] for more details. In addition, if the <mode> is given a value of scissors, scissors will be appended to MERGE_MSG before being passed on to the commit machinery in the case of a merge conflict",
           insertValue: "--cleanup={cursor}",
+          requiresEquals: true,
           args: {
             name: "mode",
             suggestions: [

--- a/src/git.ts
+++ b/src/git.ts
@@ -460,7 +460,7 @@ const addOptions: Fig.Option[] = [
     name: "--chmod",
     description:
       "Override the executable bit of the added files. The executable bit is only changed in the index, the files on disk are left unchanged",
-    insertValue: "--chmod=",
+    insertValue: "--chmod={cursor}",
     args: {
       suggestions: ["+x", "-x"],
     },
@@ -826,7 +826,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--abbrev",
-          insertValue: "--abbrev=",
+          insertValue: "--abbrev={cursor}",
           description: "Use <n> digits to display object names",
           args: {
             name: "n",
@@ -2026,7 +2026,7 @@ const completionSpec: Fig.Spec = {
 
         {
           name: "--repo",
-          insertValue: "--repo=",
+          insertValue: "--repo={cursor}",
           description:
             "This option is equivalent to the <repository> argument. If both are specified, the command-line argument takes precedence",
           args: {
@@ -2073,7 +2073,7 @@ const completionSpec: Fig.Spec = {
 
         {
           name: "--recurse-submodules",
-          insertValue: "--recurse-submodules=",
+          insertValue: "--recurse-submodules={cursor}",
           description:
             "May be used to make sure all submodule commits used by the revisions to be pushed are available on a remote-tracking branch. If check is used Git will verify that all submodule commits that changed in the revisions to be pushed are available on at least one remote of the submodule. If any commits are missing the push will be aborted and exit with non-zero status. If on-demand is used all submodules that changed in the revisions to be pushed will be pushed. If on-demand was not able to push all necessary revisions it will also be aborted and exit with non-zero status. If only is used all submodules will be recursively pushed while the superproject is left unpushed. A value of no or using --no-recurse-submodules can be used to override the push.recurseSubmodules configuration variable when no submodule recursion is required",
           args: {
@@ -2196,7 +2196,7 @@ const completionSpec: Fig.Spec = {
           name: "--cleanup",
           description:
             "This option determines how the merge message will be cleaned up before committing. See git-commit[1] for more details. In addition, if the <mode> is given a value of scissors, scissors will be appended to MERGE_MSG before being passed on to the commit machinery in the case of a merge conflict",
-          insertValue: "--cleanup=",
+          insertValue: "--cleanup={cursor}",
           args: {
             name: "mode",
             suggestions: [
@@ -2403,7 +2403,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--depth",
-          insertValue: "--depth=",
+          insertValue: "--depth={cursor}",
           args: {
             name: "depth",
           },
@@ -2412,7 +2412,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--deepen",
-          insertValue: "--deepen=",
+          insertValue: "--deepen={cursor}",
           args: {
             name: "depth",
           },
@@ -2421,7 +2421,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--shallow-since",
-          insertValue: "--shallow-since=",
+          insertValue: "--shallow-since={cursor}",
           args: {
             name: "date",
           },
@@ -2430,7 +2430,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--shallow-exclude",
-          insertValue: "--shallow-exclude=",
+          insertValue: "--shallow-exclude={cursor}",
           args: {
             name: "revision",
           },
@@ -2449,7 +2449,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--negotiation-tip",
-          insertValue: "--negotiation-tip=",
+          insertValue: "--negotiation-tip={cursor}",
           args: {
             name: "commit|glob",
             generators: gitGenerators.commits,
@@ -2486,7 +2486,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--refmap",
-          insertValue: "--refmap=",
+          insertValue: "--refmap={cursor}",
           args: {
             name: "refspec",
           },
@@ -2500,7 +2500,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--recurse-submodules",
-          insertValue: "--recurse-submodules=",
+          insertValue: "--recurse-submodules={cursor}",
           args: {
             name: "mode",
             isOptional: true,
@@ -2751,7 +2751,7 @@ const completionSpec: Fig.Spec = {
           name: "--grep",
           description:
             "Search for commits with a commit message that matches <pattern>",
-          insertValue: "--grep=",
+          insertValue: "--grep={cursor}",
           args: {
             name: "pattern",
           },
@@ -2759,7 +2759,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--author",
           description: "Search for commits by a particular author",
-          insertValue: "--author=",
+          insertValue: "--author={cursor}",
           args: {
             name: "pattern",
           },
@@ -2823,7 +2823,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--mirror",
-              insertValue: "--mirror=",
+              insertValue: "--mirror={cursor}",
               description: "Create fetch or push mirror",
               args: {
                 suggestions: ["fetch", "push"],
@@ -3049,7 +3049,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--depth",
-          insertValue: "--depth=",
+          insertValue: "--depth={cursor}",
           args: {
             name: "depth",
           },
@@ -3058,7 +3058,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--deepen",
-          insertValue: "--deepen=",
+          insertValue: "--deepen={cursor}",
           args: {
             name: "depth",
           },
@@ -3067,7 +3067,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--shallow-since",
-          insertValue: "--shallow-since=",
+          insertValue: "--shallow-since={cursor}",
           args: {
             name: "date",
           },
@@ -3076,7 +3076,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--shallow-exclude",
-          insertValue: "--shallow-exclude=",
+          insertValue: "--shallow-exclude={cursor}",
           args: {
             name: "revision",
           },
@@ -3095,7 +3095,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--negotiation-tip",
-          insertValue: "--negotiation-tip=",
+          insertValue: "--negotiation-tip={cursor}",
           args: {
             name: "commit|glob",
             generators: gitGenerators.commits,
@@ -3166,7 +3166,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--refmap",
-          insertValue: "--refmap=",
+          insertValue: "--refmap={cursor}",
           args: {
             name: "refspec",
           },
@@ -3180,7 +3180,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--recurse-submodules",
-          insertValue: "--recurse-submodules=",
+          insertValue: "--recurse-submodules={cursor}",
           args: {
             name: "mode",
             isOptional: true,
@@ -3209,7 +3209,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--submodule-prefix",
-          insertValue: "--submodule-prefix=",
+          insertValue: "--submodule-prefix={cursor}",
           args: {
             name: "path",
           },
@@ -3218,7 +3218,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--recurse-submodules-default",
-          insertValue: "--recurse-submodules-default=",
+          insertValue: "--recurse-submodules-default={cursor}",
           args: {
             name: "mode",
             isOptional: true,
@@ -3593,7 +3593,7 @@ const completionSpec: Fig.Spec = {
           name: "--server-option",
           description:
             "Transmit the given string to the server when communicating using protocol version 2. The given string must not contain a NUL or LF character. The server’s handling of server options, including unknown ones, is server-specific. When multiple --server-option=<option> are given, they are all sent to the other side in the order listed on the command line",
-          insertValue: "--server-option=",
+          insertValue: "--server-option={cursor}",
           args: {
             name: "option",
           },
@@ -3617,7 +3617,7 @@ const completionSpec: Fig.Spec = {
           name: "--filter",
           description:
             "Use the partial clone feature and request that the server sends a subset of reachable objects according to a given object filter. When using --filter, the supplied <filter-spec> is used for the partial clone filter. For example, --filter=blob:none will filter out all blobs (file contents) until needed by Git. Also, --filter=blob:limit=<size> will filter out all blobs of size at least <size>. For more details on filter specifications, see the --filter option in git-rev-list[1]",
-          insertValue: "--filter=",
+          insertValue: "--filter={cursor}",
           args: { name: "filter spec" },
         },
         {
@@ -3649,7 +3649,7 @@ const completionSpec: Fig.Spec = {
           name: "--template",
           description:
             "Specify the directory from which templates will be used",
-          insertValue: "--template=",
+          insertValue: "--template={cursor}",
           args: {
             name: "template directory",
           },
@@ -3672,7 +3672,7 @@ const completionSpec: Fig.Spec = {
           name: "--shallow-since",
           description:
             "Create a shallow clone with a history after the specified time",
-          insertValue: "--shallow-since=",
+          insertValue: "--shallow-since={cursor}",
           args: {
             name: "date",
           },
@@ -3681,7 +3681,7 @@ const completionSpec: Fig.Spec = {
           name: "--shallow-exclude",
           description:
             "Create a shallow clone with a history, excluding commits reachable from a specified remote branch or tag. This option can be specified multiple times",
-          insertValue: "--shallow-exclude=",
+          insertValue: "--shallow-exclude={cursor}",
           args: {
             name: "revision",
           },
@@ -3742,7 +3742,7 @@ const completionSpec: Fig.Spec = {
           name: "--separate-git-dir",
           description:
             "Instead of placing the cloned repository where it is supposed to be, place the cloned repository at the specified directory, then make a filesystem-agnostic Git symbolic link to there. The result is Git repository can be separated from working tree",
-          insertValue: "--separate-git-dir=",
+          insertValue: "--separate-git-dir={cursor}",
           args: {
             name: "git dir",
           },
@@ -4466,7 +4466,7 @@ const completionSpec: Fig.Spec = {
           name: "--conflict",
           description:
             "The same as --merge option above, but changes the way the conflicting hunks are presented, overriding the merge.conflictStyle configuration variable. Possible values are 'merge' (default) and 'diff3' (in addition to what is shown by 'merge' style, shows the original contents)",
-          insertValue: "--conflict=",
+          insertValue: "--conflict={cursor}",
           args: {
             isOptional: true,
             suggestions: ["merge", "diff3"],
@@ -5158,7 +5158,7 @@ const completionSpec: Fig.Spec = {
           name: "--cleanup",
           description:
             "This option determines how the merge message will be cleaned up before committing. See git-commit[1] for more details. In addition, if the <mode> is given a value of scissors, scissors will be appended to MERGE_MSG before being passed on to the commit machinery in the case of a merge conflict",
-          insertValue: "--cleanup=",
+          insertValue: "--cleanup={cursor}",
           args: {
             name: "mode",
             suggestions: [

--- a/src/go.ts
+++ b/src/go.ts
@@ -545,6 +545,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-go",
               insertValue: "-go={cursor}",
+              requiresEquals: true,
               description: "Set the expected Go language version",
               args: {
                 name: "version",
@@ -553,6 +554,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-require",
               insertValue: "-require={cursor}",
+              requiresEquals: true,
               description: "Add a requirement on the given module",
               args: {
                 name: "path",
@@ -561,6 +563,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-droprequire",
               insertValue: "-droprequire={cursor}",
+              requiresEquals: true,
               description: "Drop a requirement on the given module",
               args: {
                 name: "path",
@@ -569,6 +572,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-exclude",
               insertValue: "-exclude={cursor}",
+              requiresEquals: true,
               description: "Add an exclusion on the given module",
               args: {
                 name: "path",
@@ -577,6 +581,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-dropexclude",
               insertValue: "-dropexclude={cursor}",
+              requiresEquals: true,
               description: "Drop an exclusion on the given module",
               args: {
                 name: "path",
@@ -585,6 +590,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-replace",
               insertValue: "-replace={cursor}",
+              requiresEquals: true,
               description:
                 "Add a replacement of the given module path and version pair",
               args: {
@@ -594,6 +600,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-dropreplace",
               insertValue: "-dropreplace={cursor}",
+              requiresEquals: true,
               description:
                 "Drops a replacement of the given module path and version pair",
               args: {
@@ -603,6 +610,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-retract",
               insertValue: "-retract={cursor}",
+              requiresEquals: true,
               description: "Add a retraction for the given version",
               args: {
                 name: "version",
@@ -611,6 +619,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-dropretract",
               insertValue: "-dropretract={cursor}",
+              requiresEquals: true,
               description: "Drop a retraction for the given version",
               args: {
                 name: "version",
@@ -806,6 +815,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "-vettool",
           insertValue: "-vettool={cursor}",
+          requiresEquals: true,
           description:
             "Select a different analysis tool with alternative or additional checks",
           args: {

--- a/src/go.ts
+++ b/src/go.ts
@@ -544,7 +544,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "-go",
-              insertValue: "-go=",
+              insertValue: "-go={cursor}",
               description: "Set the expected Go language version",
               args: {
                 name: "version",
@@ -552,7 +552,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "-require",
-              insertValue: "-require=",
+              insertValue: "-require={cursor}",
               description: "Add a requirement on the given module",
               args: {
                 name: "path",
@@ -560,7 +560,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "-droprequire",
-              insertValue: "-droprequire=",
+              insertValue: "-droprequire={cursor}",
               description: "Drop a requirement on the given module",
               args: {
                 name: "path",
@@ -568,7 +568,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "-exclude",
-              insertValue: "-exclude=",
+              insertValue: "-exclude={cursor}",
               description: "Add an exclusion on the given module",
               args: {
                 name: "path",
@@ -576,7 +576,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "-dropexclude",
-              insertValue: "-dropexclude=",
+              insertValue: "-dropexclude={cursor}",
               description: "Drop an exclusion on the given module",
               args: {
                 name: "path",
@@ -584,7 +584,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "-replace",
-              insertValue: "-replace=",
+              insertValue: "-replace={cursor}",
               description:
                 "Add a replacement of the given module path and version pair",
               args: {
@@ -593,7 +593,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "-dropreplace",
-              insertValue: "-dropreplace=",
+              insertValue: "-dropreplace={cursor}",
               description:
                 "Drops a replacement of the given module path and version pair",
               args: {
@@ -602,7 +602,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "-retract",
-              insertValue: "-retract=",
+              insertValue: "-retract={cursor}",
               description: "Add a retraction for the given version",
               args: {
                 name: "version",
@@ -610,7 +610,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "-dropretract",
-              insertValue: "-dropretract=",
+              insertValue: "-dropretract={cursor}",
               description: "Drop a retraction for the given version",
               args: {
                 name: "version",
@@ -805,7 +805,7 @@ const completionSpec: Fig.Spec = {
         ...resolutionAndExecutionOptions,
         {
           name: "-vettool",
-          insertValue: "-vettool=",
+          insertValue: "-vettool={cursor}",
           description:
             "Select a different analysis tool with alternative or additional checks",
           args: {

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -50,6 +50,7 @@ const completionSpec: Fig.Spec = {
       name: "--collectCoverageFrom",
       displayName: "--collectCoverageFrom=<glob>",
       insertValue: "--collectCoverageFrom={cursor}",
+      requiresEquals: true,
       description:
         "A glob pattern relative to rootDir matching the files that coverage info needs to be collected from",
       args: {
@@ -65,6 +66,7 @@ const completionSpec: Fig.Spec = {
       name: ["--config", "-c"],
       displayName: "--config=<path>",
       insertValue: "--config={cursor}",
+      requiresEquals: true,
       description:
         "The path to a Jest config file specifying how to find and execute tests",
       args: {
@@ -76,6 +78,7 @@ const completionSpec: Fig.Spec = {
       name: "--coverage",
       displayName: "--coverage=<boolean>",
       insertValue: "--coverage={cursor}",
+      requiresEquals: true,
       description: "Enable or disable coverage, disabled by default",
       args: {
         name: "true|false",
@@ -93,6 +96,7 @@ const completionSpec: Fig.Spec = {
       name: "--coverageProvider",
       displayName: "--coverageProvider=<provider>",
       insertValue: "--coverageProvider={cursor}",
+      requiresEquals: true,
       description:
         "Indicates which provider should be used to instrument code for coverage",
       args: {
@@ -113,6 +117,7 @@ const completionSpec: Fig.Spec = {
       name: "--env",
       displayName: "--env=<environment>",
       insertValue: "--env={cursor}",
+      requiresEquals: true,
       description: "The test environment used for all tests",
       args: {
         name: "jsdom|node|path/to/env.js",
@@ -163,6 +168,7 @@ const completionSpec: Fig.Spec = {
       name: "--outputFile",
       displayName: "--outputFile=<filename>",
       insertValue: "--outputFile={cursor}",
+      requiresEquals: true,
       description:
         "Write test results to a file when the --json option is also specified",
       args: {
@@ -187,6 +193,7 @@ const completionSpec: Fig.Spec = {
       name: "--maxConcurrency",
       displayName: "--maxConcurrency=<num>",
       insertValue: "--maxConcurrency={cursor}",
+      requiresEquals: true,
       description:
         "Prevents Jest from executing more than the specified amount of tests at the same time",
       args: {
@@ -197,6 +204,7 @@ const completionSpec: Fig.Spec = {
       name: ["--maxWorkers", "-w"],
       displayName: "--maxWorkers=<num>|<string>",
       insertValue: "--maxWorkers={cursor}",
+      requiresEquals: true,
       description:
         "Specifies the maximum number of workers the worker-pool will spawn for running tests",
       args: {
@@ -235,6 +243,7 @@ const completionSpec: Fig.Spec = {
       name: "--reporters",
       displayName: "--reporters=<reporter>",
       insertValue: "--reporters={cursor}",
+      requiresEquals: true,
       description: "Run tests with specified reporters",
       args: {
         name: "reporter",
@@ -273,6 +282,7 @@ const completionSpec: Fig.Spec = {
       name: "--setupTestFrameworkScriptFile",
       displayName: "--setupTestFrameworkScriptFile=<file>",
       insertValue: "--setupTestFrameworkScriptFile={cursor}",
+      requiresEquals: true,
       description:
         "The path to a module that runs some code to configure or set up the testing framework before each test",
       args: {
@@ -292,6 +302,7 @@ const completionSpec: Fig.Spec = {
       name: ["--testNamePattern", "-t"],
       displayName: "--testNamePattern=<regex>",
       insertValue: "--testNamePattern={cursor}",
+      requiresEquals: true,
       description: "Run only tests with a name that matches the regex",
       args: {
         name: "regex",
@@ -305,6 +316,7 @@ const completionSpec: Fig.Spec = {
       name: "--testPathPattern",
       displayName: "--testPathPattern=<regex>",
       insertValue: "--testPathPattern={cursor}",
+      requiresEquals: true,
       description:
         "A regexp pattern string that is matched against all tests paths before executing the test",
       args: {
@@ -315,6 +327,7 @@ const completionSpec: Fig.Spec = {
       name: "--testPathIgnorePatterns",
       displayName: "--testPathIgnorePatterns=[array]",
       insertValue: "--testPathIgnorePatterns={cursor}",
+      requiresEquals: true,
       description:
         "An array of regexp pattern strings that are tested against all tests paths before executing the test",
       args: {
@@ -325,6 +338,7 @@ const completionSpec: Fig.Spec = {
       name: "--testRunner",
       displayName: "--testRunner=<path>",
       insertValue: "--testRunner={cursor}",
+      requiresEquals: true,
       description: "Lets you specify a custom test runner",
       args: {
         name: "path",
@@ -335,6 +349,7 @@ const completionSpec: Fig.Spec = {
       name: "--testSequencer",
       displayName: "--testSequencer=<path>",
       insertValue: "--testSequencer={cursor}",
+      requiresEquals: true,
       description: "Lets you specify a custom test sequencer",
       args: {
         name: "path",
@@ -345,6 +360,7 @@ const completionSpec: Fig.Spec = {
       name: "--testTimeout",
       displayName: "--testTimeout=<num>",
       insertValue: "--testTimeout={cursor}",
+      requiresEquals: true,
       description: "Default timeout of a test in milliseconds",
       args: {
         name: "timeout in ms",

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -49,7 +49,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--collectCoverageFrom",
       displayName: "--collectCoverageFrom=<glob>",
-      insertValue: "--collectCoverageFrom=",
+      insertValue: "--collectCoverageFrom={cursor}",
       description:
         "A glob pattern relative to rootDir matching the files that coverage info needs to be collected from",
       args: {
@@ -64,7 +64,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["--config", "-c"],
       displayName: "--config=<path>",
-      insertValue: "--config=",
+      insertValue: "--config={cursor}",
       description:
         "The path to a Jest config file specifying how to find and execute tests",
       args: {
@@ -75,7 +75,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--coverage",
       displayName: "--coverage=<boolean>",
-      insertValue: "--coverage=",
+      insertValue: "--coverage={cursor}",
       description: "Enable or disable coverage, disabled by default",
       args: {
         name: "true|false",
@@ -92,7 +92,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--coverageProvider",
       displayName: "--coverageProvider=<provider>",
-      insertValue: "--coverageProvider=",
+      insertValue: "--coverageProvider={cursor}",
       description:
         "Indicates which provider should be used to instrument code for coverage",
       args: {
@@ -112,7 +112,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--env",
       displayName: "--env=<environment>",
-      insertValue: "--env=",
+      insertValue: "--env={cursor}",
       description: "The test environment used for all tests",
       args: {
         name: "jsdom|node|path/to/env.js",
@@ -162,7 +162,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--outputFile",
       displayName: "--outputFile=<filename>",
-      insertValue: "--outputFile=",
+      insertValue: "--outputFile={cursor}",
       description:
         "Write test results to a file when the --json option is also specified",
       args: {
@@ -186,7 +186,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--maxConcurrency",
       displayName: "--maxConcurrency=<num>",
-      insertValue: "--maxConcurrency=",
+      insertValue: "--maxConcurrency={cursor}",
       description:
         "Prevents Jest from executing more than the specified amount of tests at the same time",
       args: {
@@ -196,7 +196,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["--maxWorkers", "-w"],
       displayName: "--maxWorkers=<num>|<string>",
-      insertValue: "--maxWorkers=",
+      insertValue: "--maxWorkers={cursor}",
       description:
         "Specifies the maximum number of workers the worker-pool will spawn for running tests",
       args: {
@@ -234,7 +234,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--reporters",
       displayName: "--reporters=<reporter>",
-      insertValue: "--reporters=",
+      insertValue: "--reporters={cursor}",
       description: "Run tests with specified reporters",
       args: {
         name: "reporter",
@@ -272,7 +272,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--setupTestFrameworkScriptFile",
       displayName: "--setupTestFrameworkScriptFile=<file>",
-      insertValue: "--setupTestFrameworkScriptFile=",
+      insertValue: "--setupTestFrameworkScriptFile={cursor}",
       description:
         "The path to a module that runs some code to configure or set up the testing framework before each test",
       args: {
@@ -291,7 +291,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["--testNamePattern", "-t"],
       displayName: "--testNamePattern=<regex>",
-      insertValue: "--testNamePattern=",
+      insertValue: "--testNamePattern={cursor}",
       description: "Run only tests with a name that matches the regex",
       args: {
         name: "regex",
@@ -304,7 +304,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--testPathPattern",
       displayName: "--testPathPattern=<regex>",
-      insertValue: "--testPathPattern=",
+      insertValue: "--testPathPattern={cursor}",
       description:
         "A regexp pattern string that is matched against all tests paths before executing the test",
       args: {
@@ -314,7 +314,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--testPathIgnorePatterns",
       displayName: "--testPathIgnorePatterns=[array]",
-      insertValue: "--testPathIgnorePatterns=",
+      insertValue: "--testPathIgnorePatterns={cursor}",
       description:
         "An array of regexp pattern strings that are tested against all tests paths before executing the test",
       args: {
@@ -324,7 +324,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--testRunner",
       displayName: "--testRunner=<path>",
-      insertValue: "--testRunner=",
+      insertValue: "--testRunner={cursor}",
       description: "Lets you specify a custom test runner",
       args: {
         name: "path",
@@ -334,7 +334,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--testSequencer",
       displayName: "--testSequencer=<path>",
-      insertValue: "--testSequencer=",
+      insertValue: "--testSequencer={cursor}",
       description: "Lets you specify a custom test sequencer",
       args: {
         name: "path",
@@ -344,7 +344,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--testTimeout",
       displayName: "--testTimeout=<num>",
-      insertValue: "--testTimeout=",
+      insertValue: "--testTimeout={cursor}",
       description: "Default timeout of a test in milliseconds",
       args: {
         name: "timeout in ms",

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -209,14 +209,14 @@ const sharedOpts: Record<string, Fig.Option> = {
   },
   resourceVersion: {
     name: "--resource-version",
-    insertValue: "--resource-version=",
+    insertValue: "--resource-version={cursor}",
     description:
       "If non-empty, the annotation update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource",
     args: {},
   },
   dryRun: {
     name: "--dry-run",
-    insertValue: "--dry-run=",
+    insertValue: "--dry-run={cursor}",
     description:
       'Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource',
     args: {
@@ -226,7 +226,7 @@ const sharedOpts: Record<string, Fig.Option> = {
   },
   fieldSelector: {
     name: "--field-selector",
-    insertValue: "--field-selector=",
+    insertValue: "--field-selector={cursor}",
     description:
       "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type",
     args: {},
@@ -259,7 +259,7 @@ const sharedOpts: Record<string, Fig.Option> = {
   },
   template: {
     name: "--template",
-    insertValue: "--template=",
+    insertValue: "--template={cursor}",
     description:
       "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview]",
     args: {},
@@ -390,14 +390,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--sort-by",
-          insertValue: "--sort-by=",
+          insertValue: "--sort-by={cursor}",
           description:
             "If non-empty, sort nodes list using specified field. The field can be either 'name' or 'kind'",
           args: {},
         },
         {
           name: "--verbs",
-          insertValue: "--verbs=",
+          insertValue: "--verbs={cursor}",
           description: "Limit to resources that support the specified verbs",
           args: {},
         },
@@ -420,7 +420,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--field-manager",
-          insertValue: "--field-manager=",
+          insertValue: "--field-manager={cursor}",
           description: "Name of the manager used to track field ownership",
           args: {},
         },
@@ -436,7 +436,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--grace-period",
-          insertValue: "--grace-period=",
+          insertValue: "--grace-period={cursor}",
           description:
             "Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion)",
           args: {
@@ -460,7 +460,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--prune-whitelist",
-          insertValue: "--prune-whitelist=",
+          insertValue: "--prune-whitelist={cursor}",
           description:
             "Overwrite the default whitelist with <group/version/kind> for --prune",
           args: {
@@ -474,7 +474,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--timeout",
-          insertValue: "--timeout=",
+          insertValue: "--timeout={cursor}",
           description:
             "The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object",
           args: {
@@ -580,7 +580,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--pod-running-timeout",
-          insertValue: "-pod-running-timeout=",
+          insertValue: "-pod-running-timeout={cursor}",
           description:
             "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
           args: {},
@@ -631,7 +631,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--subresource",
-              insertValue: "--subresource=",
+              insertValue: "--subresource={cursor}",
               description: "SubResource such as pod/log or deployment/scale",
               // TODO: Generator here
               args: {},
@@ -687,7 +687,7 @@ const completionSpec: Fig.Spec = {
         sharedOpts.template,
         {
           name: "--cpu-percent",
-          insertValue: "--cpu-percent=",
+          insertValue: "--cpu-percent={cursor}",
           description:
             "The target average CPU utilization (represented as a percent of requested CPU) over all the pods. If it's not specified or negative, a default autoscaling policy will be used",
           args: {
@@ -696,14 +696,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--generator",
-          insertValue: "--generator=",
+          insertValue: "--generator={cursor}",
           description:
             "The name of the API generator to use. Currently there is only 1 generator",
           args: {},
         },
         {
           name: "--max",
-          insertValue: "--max=",
+          insertValue: "--max={cursor}",
           description:
             "The upper limit for the number of pods that can be set by the autoscaler. Required",
           args: {
@@ -712,7 +712,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--min",
-          insertValue: "--min=",
+          insertValue: "--min={cursor}",
           description:
             "The lower limit for the number of pods that can be set by the autoscaler. If it's not specified or negative, the server will apply a default value",
           args: {
@@ -721,7 +721,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--name",
-          insertValue: "--name=",
+          insertValue: "--name={cursor}",
           description:
             "The name for the newly created object. If not specified, the name of the input resource will be used",
           args: {},
@@ -804,14 +804,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--output-directory",
-              insertValue: "--output-directory=",
+              insertValue: "--output-directory={cursor}",
               description:
                 "Where to output the files.  If empty or '-' uses stdout, otherwise creates a directory hierarchy in that directory",
               args: {},
             },
             {
               name: "--pod-running-timeout",
-              insertValue: "--pod-running-timeout=",
+              insertValue: "--pod-running-timeout={cursor}",
               description:
                 "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
               args: {
@@ -839,7 +839,7 @@ const completionSpec: Fig.Spec = {
       options: [
         {
           name: "--kubeconfig",
-          insertValue: "--kubeconfig=",
+          insertValue: "--kubeconfig={cursor}",
           args: {
             name: "path",
             template: "filepaths",
@@ -926,14 +926,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--server",
-              insertValue: "--server=",
+              insertValue: "--server={cursor}",
               args: {
                 name: "Server",
               },
             },
             {
               name: "--certificate-authority",
-              insertValue: "--certificate-authority=",
+              insertValue: "--certificate-authority={cursor}",
               description: "Path to certificate authority",
               args: {
                 name: "Certificate Authority",
@@ -942,14 +942,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--insecure-skip-tls-verify",
-              insertValue: "--insecure-skip-tls-verify=",
+              insertValue: "--insecure-skip-tls-verify={cursor}",
               args: {
                 suggestions: ["true", "false"],
               },
             },
             {
               name: "--tls-server-name",
-              insertValue: "--tls-server-name=",
+              insertValue: "--tls-server-name={cursor}",
               args: {
                 name: "TLS Server Name",
               },
@@ -967,21 +967,21 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--cluster",
-              insertValue: "--cluster=",
+              insertValue: "--cluster={cursor}",
               args: {
                 name: "cluster_nickname",
               },
             },
             {
               name: "--user",
-              insertValue: "--user=",
+              insertValue: "--user={cursor}",
               args: {
                 name: "user_nickname",
               },
             },
             {
               name: "--namespace",
-              insertValue: "--namespace=",
+              insertValue: "--namespace={cursor}",
               args: {
                 name: "namespace",
               },
@@ -995,7 +995,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--client-certificate",
-              insertValue: "--client-certificate=",
+              insertValue: "--client-certificate={cursor}",
               description: "Client cert for user entry",
               args: {
                 template: "filepaths",
@@ -1003,7 +1003,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--client-key",
-              insertValue: "--client-key=",
+              insertValue: "--client-key={cursor}",
               description: "Client key for user entry",
               args: {
                 template: "filepaths",
@@ -1011,7 +1011,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--token",
-              insertValue: "--token=",
+              insertValue: "--token={cursor}",
               description: "Bearer Token for user entry",
               args: {
                 name: "Bearer Token",
@@ -1019,7 +1019,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--username",
-              insertValue: "--username=",
+              insertValue: "--username={cursor}",
               description: "Username for basic authentication",
               args: {
                 name: "Username",
@@ -1027,7 +1027,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--password",
-              insertValue: "--password=",
+              insertValue: "--password={cursor}",
               description: "Password for basic authentication",
               args: {
                 name: "Password",
@@ -1035,7 +1035,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--auth-provider",
-              insertValue: "--auth-provider=",
+              insertValue: "--auth-provider={cursor}",
               description: "Auth provider for the user entry in kubeconfig",
               args: {
                 name: "Auth Provider",
@@ -1043,7 +1043,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--auth-provider-arg",
-              insertValue: "--auth-provider-arg=",
+              insertValue: "--auth-provider-arg={cursor}",
               description: "'key=value' arguments for the auth provider",
               args: {
                 name: "key=value",
@@ -1056,7 +1056,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--exec-api-version",
-              insertValue: "--exec-api-version=",
+              insertValue: "--exec-api-version={cursor}",
               description:
                 "API version of the exec credential plugin for the user entry in kubeconfig",
               args: {
@@ -1065,7 +1065,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--exec-arg",
-              insertValue: "--exec-arg=",
+              insertValue: "--exec-arg={cursor}",
               description:
                 "New arguments for the exec credential plugin command for the user entry in kubeconfig",
               args: {
@@ -1074,7 +1074,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--exec-command",
-              insertValue: "--exec-command=",
+              insertValue: "--exec-command={cursor}",
               description:
                 "Command for the exec credential plugin for the user entry in kubeconfig",
               args: {
@@ -1083,7 +1083,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--exec-env",
-              insertValue: "--exec-env=",
+              insertValue: "--exec-env={cursor}",
               description:
                 "'key=value' environment values for the exec credential plugin",
               args: {
@@ -1157,7 +1157,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--output-version",
-          insertValue: "--output-version=",
+          insertValue: "--output-version={cursor}",
           description:
             "Output the formatted object with the given group version (for ex: 'extensions/v1beta1')",
           args: {},
@@ -1247,7 +1247,7 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--aggregation-rule",
-              insertValue: "--aggregation-rule=",
+              insertValue: "--aggregation-rule={cursor}",
               description:
                 "An aggregation label selector for combining ClusterRoles",
               args: {},
@@ -1260,13 +1260,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--resource",
-              insertValue: "--resource=",
+              insertValue: "--resource={cursor}",
               description: "Resource that the rule applies to",
               args: sharedArgs.resourcesArg,
             },
             {
               name: "--resource-name",
-              insertValue: "--resource-name=",
+              insertValue: "--resource-name={cursor}",
               description:
                 "Resource in the white list that the rule applies to, repeat this flag for multiple items",
               args: {},
@@ -1283,7 +1283,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--verb",
-              insertValue: "--verb=",
+              insertValue: "--verb={cursor}",
               description:
                 "Verb that applies to the resources contained in the rule",
               args: {
@@ -1307,14 +1307,14 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--clusterrole",
-              insertValue: "--clusterrole=",
+              insertValue: "--clusterrole={cursor}",
               description:
                 "ClusterRole this ClusterRoleBinding should reference",
               args: sharedArgs.listClusterRoles,
             },
             {
               name: "--user",
-              insertValue: "--user=",
+              insertValue: "--user={cursor}",
               args: {
                 name: "User Name",
               },
@@ -1364,7 +1364,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--from-env-file",
-              insertValue: "--from-env-file=",
+              insertValue: "--from-env-file={cursor}",
               description:
                 "Specify the path to a file to read lines of key=val pairs to create a configmap (i.e. a Docker .env file)",
               args: {
@@ -1373,7 +1373,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--from-file",
-              insertValue: "--from-file=",
+              insertValue: "--from-file={cursor}",
               description:
                 "Key file can be specified using its file path, in which case file basename will be used as configmap key, or optionally with a key and file path, in which case the given key will be used.  Specifying a directory will iterate each named file in the directory whose basename is a valid configmap key",
               args: {
@@ -1382,7 +1382,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--from-literal",
-              insertValue: "--from-literal=",
+              insertValue: "--from-literal={cursor}",
               description:
                 "Specify a key and literal value to insert in configmap (i.e. mykey=somevalue)",
               args: {
@@ -1414,7 +1414,7 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--image",
-              insertValue: "--image=",
+              insertValue: "--image={cursor}",
               description: "Image name to run",
               args: {
                 name: "Image",
@@ -1422,7 +1422,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--restart",
-              insertValue: "--restart=",
+              insertValue: "--restart={cursor}",
               description:
                 "Job's restart policy. supported values: OnFailure, Never",
               args: {
@@ -1462,7 +1462,7 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--image",
-              insertValue: "--image=",
+              insertValue: "--image={cursor}",
               description: "Image name to run",
               args: {
                 name: "Image",
@@ -1501,13 +1501,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--class",
-              insertValue: "--class=",
+              insertValue: "--class={cursor}",
               description: "Ingress Class to be used",
               args: {},
             },
             {
               name: "--default-backend",
-              insertValue: "--default-backend=",
+              insertValue: "--default-backend={cursor}",
               description:
                 "Default service for backend, in format of svcname:port",
               args: {
@@ -1516,13 +1516,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field-manager",
-              insertValue: "--field-manager=",
+              insertValue: "--field-manager={cursor}",
               description: "Name of the manager used to track field ownership",
               args: {},
             },
             {
               name: "--rule",
-              insertValue: "--rule=",
+              insertValue: "--rule={cursor}",
               description:
                 "Rule in format host/path=service:port[,tls=secretname]. Paths containing the leading character '*' are considered pathType=Prefix. tls argument is optional",
               args: {
@@ -1560,7 +1560,7 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--from",
-              insertValue: "--from=",
+              insertValue: "--from={cursor}",
               description:
                 "The name of the resource to create a Job from (only cronjob is supported)",
               args: {
@@ -1578,7 +1578,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--image",
-              insertValue: "--image=",
+              insertValue: "--image={cursor}",
               description: "Image name to run",
               args: {
                 name: "Image",
@@ -1674,7 +1674,7 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--description",
-              insertValue: "--description=",
+              insertValue: "--description={cursor}",
               description:
                 "Description is an arbitrary string that usually provides guidelines on when this priority class should be used",
               args: {
@@ -1707,7 +1707,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--value",
-              insertValue: "--value=",
+              insertValue: "--value={cursor}",
               description: "The value of this priority class",
               args: {
                 name: "INT",
@@ -1729,7 +1729,7 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--field-manager",
-              insertValue: "--field-manager=",
+              insertValue: "--field-manager={cursor}",
               description: "Name of the manager used to track field ownership",
               args: {},
             },
@@ -1774,13 +1774,13 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--resource",
-              insertValue: "--resource=",
+              insertValue: "--resource={cursor}",
               description: "Resource that the rule applies to",
               args: sharedArgs.resourcesArg,
             },
             {
               name: "--resource-name",
-              insertValue: "--resource-name=",
+              insertValue: "--resource-name={cursor}",
               description:
                 "Resource in the white list that the rule applies to, repeat this flag for multiple items",
               args: {},
@@ -1797,7 +1797,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--verb",
-              insertValue: "--verb=",
+              insertValue: "--verb={cursor}",
               description:
                 "Verb that applies to the resources contained in the rule",
               args: {
@@ -1821,19 +1821,19 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--clusterrole",
-              insertValue: "--clusterrole=",
+              insertValue: "--clusterrole={cursor}",
               description: "ClusterRole this RoleBinding should reference",
               args: sharedArgs.listClusterRoles,
             },
             {
               name: "--group",
-              insertValue: "--group=",
+              insertValue: "--group={cursor}",
               description: "Groups to bind to the role",
               args: {},
             },
             {
               name: "--role",
-              insertValue: "--role=",
+              insertValue: "--role={cursor}",
               description: "Role this RoleBinding should reference",
               args: {
                 name: "Role",
@@ -1850,7 +1850,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--serviceaccount",
-              insertValue: "--serviceaccount=",
+              insertValue: "--serviceaccount={cursor}",
               description:
                 "Service accounts to bind to the role, in the format <namespace>:<name>",
               args: {
@@ -1859,7 +1859,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--username",
-              insertValue: "--username=",
+              insertValue: "--username={cursor}",
               args: {
                 name: "Username",
               },
@@ -1892,7 +1892,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--docker-email",
-                  insertValue: "--docker-email=",
+                  insertValue: "--docker-email={cursor}",
                   description: "Email for Docker registry",
                   args: {
                     name: "Email",
@@ -1900,7 +1900,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--docker-password",
-                  insertValue: "--docker-password=",
+                  insertValue: "--docker-password={cursor}",
                   description: "Password for Docker registry authentication",
                   args: {
                     name: "Password",
@@ -1908,7 +1908,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--docker-server",
-                  insertValue: "--docker-server=",
+                  insertValue: "--docker-server={cursor}",
                   description: "Server location for Docker registry",
                   args: {
                     name: "Server",
@@ -1916,7 +1916,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--docker-username",
-                  insertValue: "--docker-username=",
+                  insertValue: "--docker-username={cursor}",
                   description: "Username for Docker registry authentication",
                   args: {
                     name: "Username",
@@ -1924,7 +1924,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--from-file",
-                  insertValue: "--from-file=",
+                  insertValue: "--from-file={cursor}",
                   description:
                     "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key",
                   args: {
@@ -1961,7 +1961,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--from-env-file",
-                  insertValue: "--from-env-file=",
+                  insertValue: "--from-env-file={cursor}",
                   description:
                     "Specify the path to a file to read lines of key=val pairs to create a secret (i.e. a Docker .env file)",
                   args: {
@@ -1970,7 +1970,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--from-file",
-                  insertValue: "--from-file=",
+                  insertValue: "--from-file={cursor}",
                   description:
                     "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key",
                   args: {
@@ -1979,7 +1979,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--from-literal",
-                  insertValue: "--from-literal=",
+                  insertValue: "--from-literal={cursor}",
                   description:
                     "Specify a key and literal value to insert in secret (i.e. mykey=somevalue)",
                   args: {
@@ -1993,7 +1993,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--type",
-                  insertValue: "--type=",
+                  insertValue: "--type={cursor}",
                   description: "The type of secret to create",
                   args: {},
                 },
@@ -2022,7 +2022,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--cert",
-                  insertValue: "--cert=",
+                  insertValue: "--cert={cursor}",
                   description: "Path to PEM encoded public key certificate",
                   args: {
                     template: "filepaths",
@@ -2030,7 +2030,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--key",
-                  insertValue: "--key=",
+                  insertValue: "--key={cursor}",
                   description:
                     "Path to private key associated with given certificate",
                   args: {
@@ -2069,7 +2069,7 @@ const completionSpec: Fig.Spec = {
                 sharedOpts.template,
                 {
                   name: "--clusterip",
-                  insertValue: "--clusterip=",
+                  insertValue: "--clusterip={cursor}",
                   description:
                     "Assign your own ClusterIP or set to 'None' for a 'headless' service (no loadbalancing)",
                   args: {
@@ -2084,7 +2084,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--tcp",
-                  insertValue: "--tcp=",
+                  insertValue: "--tcp={cursor}",
                   description:
                     "Port pairs can be specified as '<port>:<targetPort>'",
                   args: {
@@ -2124,7 +2124,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--tcp",
-                  insertValue: "--tcp=",
+                  insertValue: "--tcp={cursor}",
                   description:
                     "Port pairs can be specified as '<port>:<targetPort>'",
                   args: {
@@ -2157,7 +2157,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--tcp",
-                  insertValue: "--tcp=",
+                  insertValue: "--tcp={cursor}",
                   description:
                     "Port pairs can be specified as '<port>:<targetPort>'",
                   args: {
@@ -2197,7 +2197,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--tcp",
-                  insertValue: "--tcp=",
+                  insertValue: "--tcp={cursor}",
                   description:
                     "Port pairs can be specified as '<port>:<targetPort>'",
                   args: {
@@ -2383,7 +2383,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--grace-period",
-          insertValue: "--grace-period=",
+          insertValue: "--grace-period={cursor}",
           description:
             "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used",
           args: {
@@ -2396,7 +2396,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--pod-selector",
-          insertValue: "--pod-selector=",
+          insertValue: "--pod-selector={cursor}",
           description: "Label selector to filter pods on the node",
           args: {},
         },
@@ -2408,7 +2408,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--timeout",
-          insertValue: "--timeout=",
+          insertValue: "--timeout={cursor}",
           description:
             "The length of time to wait before giving up, zero means infinite",
           args: {
@@ -2523,34 +2523,34 @@ const completionSpec: Fig.Spec = {
         sharedOpts.template,
         {
           name: "--cluster-ip",
-          insertValue: "--cluster-ip=",
+          insertValue: "--cluster-ip={cursor}",
           description:
             "ClusterIP to be assigned to the service. Leave empty to auto-allocate, or set to 'None' to create a headless service",
           args: {},
         },
         {
           name: "--external-ip",
-          insertValue: "--external-ip=",
+          insertValue: "--external-ip={cursor}",
           description:
             "Additional external IP address (not managed by Kubernetes) to accept for the service. If this IP is routed to a node, the service can be accessed by this IP in addition to its generated service IP",
           args: {},
         },
         {
           name: "--generator",
-          insertValue: "--generator=",
+          insertValue: "--generator={cursor}",
           description:
             "The name of the API generator to use. There are 2 generators: 'service/v1' and 'service/v2'. The only difference between them is that service port in v1 is named 'default', while it is left unnamed in v2. Default is 'service/v2'",
           args: {},
         },
         {
           name: ["-l", "--labels"],
-          insertValue: "--labels=",
+          insertValue: "--labels={cursor}",
           description: "Labels to apply to the service created by this call",
           args: {},
         },
         {
           name: "--load-balancer-ip",
-          insertValue: "--load-balancer-ip=",
+          insertValue: "--load-balancer-ip={cursor}",
           description:
             "IP to assign to the LoadBalancer. If empty, an ephemeral IP will be created and used (cloud-provider specific)",
           args: {},
@@ -2558,7 +2558,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--name",
           description: "The name for the newly created object",
-          insertValue: "--name=",
+          insertValue: "--name={cursor}",
           args: {},
         },
         {
@@ -2569,14 +2569,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--port",
-          insertValue: "--port=",
+          insertValue: "--port={cursor}",
           description:
             "The port that the service should serve on. Copied from the resource being exposed, if unspecified",
           args: {},
         },
         {
           name: "--protocol",
-          insertValue: "--protocol=",
+          insertValue: "--protocol={cursor}",
           description:
             "The network protocol for the service to be created. Default is 'TCP'",
           args: {
@@ -2590,21 +2590,21 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--session-affinity",
-          insertValue: "--session-affinity=",
+          insertValue: "--session-affinity={cursor}",
           description:
             "If non-empty, set the session affinity for the service to this; legal values: 'None', 'ClientIP'",
           args: {},
         },
         {
           name: "--target-port",
-          insertValue: "--target-port=",
+          insertValue: "--target-port={cursor}",
           description:
             "Name or number for the port on the container that the service should direct traffic to. Optional",
           args: {},
         },
         {
           name: "--type",
-          insertValue: "--type=",
+          insertValue: "--type={cursor}",
           description:
             "Type for this service: ClusterIP, NodePort, LoadBalancer, or ExternalName. Default is 'ClusterIP'",
           args: {
@@ -2641,7 +2641,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--chunk-size",
-          insertValue: "--chunk-size=",
+          insertValue: "--chunk-size={cursor}",
           description:
             "Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future",
           args: {},
@@ -2690,7 +2690,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--sort-by",
-          insertValue: "--sort-by=",
+          insertValue: "--sort-by={cursor}",
           description:
             "If non-empty, sort list types using this field specification.  The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}'). The field in the API resource specified by this JSONPath expression must be an integer or a string",
           args: {},
@@ -2733,7 +2733,7 @@ const completionSpec: Fig.Spec = {
           name: ["--env", "-e"],
           description:
             "A list of environment variables to be used by functions",
-          insertValue: "--env=",
+          insertValue: "--env={cursor}",
           args: {
             template: "filepaths",
           },
@@ -2742,13 +2742,13 @@ const completionSpec: Fig.Spec = {
           name: "--load-restrictor",
           description:
             "If set to 'LoadRestrictionsNone', local kustomizations may load files from outside their root. This does, however, break the relocatability of the kustomization",
-          insertValue: "--load-restrictor=",
+          insertValue: "--load-restrictor={cursor}",
           args: {},
         },
         {
           name: "--mount",
           description: "A list of storage options read from the filesystem",
-          insertValue: "--mount=",
+          insertValue: "--mount={cursor}",
           args: {},
         },
         {
@@ -2758,14 +2758,14 @@ const completionSpec: Fig.Spec = {
         {
           name: "--network-name",
           description: "The docker network to run the container in",
-          insertValue: "--network-name=",
+          insertValue: "--network-name={cursor}",
           args: {},
         },
         {
           name: "--reorder",
           description:
             "Reorder the resources just before output. Use 'legacy' to apply a legacy reordering (Namespaces first, Webhooks last, etc). Use 'none' to suppress a final reordering",
-          insertValue: "--reorder=",
+          insertValue: "--reorder={cursor}",
         },
       ],
     },
@@ -2840,20 +2840,20 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--limit-bytes",
-          insertValue: "--limit-bytes=",
+          insertValue: "--limit-bytes={cursor}",
           description: "Maximum bytes of logs to return. Defaults to no limit",
           args: {},
         },
         {
           name: "--max-log-requests",
-          insertValue: "--max-log-requests=",
+          insertValue: "--max-log-requests={cursor}",
           description:
             "Specify maximum number of concurrent logs to follow when using by a selector. Defaults to 5",
           args: {},
         },
         {
           name: "--pod-running-timeout",
-          insertValue: "--pod-running-timeout=",
+          insertValue: "--pod-running-timeout={cursor}",
           description:
             "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
           args: {},
@@ -2870,21 +2870,21 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--since",
-          insertValue: "--since=",
+          insertValue: "--since={cursor}",
           description:
             "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used",
           args: {},
         },
         {
           name: "--since-time",
-          insertValue: "--since-time=",
+          insertValue: "--since-time={cursor}",
           description:
             "Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used",
           args: {},
         },
         {
           name: "--tail",
-          insertValue: "--tail=",
+          insertValue: "--tail={cursor}",
           description:
             "Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines otherwise 10, if a selector is provided",
           args: {},
@@ -2920,7 +2920,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--type",
-          insertValue: "--type=",
+          insertValue: "--type={cursor}",
           description:
             "The type of patch being provided; one of [json merge strategic]",
           args: {
@@ -2954,7 +2954,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--pod-running-timeout",
-          insertValue: "---pod-running-timeout=",
+          insertValue: "---pod-running-timeout={cursor}",
           description:
             "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
           args: {},
@@ -2968,27 +2968,27 @@ const completionSpec: Fig.Spec = {
       options: [
         {
           name: "--accept-hosts",
-          insertValue: "--accept-hosts=",
+          insertValue: "--accept-hosts={cursor}",
           description:
             "Regular expression for hosts that the proxy should accept",
           args: {},
         },
         {
           name: "--accept-paths",
-          insertValue: "--accept-paths=",
+          insertValue: "--accept-paths={cursor}",
           description:
             "Regular expression for paths that the proxy should accept",
           args: {},
         },
         {
           name: "--address",
-          insertValue: "--address=",
+          insertValue: "--address={cursor}",
           description: "The IP address on which to serve on",
           args: {},
         },
         {
           name: "--api-prefix",
-          insertValue: "--api-prefix=",
+          insertValue: "--api-prefix={cursor}",
           description: "Prefix to serve the proxied API under",
           args: {},
         },
@@ -2999,48 +2999,48 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--keepalive",
-          insertValue: "--keepalive=",
+          insertValue: "--keepalive={cursor}",
           description:
             "Keepalive specifies the keep-alive period for an active network connection. Set to 0 to disable keepalive",
           args: {},
         },
         {
           name: ["-p", "--port"],
-          insertValue: "--port=",
+          insertValue: "--port={cursor}",
           description:
             "The port on which to run the proxy. Set to 0 to pick a random port",
           args: {},
         },
         {
           name: "--reject-methods",
-          insertValue: "--reject-methods=",
+          insertValue: "--reject-methods={cursor}",
           description:
             "Regular expression for HTTP methods that the proxy should reject (example --reject-methods='POST,PUT,PATCH')",
           args: {},
         },
         {
           name: "--reject-paths",
-          insertValue: "--reject-paths=",
+          insertValue: "--reject-paths={cursor}",
           description:
             "Regular expression for paths that the proxy should reject. Paths specified here will be rejected even accepted by --accept-paths",
           args: {},
         },
         {
           name: ["-u", "--unix-socket"],
-          insertValue: "--unix-socket=",
+          insertValue: "--unix-socket={cursor}",
           description: "Unix socket on which to run the proxy",
           args: {},
         },
         {
           name: ["-w", "--www"],
-          insertValue: "--www=",
+          insertValue: "--www={cursor}",
           description:
             "Also serve static files from the given directory under the specified prefix",
           args: {},
         },
         {
           name: ["-P", "--www-prefix"],
-          insertValue: "--www-prefix=",
+          insertValue: "--www-prefix={cursor}",
           description:
             "Prefix to serve static files under, if static file directory is specified",
           args: {},
@@ -3070,14 +3070,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--grace-period",
-          insertValue: "--grace-period=",
+          insertValue: "--grace-period={cursor}",
           description:
             "Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion)",
           args: {},
         },
         {
           name: "--raw",
-          insertValue: "--raw=",
+          insertValue: "--raw={cursor}",
           description:
             "Raw URI to PUT to the server.  Uses the transport specified by the kubeconfig file",
           args: {},
@@ -3089,7 +3089,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--timeout",
-          insertValue: "--timeout=",
+          insertValue: "--timeout={cursor}",
           description:
             "The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object",
           args: {},
@@ -3124,7 +3124,7 @@ const completionSpec: Fig.Spec = {
             sharedOpts.template,
             {
               name: "--revision",
-              insertValue: "--revision=",
+              insertValue: "--revision={cursor}",
               description:
                 "See the details, including podTemplate of the revision specified",
               // Generator for revisions of resource specified in args
@@ -3181,14 +3181,14 @@ const completionSpec: Fig.Spec = {
             sharedOpts.recursive,
             {
               name: "--revision",
-              insertValue: "--revision=",
+              insertValue: "--revision={cursor}",
               description:
                 "Pin to a specific revision for showing its status. Defaults to 0 (last revision)",
               args: {},
             },
             {
               name: "--timeout",
-              insertValue: "--timeout=",
+              insertValue: "--timeout={cursor}",
               description:
                 "The length of time to wait before ending watch, zero means never. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h)",
               args: {},
@@ -3211,12 +3211,12 @@ const completionSpec: Fig.Spec = {
             sharedOpts.dryRun,
             {
               name: "--to_revision",
-              insertValue: "--to_revision=",
+              insertValue: "--to_revision={cursor}",
               args: {},
             },
             {
               name: "--timeout",
-              insertValue: "--timeout=",
+              insertValue: "--timeout={cursor}",
               description:
                 "The length of time to wait before ending watch, zero means never. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h)",
               args: {},
@@ -3242,7 +3242,7 @@ const completionSpec: Fig.Spec = {
         sharedOpts.template,
         {
           name: "--annotations",
-          insertValue: "--annotations=",
+          insertValue: "--annotations={cursor}",
           description: "Annotations to apply to the pod",
           args: {},
         },
@@ -3266,7 +3266,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--env",
-          insertValue: "--env=",
+          insertValue: "--env={cursor}",
           description: "Environment variables to set in the container",
           args: {},
         },
@@ -3282,21 +3282,21 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--grace-period",
-          insertValue: "--grace-period=",
+          insertValue: "--grace-period={cursor}",
           description:
             "Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion)",
           args: {},
         },
         {
           name: "--hostport",
-          insertValue: "--hostport=",
+          insertValue: "--hostport={cursor}",
           description:
             "The host port mapping for the container port. To demonstrate a single-machine container",
           args: {},
         },
         {
           name: "--image",
-          insertValue: "--image=",
+          insertValue: "--image={cursor}",
           description: "The image for the container to run",
           args: {},
         },
@@ -3309,7 +3309,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: ["-l", "--labels"],
-          insertValue: "--labels=",
+          insertValue: "--labels={cursor}",
           description:
             "Comma separated labels to apply to the pod(s). Will override previous values",
           args: {},
@@ -3321,28 +3321,28 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--limits",
-          insertValue: "--limits=",
+          insertValue: "--limits={cursor}",
           description:
             "The resource requirement limits for this container.  For example, 'cpu=200m,memory=512Mi'.  Note that server side components may assign limits depending on the server configuration, such as limit ranges",
           args: {},
         },
         {
           name: "--overrides",
-          insertValue: "--overrides=",
+          insertValue: "--overrides={cursor}",
           description:
             "An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field",
           args: {},
         },
         {
           name: "--pod-running-timeout",
-          insertValue: "--pod-running-timeout=",
+          insertValue: "--pod-running-timeout={cursor}",
           description:
             "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
           args: {},
         },
         {
           name: "--port",
-          insertValue: "--port=",
+          insertValue: "--port={cursor}",
           description: "The port that this container exposes",
           args: {},
         },
@@ -3352,14 +3352,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--requests",
-          insertValue: "--requests=",
+          insertValue: "--requests={cursor}",
           description:
             "The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges",
           args: {},
         },
         {
           name: "--restart",
-          insertValue: "--restart=",
+          insertValue: "--restart={cursor}",
           description:
             "The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  If set to 'Always' a deployment is created, if set to 'OnFailure' a job is created, if set to 'Never', a regular pod is created. For the latter two --replicas must be 1.  Default 'Always', for CronJobs `Never`",
           args: {
@@ -3378,7 +3378,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--serviceaccount",
-          insertValue: "--serviceaccount=",
+          insertValue: "--serviceaccount={cursor}",
           description: "Service account to set in the pod spec",
           args: {},
         },
@@ -3389,7 +3389,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--timeout",
-          insertValue: "--timeout=",
+          insertValue: "--timeout={cursor}",
           description:
             "The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object",
           args: {},
@@ -3431,14 +3431,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--current-replicas",
-          insertValue: "--current-replicas=",
+          insertValue: "--current-replicas={cursor}",
           description:
             "Precondition for current size. Requires that the current size of the resource match this value in order to scale",
           args: {},
         },
         {
           name: "--replicas",
-          insertValue: "--replicas=",
+          insertValue: "--replicas={cursor}",
           description: "The new desired number of replicas. Required",
           args: {},
         },
@@ -3483,28 +3483,28 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: ["-c", "--containers"],
-              insertValue: "--containers=",
+              insertValue: "--containers={cursor}",
               description:
                 "The names of containers in the selected pod templates to change - may use wildcards",
               args: {},
             },
             {
               name: ["-e", "--env"],
-              insertValue: "--env=",
+              insertValue: "--env={cursor}",
               description:
                 "Specify a key-value pair for an environment variable to set into each container",
               args: {},
             },
             {
               name: "--from",
-              insertValue: "--from=",
+              insertValue: "--from={cursor}",
               description:
                 "The name of a resource from which to inject environment variables",
               args: {},
             },
             {
               name: "--keys",
-              insertValue: "--keys=",
+              insertValue: "--keys={cursor}",
               description:
                 "Comma-separated list of keys to import from specified resource",
               args: {},
@@ -3587,21 +3587,21 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: ["-c", "--containers"],
-              insertValue: "--containers=",
+              insertValue: "--containers={cursor}",
               description:
                 "The names of containers in the selected pod templates to change, all containers are selected by default - may use wildcards",
               args: {},
             },
             {
               name: "--limits",
-              insertValue: "--limits=",
+              insertValue: "--limits={cursor}",
               description:
                 "The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges",
               args: {},
             },
             {
               name: "--requests",
-              insertValue: "--requests=",
+              insertValue: "--requests={cursor}",
               description:
                 "The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges",
               args: {},
@@ -3688,13 +3688,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--group",
-              insertValue: "--group=",
+              insertValue: "--group={cursor}",
               description: "Groups to bind to the role",
               args: {},
             },
             {
               name: "--serviceaccount",
-              insertValue: "--serviceaccount=",
+              insertValue: "--serviceaccount={cursor}",
               description: "Service accounts to bind to the role",
               args: {},
             },
@@ -3783,14 +3783,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--for",
-          insertValue: "--for=",
+          insertValue: "--for={cursor}",
           description:
             "The condition to wait on: [delete|condition=condition-name]",
           args: {},
         },
         {
           name: "--timeout",
-          insertValue: "--timeout=",
+          insertValue: "--timeout={cursor}",
           description:
             "The length of time to wait before giving up.  Zero means check once and don't wait, negative means wait for a week",
           args: {},

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -210,6 +210,7 @@ const sharedOpts: Record<string, Fig.Option> = {
   resourceVersion: {
     name: "--resource-version",
     insertValue: "--resource-version={cursor}",
+    requiresEquals: true,
     description:
       "If non-empty, the annotation update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource",
     args: {},
@@ -217,6 +218,7 @@ const sharedOpts: Record<string, Fig.Option> = {
   dryRun: {
     name: "--dry-run",
     insertValue: "--dry-run={cursor}",
+    requiresEquals: true,
     description:
       'Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource',
     args: {
@@ -227,6 +229,7 @@ const sharedOpts: Record<string, Fig.Option> = {
   fieldSelector: {
     name: "--field-selector",
     insertValue: "--field-selector={cursor}",
+    requiresEquals: true,
     description:
       "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type",
     args: {},
@@ -260,6 +263,7 @@ const sharedOpts: Record<string, Fig.Option> = {
   template: {
     name: "--template",
     insertValue: "--template={cursor}",
+    requiresEquals: true,
     description:
       "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview]",
     args: {},
@@ -391,6 +395,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--sort-by",
           insertValue: "--sort-by={cursor}",
+          requiresEquals: true,
           description:
             "If non-empty, sort nodes list using specified field. The field can be either 'name' or 'kind'",
           args: {},
@@ -398,6 +403,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--verbs",
           insertValue: "--verbs={cursor}",
+          requiresEquals: true,
           description: "Limit to resources that support the specified verbs",
           args: {},
         },
@@ -421,6 +427,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--field-manager",
           insertValue: "--field-manager={cursor}",
+          requiresEquals: true,
           description: "Name of the manager used to track field ownership",
           args: {},
         },
@@ -437,6 +444,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--grace-period",
           insertValue: "--grace-period={cursor}",
+          requiresEquals: true,
           description:
             "Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion)",
           args: {
@@ -461,6 +469,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--prune-whitelist",
           insertValue: "--prune-whitelist={cursor}",
+          requiresEquals: true,
           description:
             "Overwrite the default whitelist with <group/version/kind> for --prune",
           args: {
@@ -475,6 +484,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--timeout",
           insertValue: "--timeout={cursor}",
+          requiresEquals: true,
           description:
             "The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object",
           args: {
@@ -581,6 +591,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--pod-running-timeout",
           insertValue: "-pod-running-timeout={cursor}",
+          requiresEquals: true,
           description:
             "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
           args: {},
@@ -632,6 +643,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--subresource",
               insertValue: "--subresource={cursor}",
+              requiresEquals: true,
               description: "SubResource such as pod/log or deployment/scale",
               // TODO: Generator here
               args: {},
@@ -688,6 +700,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--cpu-percent",
           insertValue: "--cpu-percent={cursor}",
+          requiresEquals: true,
           description:
             "The target average CPU utilization (represented as a percent of requested CPU) over all the pods. If it's not specified or negative, a default autoscaling policy will be used",
           args: {
@@ -697,6 +710,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--generator",
           insertValue: "--generator={cursor}",
+          requiresEquals: true,
           description:
             "The name of the API generator to use. Currently there is only 1 generator",
           args: {},
@@ -704,6 +718,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--max",
           insertValue: "--max={cursor}",
+          requiresEquals: true,
           description:
             "The upper limit for the number of pods that can be set by the autoscaler. Required",
           args: {
@@ -713,6 +728,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--min",
           insertValue: "--min={cursor}",
+          requiresEquals: true,
           description:
             "The lower limit for the number of pods that can be set by the autoscaler. If it's not specified or negative, the server will apply a default value",
           args: {
@@ -722,6 +738,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--name",
           insertValue: "--name={cursor}",
+          requiresEquals: true,
           description:
             "The name for the newly created object. If not specified, the name of the input resource will be used",
           args: {},
@@ -805,6 +822,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--output-directory",
               insertValue: "--output-directory={cursor}",
+              requiresEquals: true,
               description:
                 "Where to output the files.  If empty or '-' uses stdout, otherwise creates a directory hierarchy in that directory",
               args: {},
@@ -812,6 +830,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--pod-running-timeout",
               insertValue: "--pod-running-timeout={cursor}",
+              requiresEquals: true,
               description:
                 "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
               args: {
@@ -840,6 +859,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--kubeconfig",
           insertValue: "--kubeconfig={cursor}",
+          requiresEquals: true,
           args: {
             name: "path",
             template: "filepaths",
@@ -927,6 +947,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--server",
               insertValue: "--server={cursor}",
+              requiresEquals: true,
               args: {
                 name: "Server",
               },
@@ -934,6 +955,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--certificate-authority",
               insertValue: "--certificate-authority={cursor}",
+              requiresEquals: true,
               description: "Path to certificate authority",
               args: {
                 name: "Certificate Authority",
@@ -943,6 +965,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--insecure-skip-tls-verify",
               insertValue: "--insecure-skip-tls-verify={cursor}",
+              requiresEquals: true,
               args: {
                 suggestions: ["true", "false"],
               },
@@ -950,6 +973,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--tls-server-name",
               insertValue: "--tls-server-name={cursor}",
+              requiresEquals: true,
               args: {
                 name: "TLS Server Name",
               },
@@ -968,6 +992,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--cluster",
               insertValue: "--cluster={cursor}",
+              requiresEquals: true,
               args: {
                 name: "cluster_nickname",
               },
@@ -975,6 +1000,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--user",
               insertValue: "--user={cursor}",
+              requiresEquals: true,
               args: {
                 name: "user_nickname",
               },
@@ -982,6 +1008,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--namespace",
               insertValue: "--namespace={cursor}",
+              requiresEquals: true,
               args: {
                 name: "namespace",
               },
@@ -996,6 +1023,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--client-certificate",
               insertValue: "--client-certificate={cursor}",
+              requiresEquals: true,
               description: "Client cert for user entry",
               args: {
                 template: "filepaths",
@@ -1004,6 +1032,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--client-key",
               insertValue: "--client-key={cursor}",
+              requiresEquals: true,
               description: "Client key for user entry",
               args: {
                 template: "filepaths",
@@ -1012,6 +1041,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--token",
               insertValue: "--token={cursor}",
+              requiresEquals: true,
               description: "Bearer Token for user entry",
               args: {
                 name: "Bearer Token",
@@ -1020,6 +1050,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--username",
               insertValue: "--username={cursor}",
+              requiresEquals: true,
               description: "Username for basic authentication",
               args: {
                 name: "Username",
@@ -1028,6 +1059,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--password",
               insertValue: "--password={cursor}",
+              requiresEquals: true,
               description: "Password for basic authentication",
               args: {
                 name: "Password",
@@ -1036,6 +1068,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--auth-provider",
               insertValue: "--auth-provider={cursor}",
+              requiresEquals: true,
               description: "Auth provider for the user entry in kubeconfig",
               args: {
                 name: "Auth Provider",
@@ -1044,6 +1077,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--auth-provider-arg",
               insertValue: "--auth-provider-arg={cursor}",
+              requiresEquals: true,
               description: "'key=value' arguments for the auth provider",
               args: {
                 name: "key=value",
@@ -1057,6 +1091,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--exec-api-version",
               insertValue: "--exec-api-version={cursor}",
+              requiresEquals: true,
               description:
                 "API version of the exec credential plugin for the user entry in kubeconfig",
               args: {
@@ -1066,6 +1101,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--exec-arg",
               insertValue: "--exec-arg={cursor}",
+              requiresEquals: true,
               description:
                 "New arguments for the exec credential plugin command for the user entry in kubeconfig",
               args: {
@@ -1075,6 +1111,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--exec-command",
               insertValue: "--exec-command={cursor}",
+              requiresEquals: true,
               description:
                 "Command for the exec credential plugin for the user entry in kubeconfig",
               args: {
@@ -1084,6 +1121,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--exec-env",
               insertValue: "--exec-env={cursor}",
+              requiresEquals: true,
               description:
                 "'key=value' environment values for the exec credential plugin",
               args: {
@@ -1158,6 +1196,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--output-version",
           insertValue: "--output-version={cursor}",
+          requiresEquals: true,
           description:
             "Output the formatted object with the given group version (for ex: 'extensions/v1beta1')",
           args: {},
@@ -1248,6 +1287,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--aggregation-rule",
               insertValue: "--aggregation-rule={cursor}",
+              requiresEquals: true,
               description:
                 "An aggregation label selector for combining ClusterRoles",
               args: {},
@@ -1261,12 +1301,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--resource",
               insertValue: "--resource={cursor}",
+              requiresEquals: true,
               description: "Resource that the rule applies to",
               args: sharedArgs.resourcesArg,
             },
             {
               name: "--resource-name",
               insertValue: "--resource-name={cursor}",
+              requiresEquals: true,
               description:
                 "Resource in the white list that the rule applies to, repeat this flag for multiple items",
               args: {},
@@ -1284,6 +1326,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--verb",
               insertValue: "--verb={cursor}",
+              requiresEquals: true,
               description:
                 "Verb that applies to the resources contained in the rule",
               args: {
@@ -1308,6 +1351,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--clusterrole",
               insertValue: "--clusterrole={cursor}",
+              requiresEquals: true,
               description:
                 "ClusterRole this ClusterRoleBinding should reference",
               args: sharedArgs.listClusterRoles,
@@ -1315,6 +1359,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--user",
               insertValue: "--user={cursor}",
+              requiresEquals: true,
               args: {
                 name: "User Name",
               },
@@ -1365,6 +1410,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--from-env-file",
               insertValue: "--from-env-file={cursor}",
+              requiresEquals: true,
               description:
                 "Specify the path to a file to read lines of key=val pairs to create a configmap (i.e. a Docker .env file)",
               args: {
@@ -1374,6 +1420,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--from-file",
               insertValue: "--from-file={cursor}",
+              requiresEquals: true,
               description:
                 "Key file can be specified using its file path, in which case file basename will be used as configmap key, or optionally with a key and file path, in which case the given key will be used.  Specifying a directory will iterate each named file in the directory whose basename is a valid configmap key",
               args: {
@@ -1383,6 +1430,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--from-literal",
               insertValue: "--from-literal={cursor}",
+              requiresEquals: true,
               description:
                 "Specify a key and literal value to insert in configmap (i.e. mykey=somevalue)",
               args: {
@@ -1415,6 +1463,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--image",
               insertValue: "--image={cursor}",
+              requiresEquals: true,
               description: "Image name to run",
               args: {
                 name: "Image",
@@ -1423,6 +1472,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--restart",
               insertValue: "--restart={cursor}",
+              requiresEquals: true,
               description:
                 "Job's restart policy. supported values: OnFailure, Never",
               args: {
@@ -1463,6 +1513,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--image",
               insertValue: "--image={cursor}",
+              requiresEquals: true,
               description: "Image name to run",
               args: {
                 name: "Image",
@@ -1502,12 +1553,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--class",
               insertValue: "--class={cursor}",
+              requiresEquals: true,
               description: "Ingress Class to be used",
               args: {},
             },
             {
               name: "--default-backend",
               insertValue: "--default-backend={cursor}",
+              requiresEquals: true,
               description:
                 "Default service for backend, in format of svcname:port",
               args: {
@@ -1517,12 +1570,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field-manager",
               insertValue: "--field-manager={cursor}",
+              requiresEquals: true,
               description: "Name of the manager used to track field ownership",
               args: {},
             },
             {
               name: "--rule",
               insertValue: "--rule={cursor}",
+              requiresEquals: true,
               description:
                 "Rule in format host/path=service:port[,tls=secretname]. Paths containing the leading character '*' are considered pathType=Prefix. tls argument is optional",
               args: {
@@ -1561,6 +1616,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--from",
               insertValue: "--from={cursor}",
+              requiresEquals: true,
               description:
                 "The name of the resource to create a Job from (only cronjob is supported)",
               args: {
@@ -1579,6 +1635,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--image",
               insertValue: "--image={cursor}",
+              requiresEquals: true,
               description: "Image name to run",
               args: {
                 name: "Image",
@@ -1675,6 +1732,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--description",
               insertValue: "--description={cursor}",
+              requiresEquals: true,
               description:
                 "Description is an arbitrary string that usually provides guidelines on when this priority class should be used",
               args: {
@@ -1708,6 +1766,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--value",
               insertValue: "--value={cursor}",
+              requiresEquals: true,
               description: "The value of this priority class",
               args: {
                 name: "INT",
@@ -1730,6 +1789,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field-manager",
               insertValue: "--field-manager={cursor}",
+              requiresEquals: true,
               description: "Name of the manager used to track field ownership",
               args: {},
             },
@@ -1775,12 +1835,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--resource",
               insertValue: "--resource={cursor}",
+              requiresEquals: true,
               description: "Resource that the rule applies to",
               args: sharedArgs.resourcesArg,
             },
             {
               name: "--resource-name",
               insertValue: "--resource-name={cursor}",
+              requiresEquals: true,
               description:
                 "Resource in the white list that the rule applies to, repeat this flag for multiple items",
               args: {},
@@ -1798,6 +1860,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--verb",
               insertValue: "--verb={cursor}",
+              requiresEquals: true,
               description:
                 "Verb that applies to the resources contained in the rule",
               args: {
@@ -1822,18 +1885,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--clusterrole",
               insertValue: "--clusterrole={cursor}",
+              requiresEquals: true,
               description: "ClusterRole this RoleBinding should reference",
               args: sharedArgs.listClusterRoles,
             },
             {
               name: "--group",
               insertValue: "--group={cursor}",
+              requiresEquals: true,
               description: "Groups to bind to the role",
               args: {},
             },
             {
               name: "--role",
               insertValue: "--role={cursor}",
+              requiresEquals: true,
               description: "Role this RoleBinding should reference",
               args: {
                 name: "Role",
@@ -1851,6 +1917,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--serviceaccount",
               insertValue: "--serviceaccount={cursor}",
+              requiresEquals: true,
               description:
                 "Service accounts to bind to the role, in the format <namespace>:<name>",
               args: {
@@ -1860,6 +1927,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--username",
               insertValue: "--username={cursor}",
+              requiresEquals: true,
               args: {
                 name: "Username",
               },
@@ -1893,6 +1961,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--docker-email",
                   insertValue: "--docker-email={cursor}",
+                  requiresEquals: true,
                   description: "Email for Docker registry",
                   args: {
                     name: "Email",
@@ -1901,6 +1970,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--docker-password",
                   insertValue: "--docker-password={cursor}",
+                  requiresEquals: true,
                   description: "Password for Docker registry authentication",
                   args: {
                     name: "Password",
@@ -1909,6 +1979,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--docker-server",
                   insertValue: "--docker-server={cursor}",
+                  requiresEquals: true,
                   description: "Server location for Docker registry",
                   args: {
                     name: "Server",
@@ -1917,6 +1988,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--docker-username",
                   insertValue: "--docker-username={cursor}",
+                  requiresEquals: true,
                   description: "Username for Docker registry authentication",
                   args: {
                     name: "Username",
@@ -1925,6 +1997,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--from-file",
                   insertValue: "--from-file={cursor}",
+                  requiresEquals: true,
                   description:
                     "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key",
                   args: {
@@ -1962,6 +2035,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--from-env-file",
                   insertValue: "--from-env-file={cursor}",
+                  requiresEquals: true,
                   description:
                     "Specify the path to a file to read lines of key=val pairs to create a secret (i.e. a Docker .env file)",
                   args: {
@@ -1971,6 +2045,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--from-file",
                   insertValue: "--from-file={cursor}",
+                  requiresEquals: true,
                   description:
                     "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key",
                   args: {
@@ -1980,6 +2055,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--from-literal",
                   insertValue: "--from-literal={cursor}",
+                  requiresEquals: true,
                   description:
                     "Specify a key and literal value to insert in secret (i.e. mykey=somevalue)",
                   args: {
@@ -1994,6 +2070,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--type",
                   insertValue: "--type={cursor}",
+                  requiresEquals: true,
                   description: "The type of secret to create",
                   args: {},
                 },
@@ -2023,6 +2100,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--cert",
                   insertValue: "--cert={cursor}",
+                  requiresEquals: true,
                   description: "Path to PEM encoded public key certificate",
                   args: {
                     template: "filepaths",
@@ -2031,6 +2109,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--key",
                   insertValue: "--key={cursor}",
+                  requiresEquals: true,
                   description:
                     "Path to private key associated with given certificate",
                   args: {
@@ -2070,6 +2149,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--clusterip",
                   insertValue: "--clusterip={cursor}",
+                  requiresEquals: true,
                   description:
                     "Assign your own ClusterIP or set to 'None' for a 'headless' service (no loadbalancing)",
                   args: {
@@ -2085,6 +2165,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--tcp",
                   insertValue: "--tcp={cursor}",
+                  requiresEquals: true,
                   description:
                     "Port pairs can be specified as '<port>:<targetPort>'",
                   args: {
@@ -2125,6 +2206,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--tcp",
                   insertValue: "--tcp={cursor}",
+                  requiresEquals: true,
                   description:
                     "Port pairs can be specified as '<port>:<targetPort>'",
                   args: {
@@ -2158,6 +2240,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--tcp",
                   insertValue: "--tcp={cursor}",
+                  requiresEquals: true,
                   description:
                     "Port pairs can be specified as '<port>:<targetPort>'",
                   args: {
@@ -2198,6 +2281,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--tcp",
                   insertValue: "--tcp={cursor}",
+                  requiresEquals: true,
                   description:
                     "Port pairs can be specified as '<port>:<targetPort>'",
                   args: {
@@ -2384,6 +2468,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--grace-period",
           insertValue: "--grace-period={cursor}",
+          requiresEquals: true,
           description:
             "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used",
           args: {
@@ -2397,6 +2482,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--pod-selector",
           insertValue: "--pod-selector={cursor}",
+          requiresEquals: true,
           description: "Label selector to filter pods on the node",
           args: {},
         },
@@ -2409,6 +2495,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--timeout",
           insertValue: "--timeout={cursor}",
+          requiresEquals: true,
           description:
             "The length of time to wait before giving up, zero means infinite",
           args: {
@@ -2524,6 +2611,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--cluster-ip",
           insertValue: "--cluster-ip={cursor}",
+          requiresEquals: true,
           description:
             "ClusterIP to be assigned to the service. Leave empty to auto-allocate, or set to 'None' to create a headless service",
           args: {},
@@ -2531,6 +2619,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--external-ip",
           insertValue: "--external-ip={cursor}",
+          requiresEquals: true,
           description:
             "Additional external IP address (not managed by Kubernetes) to accept for the service. If this IP is routed to a node, the service can be accessed by this IP in addition to its generated service IP",
           args: {},
@@ -2538,6 +2627,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--generator",
           insertValue: "--generator={cursor}",
+          requiresEquals: true,
           description:
             "The name of the API generator to use. There are 2 generators: 'service/v1' and 'service/v2'. The only difference between them is that service port in v1 is named 'default', while it is left unnamed in v2. Default is 'service/v2'",
           args: {},
@@ -2545,12 +2635,14 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-l", "--labels"],
           insertValue: "--labels={cursor}",
+          requiresEquals: true,
           description: "Labels to apply to the service created by this call",
           args: {},
         },
         {
           name: "--load-balancer-ip",
           insertValue: "--load-balancer-ip={cursor}",
+          requiresEquals: true,
           description:
             "IP to assign to the LoadBalancer. If empty, an ephemeral IP will be created and used (cloud-provider specific)",
           args: {},
@@ -2559,6 +2651,7 @@ const completionSpec: Fig.Spec = {
           name: "--name",
           description: "The name for the newly created object",
           insertValue: "--name={cursor}",
+          requiresEquals: true,
           args: {},
         },
         {
@@ -2570,6 +2663,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--port",
           insertValue: "--port={cursor}",
+          requiresEquals: true,
           description:
             "The port that the service should serve on. Copied from the resource being exposed, if unspecified",
           args: {},
@@ -2577,6 +2671,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--protocol",
           insertValue: "--protocol={cursor}",
+          requiresEquals: true,
           description:
             "The network protocol for the service to be created. Default is 'TCP'",
           args: {
@@ -2591,6 +2686,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--session-affinity",
           insertValue: "--session-affinity={cursor}",
+          requiresEquals: true,
           description:
             "If non-empty, set the session affinity for the service to this; legal values: 'None', 'ClientIP'",
           args: {},
@@ -2598,6 +2694,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--target-port",
           insertValue: "--target-port={cursor}",
+          requiresEquals: true,
           description:
             "Name or number for the port on the container that the service should direct traffic to. Optional",
           args: {},
@@ -2605,6 +2702,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--type",
           insertValue: "--type={cursor}",
+          requiresEquals: true,
           description:
             "Type for this service: ClusterIP, NodePort, LoadBalancer, or ExternalName. Default is 'ClusterIP'",
           args: {
@@ -2642,6 +2740,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--chunk-size",
           insertValue: "--chunk-size={cursor}",
+          requiresEquals: true,
           description:
             "Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future",
           args: {},
@@ -2691,6 +2790,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--sort-by",
           insertValue: "--sort-by={cursor}",
+          requiresEquals: true,
           description:
             "If non-empty, sort list types using this field specification.  The field specification is expressed as a JSONPath expression (e.g. '{.metadata.name}'). The field in the API resource specified by this JSONPath expression must be an integer or a string",
           args: {},
@@ -2734,6 +2834,7 @@ const completionSpec: Fig.Spec = {
           description:
             "A list of environment variables to be used by functions",
           insertValue: "--env={cursor}",
+          requiresEquals: true,
           args: {
             template: "filepaths",
           },
@@ -2743,12 +2844,14 @@ const completionSpec: Fig.Spec = {
           description:
             "If set to 'LoadRestrictionsNone', local kustomizations may load files from outside their root. This does, however, break the relocatability of the kustomization",
           insertValue: "--load-restrictor={cursor}",
+          requiresEquals: true,
           args: {},
         },
         {
           name: "--mount",
           description: "A list of storage options read from the filesystem",
           insertValue: "--mount={cursor}",
+          requiresEquals: true,
           args: {},
         },
         {
@@ -2759,6 +2862,7 @@ const completionSpec: Fig.Spec = {
           name: "--network-name",
           description: "The docker network to run the container in",
           insertValue: "--network-name={cursor}",
+          requiresEquals: true,
           args: {},
         },
         {
@@ -2766,6 +2870,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Reorder the resources just before output. Use 'legacy' to apply a legacy reordering (Namespaces first, Webhooks last, etc). Use 'none' to suppress a final reordering",
           insertValue: "--reorder={cursor}",
+          requiresEquals: true,
         },
       ],
     },
@@ -2841,12 +2946,14 @@ const completionSpec: Fig.Spec = {
         {
           name: "--limit-bytes",
           insertValue: "--limit-bytes={cursor}",
+          requiresEquals: true,
           description: "Maximum bytes of logs to return. Defaults to no limit",
           args: {},
         },
         {
           name: "--max-log-requests",
           insertValue: "--max-log-requests={cursor}",
+          requiresEquals: true,
           description:
             "Specify maximum number of concurrent logs to follow when using by a selector. Defaults to 5",
           args: {},
@@ -2854,6 +2961,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--pod-running-timeout",
           insertValue: "--pod-running-timeout={cursor}",
+          requiresEquals: true,
           description:
             "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
           args: {},
@@ -2871,6 +2979,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--since",
           insertValue: "--since={cursor}",
+          requiresEquals: true,
           description:
             "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used",
           args: {},
@@ -2878,6 +2987,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--since-time",
           insertValue: "--since-time={cursor}",
+          requiresEquals: true,
           description:
             "Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used",
           args: {},
@@ -2885,6 +2995,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--tail",
           insertValue: "--tail={cursor}",
+          requiresEquals: true,
           description:
             "Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines otherwise 10, if a selector is provided",
           args: {},
@@ -2921,6 +3032,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--type",
           insertValue: "--type={cursor}",
+          requiresEquals: true,
           description:
             "The type of patch being provided; one of [json merge strategic]",
           args: {
@@ -2955,6 +3067,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--pod-running-timeout",
           insertValue: "---pod-running-timeout={cursor}",
+          requiresEquals: true,
           description:
             "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
           args: {},
@@ -2969,6 +3082,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--accept-hosts",
           insertValue: "--accept-hosts={cursor}",
+          requiresEquals: true,
           description:
             "Regular expression for hosts that the proxy should accept",
           args: {},
@@ -2976,6 +3090,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--accept-paths",
           insertValue: "--accept-paths={cursor}",
+          requiresEquals: true,
           description:
             "Regular expression for paths that the proxy should accept",
           args: {},
@@ -2983,12 +3098,14 @@ const completionSpec: Fig.Spec = {
         {
           name: "--address",
           insertValue: "--address={cursor}",
+          requiresEquals: true,
           description: "The IP address on which to serve on",
           args: {},
         },
         {
           name: "--api-prefix",
           insertValue: "--api-prefix={cursor}",
+          requiresEquals: true,
           description: "Prefix to serve the proxied API under",
           args: {},
         },
@@ -3000,6 +3117,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--keepalive",
           insertValue: "--keepalive={cursor}",
+          requiresEquals: true,
           description:
             "Keepalive specifies the keep-alive period for an active network connection. Set to 0 to disable keepalive",
           args: {},
@@ -3007,6 +3125,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-p", "--port"],
           insertValue: "--port={cursor}",
+          requiresEquals: true,
           description:
             "The port on which to run the proxy. Set to 0 to pick a random port",
           args: {},
@@ -3014,6 +3133,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--reject-methods",
           insertValue: "--reject-methods={cursor}",
+          requiresEquals: true,
           description:
             "Regular expression for HTTP methods that the proxy should reject (example --reject-methods='POST,PUT,PATCH')",
           args: {},
@@ -3021,6 +3141,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--reject-paths",
           insertValue: "--reject-paths={cursor}",
+          requiresEquals: true,
           description:
             "Regular expression for paths that the proxy should reject. Paths specified here will be rejected even accepted by --accept-paths",
           args: {},
@@ -3028,12 +3149,14 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-u", "--unix-socket"],
           insertValue: "--unix-socket={cursor}",
+          requiresEquals: true,
           description: "Unix socket on which to run the proxy",
           args: {},
         },
         {
           name: ["-w", "--www"],
           insertValue: "--www={cursor}",
+          requiresEquals: true,
           description:
             "Also serve static files from the given directory under the specified prefix",
           args: {},
@@ -3041,6 +3164,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-P", "--www-prefix"],
           insertValue: "--www-prefix={cursor}",
+          requiresEquals: true,
           description:
             "Prefix to serve static files under, if static file directory is specified",
           args: {},
@@ -3071,6 +3195,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--grace-period",
           insertValue: "--grace-period={cursor}",
+          requiresEquals: true,
           description:
             "Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion)",
           args: {},
@@ -3078,6 +3203,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--raw",
           insertValue: "--raw={cursor}",
+          requiresEquals: true,
           description:
             "Raw URI to PUT to the server.  Uses the transport specified by the kubeconfig file",
           args: {},
@@ -3090,6 +3216,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--timeout",
           insertValue: "--timeout={cursor}",
+          requiresEquals: true,
           description:
             "The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object",
           args: {},
@@ -3125,6 +3252,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--revision",
               insertValue: "--revision={cursor}",
+              requiresEquals: true,
               description:
                 "See the details, including podTemplate of the revision specified",
               // Generator for revisions of resource specified in args
@@ -3182,6 +3310,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--revision",
               insertValue: "--revision={cursor}",
+              requiresEquals: true,
               description:
                 "Pin to a specific revision for showing its status. Defaults to 0 (last revision)",
               args: {},
@@ -3189,6 +3318,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--timeout",
               insertValue: "--timeout={cursor}",
+              requiresEquals: true,
               description:
                 "The length of time to wait before ending watch, zero means never. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h)",
               args: {},
@@ -3212,11 +3342,13 @@ const completionSpec: Fig.Spec = {
             {
               name: "--to_revision",
               insertValue: "--to_revision={cursor}",
+              requiresEquals: true,
               args: {},
             },
             {
               name: "--timeout",
               insertValue: "--timeout={cursor}",
+              requiresEquals: true,
               description:
                 "The length of time to wait before ending watch, zero means never. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h)",
               args: {},
@@ -3243,6 +3375,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--annotations",
           insertValue: "--annotations={cursor}",
+          requiresEquals: true,
           description: "Annotations to apply to the pod",
           args: {},
         },
@@ -3267,6 +3400,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--env",
           insertValue: "--env={cursor}",
+          requiresEquals: true,
           description: "Environment variables to set in the container",
           args: {},
         },
@@ -3283,6 +3417,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--grace-period",
           insertValue: "--grace-period={cursor}",
+          requiresEquals: true,
           description:
             "Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion)",
           args: {},
@@ -3290,6 +3425,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--hostport",
           insertValue: "--hostport={cursor}",
+          requiresEquals: true,
           description:
             "The host port mapping for the container port. To demonstrate a single-machine container",
           args: {},
@@ -3297,6 +3433,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--image",
           insertValue: "--image={cursor}",
+          requiresEquals: true,
           description: "The image for the container to run",
           args: {},
         },
@@ -3310,6 +3447,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-l", "--labels"],
           insertValue: "--labels={cursor}",
+          requiresEquals: true,
           description:
             "Comma separated labels to apply to the pod(s). Will override previous values",
           args: {},
@@ -3322,6 +3460,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--limits",
           insertValue: "--limits={cursor}",
+          requiresEquals: true,
           description:
             "The resource requirement limits for this container.  For example, 'cpu=200m,memory=512Mi'.  Note that server side components may assign limits depending on the server configuration, such as limit ranges",
           args: {},
@@ -3329,6 +3468,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--overrides",
           insertValue: "--overrides={cursor}",
+          requiresEquals: true,
           description:
             "An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field",
           args: {},
@@ -3336,6 +3476,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--pod-running-timeout",
           insertValue: "--pod-running-timeout={cursor}",
+          requiresEquals: true,
           description:
             "The length of time (like 5s, 2m, or 3h, higher than zero) to wait until at least one pod is running",
           args: {},
@@ -3343,6 +3484,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--port",
           insertValue: "--port={cursor}",
+          requiresEquals: true,
           description: "The port that this container exposes",
           args: {},
         },
@@ -3353,6 +3495,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--requests",
           insertValue: "--requests={cursor}",
+          requiresEquals: true,
           description:
             "The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges",
           args: {},
@@ -3360,6 +3503,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--restart",
           insertValue: "--restart={cursor}",
+          requiresEquals: true,
           description:
             "The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  If set to 'Always' a deployment is created, if set to 'OnFailure' a job is created, if set to 'Never', a regular pod is created. For the latter two --replicas must be 1.  Default 'Always', for CronJobs `Never`",
           args: {
@@ -3379,6 +3523,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--serviceaccount",
           insertValue: "--serviceaccount={cursor}",
+          requiresEquals: true,
           description: "Service account to set in the pod spec",
           args: {},
         },
@@ -3390,6 +3535,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--timeout",
           insertValue: "--timeout={cursor}",
+          requiresEquals: true,
           description:
             "The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object",
           args: {},
@@ -3432,6 +3578,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--current-replicas",
           insertValue: "--current-replicas={cursor}",
+          requiresEquals: true,
           description:
             "Precondition for current size. Requires that the current size of the resource match this value in order to scale",
           args: {},
@@ -3439,6 +3586,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--replicas",
           insertValue: "--replicas={cursor}",
+          requiresEquals: true,
           description: "The new desired number of replicas. Required",
           args: {},
         },
@@ -3484,6 +3632,7 @@ const completionSpec: Fig.Spec = {
             {
               name: ["-c", "--containers"],
               insertValue: "--containers={cursor}",
+              requiresEquals: true,
               description:
                 "The names of containers in the selected pod templates to change - may use wildcards",
               args: {},
@@ -3491,6 +3640,7 @@ const completionSpec: Fig.Spec = {
             {
               name: ["-e", "--env"],
               insertValue: "--env={cursor}",
+              requiresEquals: true,
               description:
                 "Specify a key-value pair for an environment variable to set into each container",
               args: {},
@@ -3498,6 +3648,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--from",
               insertValue: "--from={cursor}",
+              requiresEquals: true,
               description:
                 "The name of a resource from which to inject environment variables",
               args: {},
@@ -3505,6 +3656,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--keys",
               insertValue: "--keys={cursor}",
+              requiresEquals: true,
               description:
                 "Comma-separated list of keys to import from specified resource",
               args: {},
@@ -3588,6 +3740,7 @@ const completionSpec: Fig.Spec = {
             {
               name: ["-c", "--containers"],
               insertValue: "--containers={cursor}",
+              requiresEquals: true,
               description:
                 "The names of containers in the selected pod templates to change, all containers are selected by default - may use wildcards",
               args: {},
@@ -3595,6 +3748,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--limits",
               insertValue: "--limits={cursor}",
+              requiresEquals: true,
               description:
                 "The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges",
               args: {},
@@ -3602,6 +3756,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--requests",
               insertValue: "--requests={cursor}",
+              requiresEquals: true,
               description:
                 "The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges",
               args: {},
@@ -3689,12 +3844,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--group",
               insertValue: "--group={cursor}",
+              requiresEquals: true,
               description: "Groups to bind to the role",
               args: {},
             },
             {
               name: "--serviceaccount",
               insertValue: "--serviceaccount={cursor}",
+              requiresEquals: true,
               description: "Service accounts to bind to the role",
               args: {},
             },
@@ -3784,6 +3941,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--for",
           insertValue: "--for={cursor}",
+          requiresEquals: true,
           description:
             "The condition to wait on: [delete|condition=condition-name]",
           args: {},
@@ -3791,6 +3949,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--timeout",
           insertValue: "--timeout={cursor}",
+          requiresEquals: true,
           description:
             "The length of time to wait before giving up.  Zero means check once and don't wait, negative means wait for a week",
           args: {},

--- a/src/ns.ts
+++ b/src/ns.ts
@@ -191,6 +191,7 @@ const platformEnvOptions: Fig.Option[] = [
     description:
       "Add file replacement rules. For source files (.js and .ts) this will add a new alias to the config, for everything else, this will add a new copy rule",
     insertValue: "--env.replace={cursor}:",
+    requiresEquals: true,
   },
 ];
 

--- a/src/rake.ts
+++ b/src/rake.ts
@@ -17,7 +17,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["-I", "--libdir"],
-      insertValue: "--libdir=",
+      insertValue: "--libdir={cursor}",
       description: "Include LIBDIR in the search path for required modules",
       args: {
         name: "LIBDIR",
@@ -34,7 +34,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["-f", "--rakefile"],
-      insertValue: "--rakeFile=",
+      insertValue: "--rakeFile={cursor}",
       description: "Use FILE as the rakefile",
       args: {
         name: "FILE",
@@ -43,7 +43,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["-r", "--require"],
-      insertValue: "--require=",
+      insertValue: "--require={cursor}",
       description: "Require MODULE before executing rakefile",
       args: {
         name: "MODULE",

--- a/src/rake.ts
+++ b/src/rake.ts
@@ -18,6 +18,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["-I", "--libdir"],
       insertValue: "--libdir={cursor}",
+      requiresEquals: true,
       description: "Include LIBDIR in the search path for required modules",
       args: {
         name: "LIBDIR",
@@ -35,6 +36,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["-f", "--rakefile"],
       insertValue: "--rakeFile={cursor}",
+      requiresEquals: true,
       description: "Use FILE as the rakefile",
       args: {
         name: "FILE",
@@ -44,6 +46,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["-r", "--require"],
       insertValue: "--require={cursor}",
+      requiresEquals: true,
       description: "Require MODULE before executing rakefile",
       args: {
         name: "MODULE",

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -854,7 +854,7 @@ const completionSpec: Fig.Spec = {
           dependsOn: ["g", "-g", "--listed-incremental"],
         },
         {
-          name: ["--level", "--level="],
+          name: ["--level", "--level={cursor}"],
           description: "Set dump level for created listed-incremental archive",
           args: { name: "NUMBER", default: "0" },
           dependsOn: ["g", "-g", "--listed-incremental"],

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -855,6 +855,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: ["--level", "--level={cursor}"],
+          requiresEquals: true,
           description: "Set dump level for created listed-incremental archive",
           args: { name: "NUMBER", default: "0" },
           dependsOn: ["g", "-g", "--listed-incremental"],

--- a/src/terraform.ts
+++ b/src/terraform.ts
@@ -34,6 +34,7 @@ const generalSubCommandOptions: Fig.Option[] = [
   {
     name: "-lock",
     insertValue: "-lock={cursor}",
+    requiresEquals: true,
     description:
       "Lock the state file when locking is supported. Defaults to true",
     args: {
@@ -44,6 +45,7 @@ const generalSubCommandOptions: Fig.Option[] = [
   {
     name: "-force",
     insertValue: "-force={cursor}",
+    requiresEquals: true,
     description:
       "Delete the workspace even if its state is not empty. Defaults to false",
     args: {
@@ -54,6 +56,7 @@ const generalSubCommandOptions: Fig.Option[] = [
   {
     name: "-lock-timeout",
     insertValue: "-lock-timeout={cursor}",
+    requiresEquals: true,
     description: "Duration to retry a state lock. Default 0s",
     args: {
       name: "seconds",
@@ -62,6 +65,7 @@ const generalSubCommandOptions: Fig.Option[] = [
   {
     name: "-input",
     insertValue: "-input={cursor}",
+    requiresEquals: true,
     description: "Ask for input for variables if not directly set",
     args: {
       name: "true or false",
@@ -85,6 +89,7 @@ const globalOptions: Fig.Option[] = [
     description:
       "Switch to a different working directory before executing the given subcommand",
     insertValue: "-chdir={cursor}",
+    requiresEquals: true,
     args: {
       template: "filepaths",
     },
@@ -135,6 +140,7 @@ const mainCommands: Fig.Subcommand[] = [
       {
         name: "-out",
         insertValue: "-out={cursor}",
+        requiresEquals: true,
         description: "The path to save the generated execution plan",
       },
       {
@@ -148,6 +154,7 @@ const mainCommands: Fig.Subcommand[] = [
       {
         name: "-refresh",
         insertValue: "-refresh={cursor}",
+        requiresEquals: true,
         description: "Update the state prior to checking for differences",
         args: {
           name: "true or false",
@@ -157,6 +164,7 @@ const mainCommands: Fig.Subcommand[] = [
       {
         name: "-state",
         insertValue: "-state={cursor}",
+        requiresEquals: true,
         description:
           "Path to the state file. Defaults to 'terraform.tfstate'. Ignored when remote state is used",
         args: {
@@ -184,6 +192,7 @@ const mainCommands: Fig.Subcommand[] = [
       {
         name: "-var-file",
         insertValue: "-var-file={cursor}",
+        requiresEquals: true,
         description:
           "Set variables in the Terraform configuration from a variable file",
         args: {
@@ -290,6 +299,7 @@ const otherCommands: Fig.Subcommand[] = [
       {
         name: "-lock",
         insertValue: "-lock={cursor}",
+        requiresEquals: true,
         description:
           "Disables Terraform's default behavior of attempting to take a read/write lock on the state for the duration of the operation if set to false. Defaults to true",
         args: {
@@ -300,6 +310,7 @@ const otherCommands: Fig.Subcommand[] = [
       {
         name: "-lock-timeout",
         insertValue: "-lock-timeout={cursor}",
+        requiresEquals: true,
         description:
           "Unless locking is disabled with -lock=false, instructs Terraform to retry acquiring a lock for a period of time before returning an error. The duration syntax is a number followed by a time unit letter, such as 3s for three seconds",
         args: {
@@ -358,6 +369,7 @@ const otherCommands: Fig.Subcommand[] = [
           {
             name: "-state",
             insertValue: "-state={cursor}",
+            requiresEquals: true,
             description:
               "Path to an existing state file to initialize the state of this environment",
             args: {

--- a/src/terraform.ts
+++ b/src/terraform.ts
@@ -33,7 +33,7 @@ const addressList: Fig.Generator = {
 const generalSubCommandOptions: Fig.Option[] = [
   {
     name: "-lock",
-    insertValue: "-lock=",
+    insertValue: "-lock={cursor}",
     description:
       "Lock the state file when locking is supported. Defaults to true",
     args: {
@@ -43,7 +43,7 @@ const generalSubCommandOptions: Fig.Option[] = [
   },
   {
     name: "-force",
-    insertValue: "-force=",
+    insertValue: "-force={cursor}",
     description:
       "Delete the workspace even if its state is not empty. Defaults to false",
     args: {
@@ -53,7 +53,7 @@ const generalSubCommandOptions: Fig.Option[] = [
   },
   {
     name: "-lock-timeout",
-    insertValue: "-lock-timeout=",
+    insertValue: "-lock-timeout={cursor}",
     description: "Duration to retry a state lock. Default 0s",
     args: {
       name: "seconds",
@@ -61,7 +61,7 @@ const generalSubCommandOptions: Fig.Option[] = [
   },
   {
     name: "-input",
-    insertValue: "-input=",
+    insertValue: "-input={cursor}",
     description: "Ask for input for variables if not directly set",
     args: {
       name: "true or false",
@@ -84,7 +84,7 @@ const globalOptions: Fig.Option[] = [
     name: "-chdir",
     description:
       "Switch to a different working directory before executing the given subcommand",
-    insertValue: "-chdir=",
+    insertValue: "-chdir={cursor}",
     args: {
       template: "filepaths",
     },
@@ -134,7 +134,7 @@ const mainCommands: Fig.Subcommand[] = [
       },
       {
         name: "-out",
-        insertValue: "-out=",
+        insertValue: "-out={cursor}",
         description: "The path to save the generated execution plan",
       },
       {
@@ -147,7 +147,7 @@ const mainCommands: Fig.Subcommand[] = [
       },
       {
         name: "-refresh",
-        insertValue: "-refresh=",
+        insertValue: "-refresh={cursor}",
         description: "Update the state prior to checking for differences",
         args: {
           name: "true or false",
@@ -156,7 +156,7 @@ const mainCommands: Fig.Subcommand[] = [
       },
       {
         name: "-state",
-        insertValue: "-state=",
+        insertValue: "-state={cursor}",
         description:
           "Path to the state file. Defaults to 'terraform.tfstate'. Ignored when remote state is used",
         args: {
@@ -183,7 +183,7 @@ const mainCommands: Fig.Subcommand[] = [
 
       {
         name: "-var-file",
-        insertValue: "-var-file=",
+        insertValue: "-var-file={cursor}",
         description:
           "Set variables in the Terraform configuration from a variable file",
         args: {
@@ -289,7 +289,7 @@ const otherCommands: Fig.Subcommand[] = [
       },
       {
         name: "-lock",
-        insertValue: "-lock=",
+        insertValue: "-lock={cursor}",
         description:
           "Disables Terraform's default behavior of attempting to take a read/write lock on the state for the duration of the operation if set to false. Defaults to true",
         args: {
@@ -299,7 +299,7 @@ const otherCommands: Fig.Subcommand[] = [
       },
       {
         name: "-lock-timeout",
-        insertValue: "-lock-timeout=",
+        insertValue: "-lock-timeout={cursor}",
         description:
           "Unless locking is disabled with -lock=false, instructs Terraform to retry acquiring a lock for a period of time before returning an error. The duration syntax is a number followed by a time unit letter, such as 3s for three seconds",
         args: {
@@ -357,7 +357,7 @@ const otherCommands: Fig.Subcommand[] = [
           },
           {
             name: "-state",
-            insertValue: "-state=",
+            insertValue: "-state={cursor}",
             description:
               "Path to an existing state file to initialize the state of this environment",
             args: {

--- a/src/valet.ts
+++ b/src/valet.ts
@@ -161,7 +161,7 @@ const completionSpec: Fig.Spec = {
       options: [
         {
           name: "--format",
-          insertValue: "--format=",
+          insertValue: "--format={cursor}",
           description:
             "The output format (txt, xml, json, or md) [default: 'txt']",
           args: {
@@ -238,7 +238,7 @@ const completionSpec: Fig.Spec = {
         { name: "--raw", description: "To output raw command list" },
         {
           name: "--format",
-          insertValue: "--format=",
+          insertValue: "--format={cursor}",
           description:
             "The output format (txt, xml, json, or md) [default: 'txt']",
           args: {
@@ -280,7 +280,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--lines",
-          insertValue: "--lines=",
+          insertValue: "--lines={cursor}",
           args: {
             name: "LINES",
           },

--- a/src/valet.ts
+++ b/src/valet.ts
@@ -162,6 +162,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--format",
           insertValue: "--format={cursor}",
+          requiresEquals: true,
           description:
             "The output format (txt, xml, json, or md) [default: 'txt']",
           args: {
@@ -239,6 +240,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--format",
           insertValue: "--format={cursor}",
+          requiresEquals: true,
           description:
             "The output format (txt, xml, json, or md) [default: 'txt']",
           args: {
@@ -281,6 +283,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--lines",
           insertValue: "--lines={cursor}",
+          requiresEquals: true,
           args: {
             name: "LINES",
           },

--- a/src/wp.ts
+++ b/src/wp.ts
@@ -76,7 +76,7 @@ const global_parameter_skip_plugins2: Fig.Option = {
   name: "--skip-plugins",
   insertValue: "--skip-plugins={cursor}",
   requiresEquals: true,
-  displayName: "--skip-plugins={cursor}",
+  displayName: "--skip-plugins=",
   description:
     "Skip loading all plugins, or a comma-separated list of plugins. Note: mu-plugins are still loaded",
   args: {
@@ -145,7 +145,7 @@ const global_parameter_debug1: Fig.Option = {
 
 const global_parameter_debug2: Fig.Option = {
   name: "--debug",
-  displayName: "--debug={cursor}",
+  displayName: "--debug=",
   requiresEquals: true,
   insertValue: "--debug={cursor}",
   description:
@@ -165,7 +165,7 @@ const global_parameter_prompt2: Fig.Option = {
   name: "--prompt",
   insertValue: "--prompt={cursor}",
   requiresEquals: true,
-  displayName: "--prompt={cursor}",
+  displayName: "--prompt=",
   description:
     "Prompt the user to enter values for all command arguments, or a subset specified as comma-separated values",
   args: {
@@ -8834,7 +8834,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--log",
-          displayName: "--log={cursor}",
+          displayName: "--log=",
           requiresEquals: true,
           insertValue: "--log={cursor}",
           description:

--- a/src/wp.ts
+++ b/src/wp.ts
@@ -5,7 +5,7 @@
 // To learn more about Fig's autocomplete standard visit: https://fig.io/docs/concepts/cli-skeleton
 const global_parameter_path: Fig.Option = {
   name: "--path",
-  insertValue: "--path=",
+  insertValue: "--path={cursor}",
   description: "Path to the WordPress files",
   args: {
     name: "path",
@@ -15,7 +15,7 @@ const global_parameter_path: Fig.Option = {
 
 const global_parameter_url: Fig.Option = {
   name: "--url",
-  insertValue: "--url=",
+  insertValue: "--url={cursor}",
   description:
     "Pretend request came from given URL. In multisite, this argument is how the target site is specified",
   args: {
@@ -25,7 +25,7 @@ const global_parameter_url: Fig.Option = {
 
 const global_parameter_ssh: Fig.Option = {
   name: "--ssh",
-  insertValue: "--ssh=",
+  insertValue: "--ssh={cursor}",
   description:
     "Perform operation against a remote server over SSH (or a container using scheme of “docker”, “docker-compose”, “vagrant”)",
   args: {
@@ -43,7 +43,7 @@ const global_parameter_ssh: Fig.Option = {
 
 const global_parameter_http: Fig.Option = {
   name: "--http",
-  insertValue: "--http=",
+  insertValue: "--http={cursor}",
   description:
     "Perform operation against a remote WordPress installation over HTTP",
   args: {
@@ -53,7 +53,7 @@ const global_parameter_http: Fig.Option = {
 
 const global_parameter_user: Fig.Option = {
   name: "--user",
-  insertValue: "--user=",
+  insertValue: "--user={cursor}",
   description: "Set the WordPress user",
   args: {
     name: "options",
@@ -69,8 +69,8 @@ const global_parameter_skip_plugins1: Fig.Option = {
 
 const global_parameter_skip_plugins2: Fig.Option = {
   name: "--skip-plugins",
-  insertValue: "--skip-plugins=",
-  displayName: "--skip-plugins=",
+  insertValue: "--skip-plugins={cursor}",
+  displayName: "--skip-plugins={cursor}",
   description:
     "Skip loading all plugins, or a comma-separated list of plugins. Note: mu-plugins are still loaded",
   args: {
@@ -85,8 +85,8 @@ const global_parameter_skip_themes1: Fig.Option = {
 
 const global_parameter_skip_themes2: Fig.Option = {
   name: "--skip-themes",
-  insertValue: "--skip-themes=",
-  displayName: "--skip-themes=",
+  insertValue: "--skip-themes={cursor}",
+  displayName: "--skip-themes={cursor}",
   description: "Skip loading all themes, or a comma-separated list of themes",
   args: {
     name: "themes",
@@ -100,7 +100,7 @@ const global_parameter_skip_packages: Fig.Option = {
 
 const global_parameter_require: Fig.Option = {
   name: "--require",
-  insertValue: "--require=",
+  insertValue: "--require={cursor}",
   description:
     "Load PHP file before running the command (may be used more than once)",
   args: {
@@ -110,7 +110,7 @@ const global_parameter_require: Fig.Option = {
 
 const global_parameter_exec: Fig.Option = {
   name: "--exec",
-  insertValue: "--exec=",
+  insertValue: "--exec={cursor}",
   description:
     "Execute PHP code before running the command (may be used more than once)",
   args: {
@@ -136,8 +136,8 @@ const global_parameter_debug1: Fig.Option = {
 
 const global_parameter_debug2: Fig.Option = {
   name: "--debug",
-  displayName: "--debug=",
-  insertValue: "--debug=",
+  displayName: "--debug={cursor}",
+  insertValue: "--debug={cursor}",
   description:
     "Show all PHP errors and add verbosity to WP-CLI output. Built-in groups include: bootstrap, commandfactory, and help",
   args: {
@@ -153,8 +153,8 @@ const global_parameter_prompt1: Fig.Option = {
 
 const global_parameter_prompt2: Fig.Option = {
   name: "--prompt",
-  insertValue: "--prompt=",
-  displayName: "--prompt=",
+  insertValue: "--prompt={cursor}",
+  displayName: "--prompt={cursor}",
   description:
     "Prompt the user to enter values for all command arguments, or a subset specified as comma-separated values",
   args: {
@@ -419,7 +419,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -497,19 +497,19 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--set-user",
-                  insertValue: "--set-user=",
+                  insertValue: "--set-user={cursor}",
                   description: "Set user for alias",
                   args: { name: "user" },
                 },
                 {
                   name: "--set-url",
-                  insertValue: "--set-url=",
+                  insertValue: "--set-url={cursor}",
                   description: "Set url for alias",
                   args: { name: "url" },
                 },
                 {
                   name: "--set-path",
-                  insertValue: "--set-path=",
+                  insertValue: "--set-path={cursor}",
                   description: "Set path for alias",
                   args: {
                     name: "path",
@@ -518,25 +518,25 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--set-ssh",
-                  insertValue: "--set-ssh=",
+                  insertValue: "--set-ssh={cursor}",
                   description: "Set ssh for alias",
                   args: { name: "ssh" },
                 },
                 {
                   name: "--set-http",
-                  insertValue: "--set-http=",
+                  insertValue: "--set-http={cursor}",
                   description: "Set http for alias",
                   args: { name: "http" },
                 },
                 {
                   name: "--grouping",
-                  insertValue: "--grouping=",
+                  insertValue: "--grouping={cursor}",
                   description: "For grouping multiple aliases",
                   args: { name: "grouping" },
                 },
                 {
                   name: "--config",
-                  insertValue: "--config=",
+                  insertValue: "--config={cursor}",
                   description: "Config file to be considered for operations",
                   args: {
                     name: "options",
@@ -555,7 +555,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--config",
-                  insertValue: "--config=",
+                  insertValue: "--config={cursor}",
                   description: "Config file to be considered for operations",
                   args: {
                     name: "options",
@@ -578,7 +578,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Set user for alias",
                   args: {
                     name: "options",
@@ -601,19 +601,19 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--set-user",
-                  insertValue: "--set-user=",
+                  insertValue: "--set-user={cursor}",
                   description: "Set user for alias",
                   args: { name: "user" },
                 },
                 {
                   name: "--set-url",
-                  insertValue: "--set-url=",
+                  insertValue: "--set-url={cursor}",
                   description: "Set url for alias",
                   args: { name: "url" },
                 },
                 {
                   name: "--set-path",
-                  insertValue: "--set-path=",
+                  insertValue: "--set-path={cursor}",
                   description: "Set path for alias",
                   args: {
                     name: "path",
@@ -622,25 +622,25 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--set-ssh",
-                  insertValue: "--set-ssh=",
+                  insertValue: "--set-ssh={cursor}",
                   description: "Set ssh for alias",
                   args: { name: "ssh" },
                 },
                 {
                   name: "--set-http",
-                  insertValue: "--set-http=",
+                  insertValue: "--set-http={cursor}",
                   description: "Set http for alias",
                   args: { name: "http" },
                 },
                 {
                   name: "--grouping",
-                  insertValue: "--grouping=",
+                  insertValue: "--grouping={cursor}",
                   description: "For grouping multiple aliases",
                   args: { name: "grouping" },
                 },
                 {
                   name: "--config",
-                  insertValue: "--config=",
+                  insertValue: "--config={cursor}",
                   description: "Config file to be considered for operations",
                   args: {
                     name: "options",
@@ -684,20 +684,20 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each update",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific object fields. Defaults to version,update_type,package_url",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -722,13 +722,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--line",
-              insertValue: "--line=",
+              insertValue: "--line={cursor}",
               description: "The current command line to be executed",
               args: { name: "line" },
             },
             {
               name: "--point",
-              insertValue: "--point=",
+              insertValue: "--point={cursor}",
               description:
                 "The index to the current cursor position relative to the beginning of the command",
               args: { name: "point" },
@@ -749,7 +749,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -769,7 +769,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -907,7 +907,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--count",
-              insertValue: "--count=",
+              insertValue: "--count={cursor}",
               description: "How many comments to generate?",
               args: {
                 name: "default",
@@ -916,7 +916,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--post_id",
-              insertValue: "--post_id=",
+              insertValue: "--post_id={cursor}",
               description: "Assign comments to a specific post",
               args: {
                 name: "post-id",
@@ -924,7 +924,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -943,7 +943,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Instead of returning the whole comment, returns the value of a single field",
               args: {
@@ -952,7 +952,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: {
@@ -961,7 +961,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -986,7 +986,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Prints the value of a single field for each comment",
               args: {
@@ -995,7 +995,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific object fields",
               args: {
                 name: "fields",
@@ -1003,7 +1003,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -1045,7 +1045,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "options",
@@ -1095,7 +1095,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Get value in a particular format",
                   args: {
                     name: "options",
@@ -1118,7 +1118,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--keys",
-                  insertValue: "--keys=",
+                  insertValue: "--keys={cursor}",
                   description: "Limit output to metadata of specific keys",
                   args: {
                     name: "keys",
@@ -1126,7 +1126,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: {
@@ -1135,7 +1135,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "options",
@@ -1150,7 +1150,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--orderby",
-                  insertValue: "--orderby=",
+                  insertValue: "--orderby={cursor}",
                   description: "Set orderby which field",
                   args: {
                     name: "options",
@@ -1163,7 +1163,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--order",
-                  insertValue: "--order=",
+                  insertValue: "--order={cursor}",
                   description: "Set ascending or descending order",
                   args: {
                     name: "options",
@@ -1211,7 +1211,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "options",
@@ -1241,7 +1241,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The output format of the value",
                   args: {
                     name: "options",
@@ -1275,7 +1275,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "options",
@@ -1392,19 +1392,19 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbname",
-              insertValue: "--dbname=",
+              insertValue: "--dbname={cursor}",
               description: "Set the database name",
               args: { name: "dbname" },
             },
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description: "Set the database user",
               args: { name: "dbuser" },
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description: "Set the database password",
               args: {
                 name: "options",
@@ -1413,7 +1413,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--dbhost",
-              insertValue: "--dbhost=",
+              insertValue: "--dbhost={cursor}",
               description: "Set the database host",
               args: {
                 name: "default",
@@ -1422,7 +1422,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--dbprefix",
-              insertValue: "--dbprefix=",
+              insertValue: "--dbprefix={cursor}",
               description: "Set the database table prefix",
               args: {
                 name: "default",
@@ -1431,7 +1431,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--dbcharset",
-              insertValue: "--dbcharset=",
+              insertValue: "--dbcharset={cursor}",
               description: "Set the database charset",
               args: {
                 name: "default",
@@ -1440,13 +1440,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--dbcollate",
-              insertValue: "--dbcollate=",
+              insertValue: "--dbcollate={cursor}",
               description: "Set the database collation",
               args: { name: "dbcollate" },
             },
             {
               name: "--locale",
-              insertValue: "--locale=",
+              insertValue: "--locale={cursor}",
               description:
                 "Set the WPLANG constant. Defaults to $wp_local_package variable",
               args: { name: "locale" },
@@ -1487,7 +1487,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--type",
-              insertValue: "--type=",
+              insertValue: "--type={cursor}",
               description:
                 "Type of the config value to delete. Defaults to ‘all’",
               args: {
@@ -1516,7 +1516,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--type",
-              insertValue: "--type=",
+              insertValue: "--type={cursor}",
               description:
                 "Type of the config value to delete. Defaults to ‘all’",
               args: {
@@ -1530,7 +1530,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Get value in a particular format",
               args: {
                 name: "options",
@@ -1554,7 +1554,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--type",
-              insertValue: "--type=",
+              insertValue: "--type={cursor}",
               description:
                 "Type of the config value to delete. Defaults to ‘all’",
               args: {
@@ -1579,14 +1579,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -1641,14 +1641,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--anchor",
-              insertValue: "--anchor=",
+              insertValue: "--anchor={cursor}",
               description:
                 "Anchor string where additions of new values are anchored around. Defaults to “/* That’s all, stop editing!”",
               args: { name: "anchor" },
             },
             {
               name: "--placement",
-              insertValue: "--placement=",
+              insertValue: "--placement={cursor}",
               description:
                 "Where to place the new values in relation to the anchor string",
               args: {
@@ -1658,14 +1658,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--separator",
-              insertValue: "--separator=",
+              insertValue: "--separator={cursor}",
               description:
                 "Separator string to put between an added value and its anchor string. The following escape sequences will be recognized and properly interpreted: ‘\n’ => newline, ‘\r’ => carriage return, ‘\t’ => tab. Defaults to a single EOL (“\n” on *nix and “\r\n” on Windows)",
               args: { name: "separator" },
             },
             {
               name: "--type",
-              insertValue: "--type=",
+              insertValue: "--type={cursor}",
               description: "Type of the config value to set. Defaults to ‘all’",
               args: {
                 name: "options",
@@ -1742,20 +1742,20 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each update",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific object fields. Defaults to version,update_type,package_url",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -1781,20 +1781,20 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--path",
-              insertValue: "--path=",
+              insertValue: "--path={cursor}",
               description:
                 "Specify the path in which to install WordPress. Defaults to current directory",
               args: { name: "path", template: "folders" },
             },
             {
               name: "--locale",
-              insertValue: "--locale=",
+              insertValue: "--locale={cursor}",
               description: "Select which language you want to download",
               args: { name: "locale" },
             },
             {
               name: "--version",
-              insertValue: "--version=",
+              insertValue: "--version={cursor}",
               description:
                 "Select which version you want to download. Accepts a version number, ‘latest’ or ‘nightly’",
               args: {
@@ -1827,32 +1827,32 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--url",
-              insertValue: "--url=",
+              insertValue: "--url={cursor}",
               description: "The address of the new site",
               args: { name: "url" },
             },
             {
               name: "--title",
-              insertValue: "--title=",
+              insertValue: "--title={cursor}",
               description: "The title of the new site",
               args: { name: "site-title" },
             },
             {
               name: "--admin_user",
-              insertValue: "--admin_user=",
+              insertValue: "--admin_user={cursor}",
               description: "The name of the admin user",
               args: { name: "username" },
             },
             {
               name: "--admin_password",
-              insertValue: "--admin_password=",
+              insertValue: "--admin_password={cursor}",
               description:
                 "The password for the admin user. Defaults to randomly generated string",
               args: { name: "password" },
             },
             {
               name: "--admin_email",
-              insertValue: "--admin_email=",
+              insertValue: "--admin_email={cursor}",
               description: "The email address for the admin user",
               args: { name: "email" },
             },
@@ -1880,13 +1880,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--title",
-              insertValue: "--title=",
+              insertValue: "--title={cursor}",
               description: "The title of the new network",
               args: { name: "network-title" },
             },
             {
               name: "--base",
-              insertValue: "--base=",
+              insertValue: "--base={cursor}",
               description:
                 "Base path after the domain name that each site url will start with",
               args: {
@@ -1907,13 +1907,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--url",
-              insertValue: "--url=",
+              insertValue: "--url={cursor}",
               description: "The address of the new site",
               args: { name: "url" },
             },
             {
               name: "--base",
-              insertValue: "--base=",
+              insertValue: "--base={cursor}",
               description:
                 "Base path after the domain name that each site url will start with",
               args: {
@@ -1928,13 +1928,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--title",
-              insertValue: "--title=",
+              insertValue: "--title={cursor}",
               description: "The title of the new site",
               args: { name: "site-title" },
             },
             {
               name: "--admin_user",
-              insertValue: "--admin_user=",
+              insertValue: "--admin_user={cursor}",
               description: "The name of the admin user",
               args: {
                 name: "username",
@@ -1943,14 +1943,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--admin_password",
-              insertValue: "--admin_password=",
+              insertValue: "--admin_password={cursor}",
               description:
                 "The password for the admin user. Defaults to randomly generated string",
               args: { name: "password" },
             },
             {
               name: "--admin_email",
-              insertValue: "--admin_email=",
+              insertValue: "--admin_email={cursor}",
               description: "The email address for the admin user",
               args: { name: "email" },
             },
@@ -1982,7 +1982,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--version",
-              insertValue: "--version=",
+              insertValue: "--version={cursor}",
               description:
                 "Update to a specific version, instead of to the latest version. Alternatively accepts ‘nightly’",
               args: { name: "version" },
@@ -1994,7 +1994,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--locale",
-              insertValue: "--locale=",
+              insertValue: "--locale={cursor}",
               description: "Select which language you want to download",
               args: { name: "locale" },
             },
@@ -2027,14 +2027,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--version",
-              insertValue: "--version=",
+              insertValue: "--version={cursor}",
               description:
                 "Verify checksums against a specific version of WordPress",
               args: { name: "version" },
             },
             {
               name: "--locale",
-              insertValue: "--locale=",
+              insertValue: "--locale={cursor}",
               description:
                 "Verify checksums against a specific locale of WordPress",
               args: { name: "locale" },
@@ -2103,7 +2103,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific object fields",
                   args: { name: "fields" },
                 },
@@ -2114,14 +2114,14 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description:
                     "Prints the value of a single field for each term",
                   args: { name: "field" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "options",
@@ -2205,20 +2205,20 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific object fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description:
                     "Prints the value of a single field for each schedule",
                   args: { name: "field" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "options",
@@ -2274,14 +2274,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description:
                 "Username to pass to mysqlcheck. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description:
                 "Password to pass to mysqlcheck. Defaults to DB_PASSWORD",
               args: { name: "value" },
@@ -2306,14 +2306,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description:
                 "Username to pass to mysqlcheck. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description:
                 "Password to pass to mysqlcheck. Defaults to DB_PASSWORD",
               args: { name: "value" },
@@ -2331,26 +2331,26 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--database",
-              insertValue: "--database=",
+              insertValue: "--database={cursor}",
               description: "Use a specific database. Defaults to DB_NAME",
               args: { name: "database" },
             },
             {
               name: "--default-character-set",
-              insertValue: "--default-character-set=",
+              insertValue: "--default-character-set={cursor}",
               description:
                 "Use a specific character set. Defaults to DB_CHARSET when defined",
               args: { name: "character-set" },
             },
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: { name: "value" },
             },
@@ -2377,7 +2377,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -2397,13 +2397,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: { name: "value" },
             },
@@ -2415,13 +2415,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: { name: "value" },
             },
@@ -2442,13 +2442,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description: "Username to pass to mysqldump. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description:
                 "Password to pass to mysqldump. Defaults to DB_PASSWORD",
               args: { name: "value" },
@@ -2461,14 +2461,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--tables",
-              insertValue: "--tables=",
+              insertValue: "--tables={cursor}",
               description:
                 "The comma separated list of specific tables to export. Excluding this parameter will export all tables in the database",
               args: { name: "tables" },
             },
             {
               name: "--exclude_tables",
-              insertValue: "--exclude_tables=",
+              insertValue: "--exclude_tables={cursor}",
               description:
                 "The comma separated list of specific tables that should be skipped from exporting. Excluding this parameter will export all tables in the database",
               args: { name: "tables" },
@@ -2500,7 +2500,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: {
                 name: "value",
@@ -2509,7 +2509,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: {
                 name: "value",
@@ -2540,7 +2540,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description:
                 "Username to pass to mysqlcheck. Defaults to DB_USER",
               args: {
@@ -2550,7 +2550,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description:
                 "Password to pass to mysqlcheck. Defaults to DB_PASSWORD",
               args: {
@@ -2586,7 +2586,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: {
                 name: "value",
@@ -2595,7 +2595,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: {
                 name: "value",
@@ -2621,7 +2621,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description:
                 "Username to pass to mysqlcheck. Defaults to DB_USER",
               args: {
@@ -2631,7 +2631,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description:
                 "Password to pass to mysqlcheck. Defaults to DB_PASSWORD",
               args: {
@@ -2658,7 +2658,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dbuser",
-              insertValue: "--dbuser=",
+              insertValue: "--dbuser={cursor}",
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: {
                 name: "value",
@@ -2667,7 +2667,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--dbpass",
-              insertValue: "--dbpass=",
+              insertValue: "--dbpass={cursor}",
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: {
                 name: "value",
@@ -2713,7 +2713,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--before_context",
-              insertValue: "--before_context=",
+              insertValue: "--before_context={cursor}",
               description: "Number of characters to display before the match",
               args: {
                 name: "num",
@@ -2722,7 +2722,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--after_context",
-              insertValue: "--after_context=",
+              insertValue: "--after_context={cursor}",
               description: "Number of characters to display after the match",
               args: {
                 name: "num",
@@ -2736,14 +2736,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--regex-flags",
-              insertValue: "--regex-flags=",
+              insertValue: "--regex-flags={cursor}",
               description:
                 "Pass PCRE modifiers to the regex search (e.g. ‘i’ for case-insensitivity)",
               args: { name: "regex-flags" },
             },
             {
               name: "--regex-delimiter",
-              insertValue: "--regex-delimiter=",
+              insertValue: "--regex-delimiter={cursor}",
               description:
                 "The delimiter to use for the regex. It must be escaped if it appears in the search string. The default value is the result of chr(1)",
               args: { name: "regex-delimiter" },
@@ -2770,21 +2770,21 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--table_column_color",
-              insertValue: "--table_column_color=",
+              insertValue: "--table_column_color={cursor}",
               description:
                 "Percent color code to use for the ‘table:column’ output. For a list of available percent color codes, see below. Default ‘%G’ (bright green)",
               args: { name: "table_column_color" },
             },
             {
               name: "--id_color",
-              insertValue: "--id_color=",
+              insertValue: "--id_color={cursor}",
               description:
                 "Percent color code to use for the row id output. For a list of available percent color codes, see below. Default ‘%Y’ (bright yellow)",
               args: { name: "id_color" },
             },
             {
               name: "--match_color",
-              insertValue: "--match_color=",
+              insertValue: "--match_color={cursor}",
               description:
                 "Percent color code to use for the match (unless both before and after context are 0, when no color code is used). For a list of available percent color codes, see below. Default ‘%3%k’ (black on a mustard background)",
               args: { name: "match_color" },
@@ -2797,7 +2797,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--size_format",
-              insertValue: "--size_format=",
+              insertValue: "--size_format={cursor}",
               description: "Display the database size only, as a bare number",
               args: {
                 name: "format",
@@ -2830,7 +2830,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -2844,7 +2844,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--scope",
-              insertValue: "--scope=",
+              insertValue: "--scope={cursor}",
               description:
                 "Can be all, global, ms_global, blog, or old tables. Defaults to all",
               args: { name: "scope" },
@@ -2876,7 +2876,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--scope",
-              insertValue: "--scope=",
+              insertValue: "--scope={cursor}",
               description:
                 "Can be all, global, ms_global, blog, or old tables. Defaults to all",
               args: { name: "scope" },
@@ -2897,7 +2897,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -2932,7 +2932,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--format",
-          insertValue: "--format=",
+          insertValue: "--format={cursor}",
           description: "Choose the format for the archive",
           args: {
             name: "options",
@@ -3007,14 +3007,14 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--width",
-                  insertValue: "--width=",
+                  insertValue: "--width={cursor}",
                   description:
                     "Width of the embed in pixels. Part of cache key so must match. Defaults to content_width if set else 500px, so is theme and context dependent",
                   args: { name: "width" },
                 },
                 {
                   name: "--height",
-                  insertValue: "--height=",
+                  insertValue: "--height={cursor}",
                   description:
                     "Height of the embed in pixels. Part of cache key so must match. Defaults to 1.5 * default width (content_width or 500px), to a maximum of 1000px",
                   args: { name: "height" },
@@ -3047,19 +3047,19 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--width",
-              insertValue: "--width=",
+              insertValue: "--width={cursor}",
               description: "Width of the embed in pixels",
               args: { name: "width" },
             },
             {
               name: "--height",
-              insertValue: "--height=",
+              insertValue: "--height={cursor}",
               description: "Height of the embed in pixels",
               args: { name: "height" },
             },
             {
               name: "--post-id",
-              insertValue: "--post-id=",
+              insertValue: "--post-id={cursor}",
               description: "Cache oEmbed response for a given post",
               args: { name: "id" },
             },
@@ -3084,7 +3084,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--limit-response-size",
-              insertValue: "--limit-response-size=",
+              insertValue: "--limit-response-size={cursor}",
               description:
                 "Limit the size of the resulting HTML when using discovery. Default 150 KB (the standard WordPress limit). Not compatible with ‘no-discover’",
               args: { name: "size" },
@@ -3096,7 +3096,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--raw-format",
-              insertValue: "--raw-format=",
+              insertValue: "--raw-format={cursor}",
               description: "The serialization format for the value",
               args: {
                 name: "json|xml",
@@ -3115,19 +3115,19 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -3152,19 +3152,19 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -3192,14 +3192,14 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--limit-response-size",
-                  insertValue: "--limit-response-size=",
+                  insertValue: "--limit-response-size={cursor}",
                   description:
                     "Limit the size of the resulting HTML when using discovery. Default 150 KB (the standard WordPress limit). Not compatible with ‘no-discover’",
                   args: { name: "size" },
                 },
                 {
                   name: "--link-type",
-                  insertValue: "--link-type=",
+                  insertValue: "--link-type={cursor}",
                   description:
                     "Whether to accept only a certain link type when using discovery. Defaults to any (json or xml), preferring json. Not compatible with ‘no-discover’",
                   args: {
@@ -3293,7 +3293,7 @@ const completionSpec: Fig.Spec = {
       options: [
         {
           name: "--dir",
-          insertValue: "--dir=",
+          insertValue: "--dir={cursor}",
           description:
             "Full path to directory where WXR export files should be stored. Defaults to current working directory",
           args: { name: "dirname", template: "folders" },
@@ -3309,7 +3309,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--max_file_size",
-          insertValue: "--max_file_size=",
+          insertValue: "--max_file_size={cursor}",
           description:
             "A single export file should have this many megabytes. -1 for unlimited",
           args: {
@@ -3319,21 +3319,21 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--start_date",
-          insertValue: "--start_date=",
+          insertValue: "--start_date={cursor}",
           description:
             "Export only posts published after this date, in format YYYY-MM-DD",
           args: { name: "date" },
         },
         {
           name: "--end_date",
-          insertValue: "--end_date=",
+          insertValue: "--end_date={cursor}",
           description:
             "Export only posts published before this date, in format YYYY-MM-DD",
           args: { name: "date" },
         },
         {
           name: "--post_type",
-          insertValue: "--post_type=",
+          insertValue: "--post_type={cursor}",
           description:
             "Export only posts with this post_type. Separate multiple post types with a comma",
           args: {
@@ -3343,14 +3343,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--post_type__not_in",
-          insertValue: "--post_type__not_in=",
+          insertValue: "--post_type__not_in={cursor}",
           description:
             "Export all post types except those identified. Separate multiple post types with a comma. Defaults to none",
           args: { name: "post-type" },
         },
         {
           name: "--post_in",
-          insertValue: "--post_in=",
+          insertValue: "--post_in={cursor}",
           description:
             "Export all posts specified as a comma- or space-separated list of IDs. Post’s attachments won’t be exported unless –with_attachments is specified",
           args: { name: "pid" },
@@ -3362,40 +3362,40 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--start_id",
-          insertValue: "--start_id=",
+          insertValue: "--start_id={cursor}",
           description:
             "Export only posts with IDs greater than or equal to this post ID",
           args: { name: "pid" },
         },
         {
           name: "--max_num_posts",
-          insertValue: "--max_num_posts=",
+          insertValue: "--max_num_posts={cursor}",
           description:
             "Export no more than <num> posts (excluding attachments)",
           args: { name: "num" },
         },
         {
           name: "--author",
-          insertValue: "--author=",
+          insertValue: "--author={cursor}",
           description:
             "Export only posts by this author. Can be either user login or user ID",
           args: { name: "author" },
         },
         {
           name: "--category",
-          insertValue: "--category=",
+          insertValue: "--category={cursor}",
           description: "Export only posts in this category",
           args: { name: "category" },
         },
         {
           name: "--post_status",
-          insertValue: "--post_status=",
+          insertValue: "--post_status={cursor}",
           description: "Export only posts with this status",
           args: { name: "status" },
         },
         {
           name: "--filename_format",
-          insertValue: "--filename_format=",
+          insertValue: "--filename_format={cursor}",
           description:
             "Use a custom format for export filenames. Defaults to ‘{site}.wordpress.{date}.{n}.xml’",
           args: { name: "format" },
@@ -3417,32 +3417,32 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--include_ignored_paths",
-          insertValue: "--include_ignored_paths=",
+          insertValue: "--include_ignored_paths={cursor}",
           description:
             "Include additional ignored paths as CSV (e.g. ‘/sys-backup/,/temp/’)",
           args: { name: "paths" },
         },
         {
           name: "--max_depth",
-          insertValue: "--max_depth=",
+          insertValue: "--max_depth={cursor}",
           description: "Only recurse to a specified depth, inclusive",
           args: { name: "max-depth" },
         },
         {
           name: "--fields",
-          insertValue: "--fields=",
+          insertValue: "--fields={cursor}",
           description: "Limit the output to specific row fields",
           args: { name: "fields" },
         },
         {
           name: "--field",
-          insertValue: "--field=",
+          insertValue: "--field={cursor}",
           description: "Output a specific field for each row",
           args: { name: "field" },
         },
         {
           name: "--format",
-          insertValue: "--format=",
+          insertValue: "--format={cursor}",
           description: "Render output in a particular format",
           args: {
             name: "options",
@@ -3594,14 +3594,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--slug",
-              insertValue: "--slug=",
+              insertValue: "--slug={cursor}",
               description:
                 "Plugin or theme slug. Defaults to the source directory’s basename",
               args: { name: "slug" },
             },
             {
               name: "--domain",
-              insertValue: "--domain=",
+              insertValue: "--domain={cursor}",
               description:
                 "Text domain to look for in the source code, unless the --ignore-domain option is used. By default, the “Text Domain” header of the plugin or theme is used. If none is provided, it falls back to the project slug",
               args: { name: "domain" },
@@ -3613,35 +3613,35 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--merge",
-              insertValue: "--merge=",
+              insertValue: "--merge={cursor}",
               description:
                 "Comma-separated list of POT files whose contents should be merged with the extracted strings. If left empty, defaults to the destination POT file. POT file headers will be ignored",
               args: { name: "paths" },
             },
             {
               name: "--subtract",
-              insertValue: "--subtract=",
+              insertValue: "--subtract={cursor}",
               description:
                 "Comma-separated list of POT files whose contents should act as some sort of blacklist for string extraction. Any string which is found on that blacklist will not be extracted. This can be useful when you want to create multiple POT files from the same source directory with slightly different content and no duplicate strings between them",
               args: { name: "paths" },
             },
             {
               name: "--include",
-              insertValue: "--include=",
+              insertValue: "--include={cursor}",
               description:
                 "Comma-separated list of files and paths that should be used for string extraction. If provided, only these files and folders will be taken into account for string extraction. For example, --include='src,my-file.php will ignore anything besides my-file.php and files in the src directory. Simple glob patterns can be used, i.e. --include=foo-*.php includes any PHP file with the foo- prefix. Leading and trailing slashes are ignored, i.e. /my/directory/ is the same as my/directory",
               args: { name: "paths" },
             },
             {
               name: "--exclude",
-              insertValue: "--exclude=",
+              insertValue: "--exclude={cursor}",
               description:
                 "Comma-separated list of files and paths that should be skipped for string extraction. For example, --exclude='.github,myfile.php would ignore any strings found within myfile.php or the .github folder. Simple glob patterns can be used, i.e. --exclude=foo-*.php excludes any PHP file with the foo- prefix. Leading and trailing slashes are ignored, i.e. /my/directory/ is the same as my/directory. The following files and folders are always excluded: node_modules, .git, .svn, .CVS, .hg, vendor, *.min.js",
               args: { name: "paths" },
             },
             {
               name: "--headers",
-              insertValue: "--headers=",
+              insertValue: "--headers={cursor}",
               description:
                 "Array in JSON format of custom headers which will be added to the POT file. Defaults to empty array",
               args: { name: "headers" },
@@ -3666,14 +3666,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--file-comment",
-              insertValue: "--file-comment=",
+              insertValue: "--file-comment={cursor}",
               description:
                 "String that should be added as a comment to the top of the resulting POT file. By default, a copyright comment is added for WordPress plugins and themes in the following manner: Copyright (C) 2018 Example Plugin Author. This file is distributed under the same license as the Example Plugin package. If a plugin or theme specifies a license in their main plugin file or stylesheet, the comment looks like this: Copyright (C) 2018 Example Plugin Author. This file is distributed under the GPLv2",
               args: { name: "file-comment" },
             },
             {
               name: "--package-name",
-              insertValue: "--package-name=",
+              insertValue: "--package-name={cursor}",
               description:
                 "Name to use for package name in the resulting POT file’s Project-Id-Version header. Overrides plugin or theme name, if applicable",
               args: { name: "name" },
@@ -3694,14 +3694,14 @@ const completionSpec: Fig.Spec = {
       options: [
         {
           name: "--authors",
-          insertValue: "--authors=",
+          insertValue: "--authors={cursor}",
           description:
             "How the author mapping should be handled. Options are ‘create’, ‘mapping.csv’, or ‘skip’. The first will create any non-existent users from the WXR file. The second will read author mapping associations from a CSV, or create a CSV for editing if the file path doesn’t exist. The CSV requires two columns, and a header row like “old_user_login,new_user_login”. The last option will skip any author mapping",
           args: { name: "authors" },
         },
         {
           name: "--skip",
-          insertValue: "--skip=",
+          insertValue: "--skip={cursor}",
           description:
             "Skip importing specific data. Supported options are: ‘attachment’ and ‘image_resize’ (skip time-consuming thumbnail generation)",
           args: { name: "data-type" },
@@ -3793,7 +3793,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
@@ -3804,13 +3804,13 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -3868,7 +3868,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description:
                     "Render output in a particular format. Used when installing languages for all plugins",
                   args: {
@@ -3913,7 +3913,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
@@ -3924,13 +3924,13 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4004,7 +4004,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description:
                     "Render output in a particular format. Used when installing languages for all themes",
                   args: {
@@ -4049,7 +4049,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
@@ -4060,13 +4060,13 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4213,14 +4213,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -4247,31 +4247,31 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--post_id",
-              insertValue: "--post_id=",
+              insertValue: "--post_id={cursor}",
               description: "ID of the post to attach the imported files to",
               args: { name: "post_id" },
             },
             {
               name: "--title",
-              insertValue: "--title=",
+              insertValue: "--title={cursor}",
               description: "Attachment title (post title field)",
               args: { name: "title" },
             },
             {
               name: "--caption",
-              insertValue: "--caption=",
+              insertValue: "--caption={cursor}",
               description: "Caption for attachent (post excerpt field)",
               args: { name: "caption" },
             },
             {
               name: "--alt",
-              insertValue: "--alt=",
+              insertValue: "--alt={cursor}",
               description: "Alt text for image (saved as post meta)",
               args: { name: "alt_text" },
             },
             {
               name: "--desc",
-              insertValue: "--desc=",
+              insertValue: "--desc={cursor}",
               description:
                 "'Description' field (post content) of attachment post",
               args: { name: "description" },
@@ -4307,7 +4307,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--image_size",
-              insertValue: "--image_size=",
+              insertValue: "--image_size={cursor}",
               description:
                 "Name of the image size to regenerate. Only thumbnails of this image size will be regenerated, thumbnails of other image sizes will not",
               args: { name: "image_size" },
@@ -4403,37 +4403,37 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--description",
-                  insertValue: "--description=",
+                  insertValue: "--description={cursor}",
                   description: "Set a custom description for the menu item",
                   args: { name: "description" },
                 },
                 {
                   name: "--attr-title",
-                  insertValue: "--attr-title=",
+                  insertValue: "--attr-title={cursor}",
                   description: "Set a custom title attribute for the menu item",
                   args: { name: "attr-title" },
                 },
                 {
                   name: "--target",
-                  insertValue: "--target=",
+                  insertValue: "--target={cursor}",
                   description: "Set a custom link target for the menu item",
                   args: { name: "target" },
                 },
                 {
                   name: "--classes",
-                  insertValue: "--classes=",
+                  insertValue: "--classes={cursor}",
                   description: "Set a custom link classes for the menu item",
                   args: { name: "classes" },
                 },
                 {
                   name: "--position",
-                  insertValue: "--position=",
+                  insertValue: "--position={cursor}",
                   description: "Specify the position of this menu item",
                   args: { name: "position" },
                 },
                 {
                   name: "--parent-id",
-                  insertValue: "--parent-id=",
+                  insertValue: "--parent-id={cursor}",
                   description:
                     "Make this menu item a child of another menu item",
                   args: { name: "parent-id" },
@@ -4460,49 +4460,49 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--title",
-                  insertValue: "--title=",
+                  insertValue: "--title={cursor}",
                   description: "Set a custom title for the menu item",
                   args: { name: "title" },
                 },
                 {
                   name: "--link",
-                  insertValue: "--link=",
+                  insertValue: "--link={cursor}",
                   description: "Set a custom url for the menu item",
                   args: { name: "link" },
                 },
                 {
                   name: "--description",
-                  insertValue: "--description=",
+                  insertValue: "--description={cursor}",
                   description: "Set a custom description for the menu item",
                   args: { name: "description" },
                 },
                 {
                   name: "--attr-title",
-                  insertValue: "--attr-title=",
+                  insertValue: "--attr-title={cursor}",
                   description: "Set a custom title attribute for the menu item",
                   args: { name: "attr-title" },
                 },
                 {
                   name: "--target",
-                  insertValue: "--target=",
+                  insertValue: "--target={cursor}",
                   description: "Set a custom link target for the menu item",
                   args: { name: "target" },
                 },
                 {
                   name: "--classes",
-                  insertValue: "--classes=",
+                  insertValue: "--classes={cursor}",
                   description: "Set a custom link classes for the menu item",
                   args: { name: "classes" },
                 },
                 {
                   name: "--position",
-                  insertValue: "--position=",
+                  insertValue: "--position={cursor}",
                   description: "Specify the position of this menu item",
                   args: { name: "position" },
                 },
                 {
                   name: "--parent-id",
-                  insertValue: "--parent-id=",
+                  insertValue: "--parent-id={cursor}",
                   description:
                     "Make this menu item a child of another menu item",
                   args: { name: "parent-id" },
@@ -4533,49 +4533,49 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--title",
-                  insertValue: "--title=",
+                  insertValue: "--title={cursor}",
                   description: "Set a custom title for the menu item",
                   args: { name: "title" },
                 },
                 {
                   name: "--link",
-                  insertValue: "--link=",
+                  insertValue: "--link={cursor}",
                   description: "Set a custom url for the menu item",
                   args: { name: "link" },
                 },
                 {
                   name: "--description",
-                  insertValue: "--description=",
+                  insertValue: "--description={cursor}",
                   description: "Set a custom description for the menu item",
                   args: { name: "description" },
                 },
                 {
                   name: "--attr-title",
-                  insertValue: "--attr-title=",
+                  insertValue: "--attr-title={cursor}",
                   description: "Set a custom title attribute for the menu item",
                   args: { name: "attr-title" },
                 },
                 {
                   name: "--target",
-                  insertValue: "--target=",
+                  insertValue: "--target={cursor}",
                   description: "Set a custom link target for the menu item",
                   args: { name: "target" },
                 },
                 {
                   name: "--classes",
-                  insertValue: "--classes=",
+                  insertValue: "--classes={cursor}",
                   description: "Set a custom link classes for the menu item",
                   args: { name: "classes" },
                 },
                 {
                   name: "--position",
-                  insertValue: "--position=",
+                  insertValue: "--position={cursor}",
                   description: "Specify the position of this menu item",
                   args: { name: "position" },
                 },
                 {
                   name: "--parent-id",
-                  insertValue: "--parent-id=",
+                  insertValue: "--parent-id={cursor}",
                   description:
                     "Make this menu item a child of another menu item",
                   args: { name: "parent-id" },
@@ -4604,13 +4604,13 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific object fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4636,49 +4636,49 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--title",
-                  insertValue: "--title=",
+                  insertValue: "--title={cursor}",
                   description: "Set a custom title for the menu item",
                   args: { name: "title" },
                 },
                 {
                   name: "--link",
-                  insertValue: "--link=",
+                  insertValue: "--link={cursor}",
                   description: "Set a custom url for the menu item",
                   args: { name: "link" },
                 },
                 {
                   name: "--description",
-                  insertValue: "--description=",
+                  insertValue: "--description={cursor}",
                   description: "Set a custom description for the menu item",
                   args: { name: "description" },
                 },
                 {
                   name: "--attr-title",
-                  insertValue: "--attr-title=",
+                  insertValue: "--attr-title={cursor}",
                   description: "Set a custom title attribute for the menu item",
                   args: { name: "attr-title" },
                 },
                 {
                   name: "--target",
-                  insertValue: "--target=",
+                  insertValue: "--target={cursor}",
                   description: "Set a custom link target for the menu item",
                   args: { name: "target" },
                 },
                 {
                   name: "--classes",
-                  insertValue: "--classes=",
+                  insertValue: "--classes={cursor}",
                   description: "Set a custom link classes for the menu item",
                   args: { name: "classes" },
                 },
                 {
                   name: "--position",
-                  insertValue: "--position=",
+                  insertValue: "--position={cursor}",
                   description: "Specify the position of this menu item",
                   args: { name: "position" },
                 },
                 {
                   name: "--parent-id",
-                  insertValue: "--parent-id=",
+                  insertValue: "--parent-id={cursor}",
                   description:
                     "Make this menu item a child of another menu item",
                   args: { name: "parent-id" },
@@ -4693,13 +4693,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -4739,7 +4739,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4824,7 +4824,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -4874,7 +4874,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -4897,20 +4897,20 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--keys",
-                  insertValue: "--keys=",
+                  insertValue: "--keys={cursor}",
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4925,7 +4925,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--orderby",
-                  insertValue: "--orderby=",
+                  insertValue: "--orderby={cursor}",
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -4938,7 +4938,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--order",
-                  insertValue: "--order=",
+                  insertValue: "--order={cursor}",
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -4986,7 +4986,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -5016,7 +5016,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -5050,7 +5050,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -5106,7 +5106,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "The serialization format for the value",
               args: {
                 name: "format",
@@ -5115,7 +5115,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--autoload",
-              insertValue: "--autoload=",
+              insertValue: "--autoload={cursor}",
               description: "Should this option be automatically loaded",
               args: {
                 name: "autoload",
@@ -5142,7 +5142,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Get value in a particular format",
               args: {
                 name: "format",
@@ -5161,20 +5161,20 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--search",
-              insertValue: "--search=",
+              insertValue: "--search={cursor}",
               description: "Use wildcards ( * and ? ) to match option name",
               args: { name: "search" },
             },
             {
               name: "--exclude",
-              insertValue: "--exclude=",
+              insertValue: "--exclude={cursor}",
               description:
                 "Pattern to exclude. Use wildcards ( * and ? ) to match option name",
               args: { name: "exclude" },
             },
             {
               name: "--autoload",
-              insertValue: "--autoload=",
+              insertValue: "--autoload={cursor}",
               description:
                 "Match only autoload options when value is on, and only not-autoload option when off",
               args: { name: "autoload" },
@@ -5195,19 +5195,19 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description:
                 "The serialization format for the value. total_bytes displays the total size of matching options in bytes",
               args: {
@@ -5224,7 +5224,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--orderby",
-              insertValue: "--orderby=",
+              insertValue: "--orderby={cursor}",
               description: "Set orderby which field",
               args: {
                 name: "fields",
@@ -5237,7 +5237,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--order",
-              insertValue: "--order=",
+              insertValue: "--order={cursor}",
               description: "Set ascending or descending order",
               args: {
                 name: "order",
@@ -5277,7 +5277,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "The serialization format for the value",
               args: {
                 name: "format",
@@ -5303,7 +5303,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "The output format for the value",
               args: {
                 name: "format",
@@ -5333,7 +5333,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--autoload",
-              insertValue: "--autoload=",
+              insertValue: "--autoload={cursor}",
               description:
                 "Requires WP 4.2. Should this option be automatically loaded",
               args: {
@@ -5343,7 +5343,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "The serialization format for the value",
               args: {
                 name: "format",
@@ -5385,14 +5385,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5429,14 +5429,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5591,7 +5591,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Only show the provided field",
                   args: { name: "field" },
                 },
@@ -5647,21 +5647,21 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Instead of returning the whole plugin, returns the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5686,7 +5686,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--version",
-              insertValue: "--version=",
+              insertValue: "--version={cursor}",
               description:
                 "If set, get that particular version from wordpress.org, instead of the stable version",
               args: { name: "version" },
@@ -5746,19 +5746,19 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each plugin",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5773,7 +5773,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--status",
-              insertValue: "--status=",
+              insertValue: "--status={cursor}",
               description: "Filter the output by plugin status",
               args: {
                 name: "status",
@@ -5814,7 +5814,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--page",
-              insertValue: "--page=",
+              insertValue: "--page={cursor}",
               description: "Optional page to display",
               args: {
                 name: "page",
@@ -5823,7 +5823,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--per-page",
-              insertValue: "--per-page=",
+              insertValue: "--per-page={cursor}",
               description: "Optional number of results to display",
               args: {
                 name: "per-page",
@@ -5832,13 +5832,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each plugin",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Ask for specific fields from the API. Defaults to name,slug,author_profile,rating. Acceptable values:",
               args: {
@@ -5876,7 +5876,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5954,7 +5954,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--exclude",
-              insertValue: "--exclude=",
+              insertValue: "--exclude={cursor}",
               description:
                 "Comma separated list of plugin names that should be excluded from updating",
               args: { name: "name" },
@@ -5971,7 +5971,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5985,7 +5985,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--version",
-              insertValue: "--version=",
+              insertValue: "--version={cursor}",
               description:
                 "If set, the plugin will be updated to the specified version",
             },
@@ -6021,7 +6021,7 @@ const completionSpec: Fig.Spec = {
 
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -6079,63 +6079,63 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--post_author",
-              insertValue: "--post_author=",
+              insertValue: "--post_author={cursor}",
               description:
                 "The ID of the user who added the post. Default is the current user ID",
               args: { name: "post_author" },
             },
             {
               name: "--post_date",
-              insertValue: "--post_date=",
+              insertValue: "--post_date={cursor}",
               description: "The date of the post. Default is the current time",
               args: { name: "post_date" },
             },
             {
               name: "--post_date_gmt",
-              insertValue: "--post_date_gmt=",
+              insertValue: "--post_date_gmt={cursor}",
               description:
                 "The date of the post in the GMT timezone. Default is the value of $post_date",
               args: { name: "post_date_gmt" },
             },
             {
               name: "--post_content",
-              insertValue: "--post_content=",
+              insertValue: "--post_content={cursor}",
               description: "The post content. Default empty",
               args: { name: "post_content" },
             },
             {
               name: "--post_content_filtered",
-              insertValue: "--post_content_filtered=",
+              insertValue: "--post_content_filtered={cursor}",
               description: "The filtered post content. Default empty",
               args: { name: "post_content_filtered" },
             },
             {
               name: "--post_title",
-              insertValue: "--post_title=",
+              insertValue: "--post_title={cursor}",
               description: "The post title. Default empty",
               args: { name: "post_title" },
             },
             {
               name: "--post_excerpt",
-              insertValue: "--post_excerpt=",
+              insertValue: "--post_excerpt={cursor}",
               description: "The post excerpt. Default empty",
               args: { name: "post_excerpt" },
             },
             {
               name: "--post_status",
-              insertValue: "--post_status=",
+              insertValue: "--post_status={cursor}",
               description: "The post status. Default ‘draft’",
               args: { name: "post_status" },
             },
             {
               name: "--post_type",
-              insertValue: "--post_type=",
+              insertValue: "--post_type={cursor}",
               description: "The post type. Default ‘post’",
               args: { name: "post_type" },
             },
             {
               name: "--comment_status",
-              insertValue: "--comment_status=",
+              insertValue: "--comment_status={cursor}",
               description:
                 "Whether the post can accept comments. Accepts ‘open’ or ‘closed’. Default is the value of ‘default_comment_status’ option",
               args: {
@@ -6145,7 +6145,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--ping_status",
-              insertValue: "--ping_status=",
+              insertValue: "--ping_status={cursor}",
               description:
                 "Whether the post can accept pings. Accepts ‘open’ or ‘closed’. Default is the value of ‘default_ping_status’ option",
               args: {
@@ -6155,54 +6155,54 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--post_password",
-              insertValue: "--post_password=",
+              insertValue: "--post_password={cursor}",
               description: "The password to access the post. Default empty",
               args: { name: "post_password" },
             },
             {
               name: "--post_name",
-              insertValue: "--post_name=",
+              insertValue: "--post_name={cursor}",
               description:
                 "The post name. Default is the sanitized post title when creating a new post",
               args: { name: "post_name" },
             },
             {
               name: "--from-post",
-              insertValue: "--from-post=",
+              insertValue: "--from-post={cursor}",
               description: "Post id of a post to be duplicated",
               args: { name: "post_id" },
             },
             {
               name: "--to_ping",
-              insertValue: "--to_ping=",
+              insertValue: "--to_ping={cursor}",
               description:
                 "Space or carriage return-separated list of URLs to ping. Default empty",
               args: { name: "to_ping" },
             },
             {
               name: "--pinged",
-              insertValue: "--pinged=",
+              insertValue: "--pinged={cursor}",
               description:
                 "Space or carriage return-separated list of URLs that have been pinged. Default empty",
               args: { name: "pinged" },
             },
             {
               name: "--post_modified",
-              insertValue: "--post_modified=",
+              insertValue: "--post_modified={cursor}",
               description:
                 "The date when the post was last modified. Default is the current time",
               args: { name: "post_modified" },
             },
             {
               name: "--post_modified_gmt",
-              insertValue: "--post_modified_gmt=",
+              insertValue: "--post_modified_gmt={cursor}",
               description:
                 "The date when the post was last modified in the GMT timezone. Default is the current time",
               args: { name: "post_modified_gmt" },
             },
             {
               name: "--post_parent",
-              insertValue: "--post_parent=",
+              insertValue: "--post_parent={cursor}",
               description:
                 "Set this for the post it belongs to, if any. Default 0",
               args: {
@@ -6212,7 +6212,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--menu_order",
-              insertValue: "--menu_order=",
+              insertValue: "--menu_order={cursor}",
               description:
                 "The order the post should be displayed in. Default 0",
               args: {
@@ -6222,40 +6222,40 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--post_mime_type",
-              insertValue: "--post_mime_type=",
+              insertValue: "--post_mime_type={cursor}",
               description: "The mime type of the post. Default empty",
               args: { name: "post_mime_type" },
             },
             {
               name: "--guid",
-              insertValue: "--guid=",
+              insertValue: "--guid={cursor}",
               description:
                 "Global Unique ID for referencing the post. Default empty",
               args: { name: "guid" },
             },
             {
               name: "--post_category",
-              insertValue: "--post_category=",
+              insertValue: "--post_category={cursor}",
               description:
                 "Array of category names, slugs, or IDs. Defaults to value of the ‘default_category’ option",
               args: { name: "post_category" },
             },
             {
               name: "--tags_input",
-              insertValue: "--tags_input=",
+              insertValue: "--tags_input={cursor}",
               description: "Array of tag names, slugs, or IDs. Default empty",
               args: { name: "tags_input" },
             },
             {
               name: "--tax_input",
-              insertValue: "--tax_input=",
+              insertValue: "--tax_input={cursor}",
               description:
                 "Array of taxonomy terms keyed by their taxonomy name. Default empty",
               args: { name: "tax_input" },
             },
             {
               name: "--meta_input",
-              insertValue: "--meta_input=",
+              insertValue: "--meta_input={cursor}",
               description:
                 "Array in JSON format of post meta values keyed by their post meta key. Default empty",
               args: { name: "meta_input" },
@@ -6318,7 +6318,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--count",
-              insertValue: "--count=",
+              insertValue: "--count={cursor}",
               description: "How many posts to generate?",
               args: {
                 name: "number",
@@ -6327,7 +6327,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--post_type",
-              insertValue: "--post_type=",
+              insertValue: "--post_type={cursor}",
               description: "The type of the generated posts",
               args: {
                 name: "type",
@@ -6336,7 +6336,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--post_status",
-              insertValue: "--post_status=",
+              insertValue: "--post_status={cursor}",
               description: "The status of the generated posts",
               args: {
                 name: "status",
@@ -6345,26 +6345,26 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--post_title",
-              insertValue: "--post_title=",
+              insertValue: "--post_title={cursor}",
               description: "The post title",
               args: { name: "post_title" },
             },
             {
               name: "--post_author",
-              insertValue: "--post_author=",
+              insertValue: "--post_author={cursor}",
               description: "The author of the generated posts",
               args: { name: "login" },
             },
             {
               name: "--post_date",
-              insertValue: "--post_date=",
+              insertValue: "--post_date={cursor}",
               description:
                 "The date of the generated posts. Default: current date",
               args: { name: "yyyy-mm-dd-hh-ii-ss" },
             },
             {
               name: "--post_date_gmt",
-              insertValue: "--post_date_gmt=",
+              insertValue: "--post_date_gmt={cursor}",
               description:
                 "The GMT date of the generated posts. Default: value of post_date (or current date if it’s not set)",
               args: { name: "yyyy-mm-dd-hh-ii-ss" },
@@ -6376,7 +6376,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--max_depth",
-              insertValue: "--max_depth=",
+              insertValue: "--max_depth={cursor}",
               description:
                 "For hierarchical post types, generate child posts down to a certain depth",
               args: {
@@ -6386,7 +6386,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -6405,21 +6405,21 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Instead of returning the whole post, returns the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -6444,7 +6444,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each post",
               args: {
                 name: "fields",
@@ -6479,7 +6479,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific object fields",
               args: {
                 name: "fields",
@@ -6514,7 +6514,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -6555,7 +6555,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -6605,7 +6605,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -6628,20 +6628,20 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--keys",
-                  insertValue: "--keys=",
+                  insertValue: "--keys={cursor}",
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -6656,7 +6656,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--orderby",
-                  insertValue: "--orderby=",
+                  insertValue: "--orderby={cursor}",
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -6669,7 +6669,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--order",
-                  insertValue: "--order=",
+                  insertValue: "--order={cursor}",
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -6717,7 +6717,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -6747,7 +6747,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -6781,7 +6781,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -6816,7 +6816,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--by",
-                  insertValue: "--by=",
+                  insertValue: "--by={cursor}",
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -6842,7 +6842,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description:
                     "Prints the value of a single field for each term",
                   args: {
@@ -6862,7 +6862,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific row fields",
                   args: {
                     name: "fields",
@@ -6881,7 +6881,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -6918,7 +6918,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--by",
-                  insertValue: "--by=",
+                  insertValue: "--by={cursor}",
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -6952,7 +6952,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--by",
-                  insertValue: "--by=",
+                  insertValue: "--by={cursor}",
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -6980,63 +6980,63 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--post_author",
-              insertValue: "--post_author=",
+              insertValue: "--post_author={cursor}",
               description:
                 "The ID of the user who added the post. Default is the current user ID",
               args: { name: "post_author" },
             },
             {
               name: "--post_date",
-              insertValue: "--post_date=",
+              insertValue: "--post_date={cursor}",
               description: "The date of the post. Default is the current time",
               args: { name: "post_date" },
             },
             {
               name: "--post_date_gmt",
-              insertValue: "--post_date_gmt=",
+              insertValue: "--post_date_gmt={cursor}",
               description:
                 "The date of the post in the GMT timezone. Default is the value of $post_date",
               args: { name: "post_date_gmt" },
             },
             {
               name: "--post_content",
-              insertValue: "--post_content=",
+              insertValue: "--post_content={cursor}",
               description: "The post content. Default empty",
               args: { name: "post_content" },
             },
             {
               name: "--post_content_filtered",
-              insertValue: "--post_content_filtered=",
+              insertValue: "--post_content_filtered={cursor}",
               description: "The filtered post content. Default empty",
               args: { name: "post_content_filtered" },
             },
             {
               name: "--post_title",
-              insertValue: "--post_title=",
+              insertValue: "--post_title={cursor}",
               description: "The post title. Default empty",
               args: { name: "post_title" },
             },
             {
               name: "--post_excerpt",
-              insertValue: "--post_excerpt=",
+              insertValue: "--post_excerpt={cursor}",
               description: "The post excerpt. Default empty",
               args: { name: "post_excerpt" },
             },
             {
               name: "--post_status",
-              insertValue: "--post_status=",
+              insertValue: "--post_status={cursor}",
               description: "The post status. Default ‘draft’",
               args: { name: "post_status" },
             },
             {
               name: "--post_type",
-              insertValue: "--post_type=",
+              insertValue: "--post_type={cursor}",
               description: "The post type. Default ‘post’",
               args: { name: "post_type" },
             },
             {
               name: "--comment_status",
-              insertValue: "--comment_status=",
+              insertValue: "--comment_status={cursor}",
               description:
                 "Whether the post can accept comments. Accepts ‘open’ or ‘closed’. Default is the value of ‘default_comment_status’ option",
               args: {
@@ -7046,7 +7046,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--ping_status",
-              insertValue: "--ping_status=",
+              insertValue: "--ping_status={cursor}",
               description:
                 "Whether the post can accept pings. Accepts ‘open’ or ‘closed’. Default is the value of ‘default_ping_status’ option",
               args: {
@@ -7056,48 +7056,48 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--post_password",
-              insertValue: "--post_password=",
+              insertValue: "--post_password={cursor}",
               description: "The password to access the post. Default empty",
               args: { name: "post_password" },
             },
             {
               name: "--post_name",
-              insertValue: "--post_name=",
+              insertValue: "--post_name={cursor}",
               description:
                 "The post name. Default is the sanitized post title when creating a new post",
               args: { name: "post_name" },
             },
             {
               name: "--to_ping",
-              insertValue: "--to_ping=",
+              insertValue: "--to_ping={cursor}",
               description:
                 "Space or carriage return-separated list of URLs to ping. Default empty",
               args: { name: "to_ping" },
             },
             {
               name: "--pinged",
-              insertValue: "--pinged=",
+              insertValue: "--pinged={cursor}",
               description:
                 "Space or carriage return-separated list of URLs that have been pinged. Default empty",
               args: { name: "pinged" },
             },
             {
               name: "--post_modified",
-              insertValue: "--post_modified=",
+              insertValue: "--post_modified={cursor}",
               description:
                 "The date when the post was last modified. Default is the current time",
               args: { name: "post_modified" },
             },
             {
               name: "--post_modified_gmt",
-              insertValue: "--post_modified_gmt=",
+              insertValue: "--post_modified_gmt={cursor}",
               description:
                 "The date when the post was last modified in the GMT timezone. Default is the current time",
               args: { name: "post_modified_gmt" },
             },
             {
               name: "--post_parent",
-              insertValue: "--post_parent=",
+              insertValue: "--post_parent={cursor}",
               description:
                 "Set this for the post it belongs to, if any. Default 0",
               args: {
@@ -7107,7 +7107,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--menu_order",
-              insertValue: "--menu_order=",
+              insertValue: "--menu_order={cursor}",
               description:
                 "The order the post should be displayed in. Default 0",
               args: {
@@ -7117,47 +7117,47 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--post_mime_type",
-              insertValue: "--post_mime_type=",
+              insertValue: "--post_mime_type={cursor}",
               description: "The mime type of the post. Default empty",
               args: { name: "post_mime_type" },
             },
             {
               name: "--guid",
-              insertValue: "--guid=",
+              insertValue: "--guid={cursor}",
               description:
                 "Global Unique ID for referencing the post. Default empty",
               args: { name: "guid" },
             },
             {
               name: "--post_category",
-              insertValue: "--post_category=",
+              insertValue: "--post_category={cursor}",
               description:
                 "Array of category names, slugs, or IDs. Defaults to value of the ‘default_category’ option",
               args: { name: "post_category" },
             },
             {
               name: "--tags_input",
-              insertValue: "--tags_input=",
+              insertValue: "--tags_input={cursor}",
               description: "Array of tag names, slugs, or IDs. Default empty",
               args: { name: "tags_input" },
             },
             {
               name: "--tax_input",
-              insertValue: "--tax_input=",
+              insertValue: "--tax_input={cursor}",
               description:
                 "Array of taxonomy terms keyed by their taxonomy name. Default empty",
               args: { name: "tax_input" },
             },
             {
               name: "--meta_input",
-              insertValue: "--meta_input=",
+              insertValue: "--meta_input={cursor}",
               description:
                 "Array in JSON format of post meta values keyed by their post meta key. Default empty",
               args: { name: "meta_input" },
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "One or more fields to update. See wp_insert_post()",
             },
             {
@@ -7204,21 +7204,21 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Instead of returning the whole taxonomy, returns the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7244,20 +7244,20 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Prints the value of a single field for each post type",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific post type fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7309,20 +7309,20 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--hook",
-              insertValue: "--hook=",
+              insertValue: "--hook={cursor}",
               description:
                 "Focus on key metrics for all hooks, or callbacks on a specific hook",
               args: { name: "hook" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Display one or more fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7336,7 +7336,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--order",
-              insertValue: "--order=",
+              insertValue: "--order={cursor}",
               description: "Ascending or descending order",
               args: {
                 name: "order",
@@ -7345,7 +7345,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--orderby",
-              insertValue: "--orderby=",
+              insertValue: "--orderby={cursor}",
               description: "Order by fields",
               args: { name: "orderby" },
             },
@@ -7362,20 +7362,20 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--hook",
-              insertValue: "--hook=",
+              insertValue: "--hook={cursor}",
               description:
                 "Focus on key metrics for all hooks, or callbacks on a specific hook",
               args: { name: "hook" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Display one or more fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7389,7 +7389,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--order",
-              insertValue: "--order=",
+              insertValue: "--order={cursor}",
               description: "Ascending or descending order",
               args: {
                 name: "order",
@@ -7398,7 +7398,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--orderby",
-              insertValue: "--orderby=",
+              insertValue: "--orderby={cursor}",
               description: "Order by fields",
               args: { name: "orderby" },
             },
@@ -7424,20 +7424,20 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--url",
-              insertValue: "--url=",
+              insertValue: "--url={cursor}",
               description:
                 "Execute a request against a specified URL. Defaults to the home URL",
               args: { name: "url" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Display one or more fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7451,7 +7451,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--order",
-              insertValue: "--order=",
+              insertValue: "--order={cursor}",
               description: "Ascending or descending order",
               args: {
                 name: "order",
@@ -7460,7 +7460,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--orderby",
-              insertValue: "--orderby=",
+              insertValue: "--orderby={cursor}",
               description: "Order by fields",
               args: { name: "orderby" },
             },
@@ -7485,21 +7485,21 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--url",
-              insertValue: "--url=",
+              insertValue: "--url={cursor}",
               description:
                 "Execute a request against a specified URL. Defaults to the home URL",
               args: { name: "url" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Default is all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7513,7 +7513,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--order",
-              insertValue: "--order=",
+              insertValue: "--order={cursor}",
               description: "Ascending or descending order",
               args: {
                 name: "order",
@@ -7522,7 +7522,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--orderby",
-              insertValue: "--orderby=",
+              insertValue: "--orderby={cursor}",
               description: "Order by fields",
               args: { name: "orderby" },
             },
@@ -7573,26 +7573,26 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--match",
-              insertValue: "--match=",
+              insertValue: "--match={cursor}",
               description: "Show rewrite rules matching a particular URL",
               args: { name: "url" },
             },
             {
               name: "--source",
-              insertValue: "--source=",
+              insertValue: "--source={cursor}",
               description: "Show rewrite rules from a particular source",
               args: { name: "source" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to match,query,source",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7617,14 +7617,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--category-base",
-              insertValue: "--category-base=",
+              insertValue: "--category-base={cursor}",
               description:
                 "Set the base for category permalinks, i.e. ‘/category/’",
               args: { name: "base" },
             },
             {
               name: "--tag-base",
-              insertValue: "--tag-base=",
+              insertValue: "--tag-base={cursor}",
               description: "Set the base for tag permalinks, i.e. ‘/tag/’",
               args: { name: "base" },
             },
@@ -7679,7 +7679,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--clone",
-              insertValue: "--clone=",
+              insertValue: "--clone={cursor}",
               description: "Clone capabilities from an existing role",
               args: { name: "role" },
             },
@@ -7707,19 +7707,19 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific row fields",
               args: { name: "fields" },
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7787,20 +7787,20 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--title",
-              insertValue: "--title=",
+              insertValue: "--title={cursor}",
               description: "The display title for your block",
               args: { name: "title" },
             },
             {
               name: "--dashicon",
-              insertValue: "--dashicon=",
+              insertValue: "--dashicon={cursor}",
               description:
                 "The dashicon to make it easier to identify your block",
               args: { name: "dashicon" },
             },
             {
               name: "--category",
-              insertValue: "--category=",
+              insertValue: "--category={cursor}",
               description:
                 "The category name to help users browse and discover your block",
               args: {
@@ -7821,7 +7821,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--plugin",
-              insertValue: "--plugin=",
+              insertValue: "--plugin={cursor}",
               description: "Create files in the given plugin’s directory",
               args: { name: "plugin" },
             },
@@ -7841,34 +7841,34 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--parent_theme",
-              insertValue: "--parent_theme=",
+              insertValue: "--parent_theme={cursor}",
               description:
                 "What to put in the ‘Template:’ header in ‘style.css’",
               args: { name: "slug" },
             },
             {
               name: "--theme_name",
-              insertValue: "--theme_name=",
+              insertValue: "--theme_name={cursor}",
               description:
                 "What to put in the ‘Theme Name:’ header in ‘style.css’",
               args: { name: "title" },
             },
             {
               name: "--author",
-              insertValue: "--author=",
+              insertValue: "--author={cursor}",
               description: "What to put in the ‘Author:’ header in ‘style.css’",
               args: { name: "full-name" },
             },
             {
               name: "--author_uri",
-              insertValue: "--author_uri=",
+              insertValue: "--author_uri={cursor}",
               description:
                 "What to put in the ‘Author URI:’ header in ‘style.css’",
               args: { name: "uri" },
             },
             {
               name: "--theme_uri",
-              insertValue: "--theme_uri=",
+              insertValue: "--theme_uri={cursor}",
               description:
                 "What to put in the ‘Theme URI:’ header in ‘style.css’",
               args: { name: "uri" },
@@ -7898,38 +7898,38 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dir",
-              insertValue: "--dir=",
+              insertValue: "--dir={cursor}",
               description:
                 "Put the new plugin in some arbitrary directory path. Plugin directory will be path plus supplied slug",
               args: { name: "dirname", template: "folders" },
             },
             {
               name: "--plugin_name",
-              insertValue: "--plugin_name=",
+              insertValue: "--plugin_name={cursor}",
               description: "What to put in the ‘Plugin Name:’ header",
               args: { name: "title" },
             },
             {
               name: "--plugin_description",
-              insertValue: "--plugin_description=",
+              insertValue: "--plugin_description={cursor}",
               description: "What to put in the ‘Description:’ header",
               args: { name: "description" },
             },
             {
               name: "--plugin_author",
-              insertValue: "--plugin_author=",
+              insertValue: "--plugin_author={cursor}",
               description: "What to put in the ‘Author:’ header",
               args: { name: "author" },
             },
             {
               name: "--plugin_author_uri",
-              insertValue: "--plugin_author_uri=",
+              insertValue: "--plugin_author_uri={cursor}",
               description: "What to put in the ‘Author URI:’ header",
               args: { name: "uri" },
             },
             {
               name: "--plugin_uri",
-              insertValue: "--plugin_uri=",
+              insertValue: "--plugin_uri={cursor}",
               description: "What to put in the ‘Plugin URI:’ header",
               args: { name: "uri" },
             },
@@ -7939,7 +7939,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--ci",
-              insertValue: "--ci=",
+              insertValue: "--ci={cursor}",
               description:
                 "Choose a configuration file for a continuous integration provider",
               args: {
@@ -7976,14 +7976,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dir",
-              insertValue: "--dir=",
+              insertValue: "--dir={cursor}",
               description:
                 "Generate test files for a non-standard plugin path. If no plugin slug is specified, the directory name is used",
               args: { name: "dirname", template: "folders" },
             },
             {
               name: "--ci",
-              insertValue: "--ci=",
+              insertValue: "--ci={cursor}",
               description:
                 "Choose a configuration file for a continuous integration provider",
               args: {
@@ -8012,19 +8012,19 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--label",
-              insertValue: "--label=",
+              insertValue: "--label={cursor}",
               description: "The text used to translate the update messages",
               args: { name: "label" },
             },
             {
               name: "--textdomain",
-              insertValue: "--textdomain=",
+              insertValue: "--textdomain={cursor}",
               description: "The textdomain to use for the labels",
               args: { name: "textdomain" },
             },
             {
               name: "--dashicon",
-              insertValue: "--dashicon=",
+              insertValue: "--dashicon={cursor}",
               description: "The dashicon to use in the menu",
               args: { name: "dashicon" },
             },
@@ -8035,7 +8035,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--plugin",
-              insertValue: "--plugin=",
+              insertValue: "--plugin={cursor}",
               description:
                 "Create a file in the given plugin’s directory, instead of sending to STDOUT",
               args: { name: "plugin" },
@@ -8061,19 +8061,19 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--post_types",
-              insertValue: "--post_types=",
+              insertValue: "--post_types={cursor}",
               description: "Post types to register for use with the taxonomy",
               args: { name: "post_types" },
             },
             {
               name: "--label",
-              insertValue: "--label=",
+              insertValue: "--label={cursor}",
               description: "The text used to translate the update messages",
               args: { name: "label" },
             },
             {
               name: "--textdomain",
-              insertValue: "--textdomain=",
+              insertValue: "--textdomain={cursor}",
               description: "The textdomain to use for the labels",
               args: { name: "textdomain" },
             },
@@ -8084,7 +8084,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--plugin",
-              insertValue: "--plugin=",
+              insertValue: "--plugin={cursor}",
               description:
                 "Create a file in the given plugin’s directory, instead of sending to STDOUT",
               args: { name: "plugin" },
@@ -8111,14 +8111,14 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--dir",
-              insertValue: "--dir=",
+              insertValue: "--dir={cursor}",
               description:
                 "Generate test files for a non-standard theme path. If no theme slug is specified, the directory name is used",
               args: { name: "dirname", template: "folders" },
             },
             {
               name: "--ci",
-              insertValue: "--ci=",
+              insertValue: "--ci={cursor}",
               description:
                 "Choose a configuration file for a continuous integration provider",
               args: {
@@ -8157,20 +8157,20 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--theme_name",
-              insertValue: "--theme_name=",
+              insertValue: "--theme_name={cursor}",
               description:
                 "What to put in the ‘Theme Name:’ header in ‘style.css’",
               args: { name: "title" },
             },
             {
               name: "--author",
-              insertValue: "--author=",
+              insertValue: "--author={cursor}",
               description: "What to put in the ‘Author:’ header in ‘style.css’",
               args: { name: "full-name" },
             },
             {
               name: "--author_uri",
-              insertValue: "--author_uri=",
+              insertValue: "--author_uri={cursor}",
               description:
                 "What to put in the ‘Author URI:’ header in ‘style.css’",
               args: { name: "uri" },
@@ -8209,20 +8209,20 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--theme_name",
-              insertValue: "--theme_name=",
+              insertValue: "--theme_name={cursor}",
               description:
                 "What to put in the ‘Theme Name:’ header in ‘style.css’",
               args: { name: "title" },
             },
             {
               name: "--author",
-              insertValue: "--author=",
+              insertValue: "--author={cursor}",
               description: "What to put in the ‘Author:’ header in ‘style.css’",
               args: { name: "full-name" },
             },
             {
               name: "--author_uri",
-              insertValue: "--author_uri=",
+              insertValue: "--author_uri={cursor}",
               description:
                 "What to put in the ‘Author URI:’ header in ‘style.css’",
               args: { name: "uri" },
@@ -8285,14 +8285,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--export",
-          insertValue: "--export=",
+          insertValue: "--export={cursor}",
           description:
             "Write transformed data as SQL file instead of saving replacements to the database. If <file> is not supplied, will output to STDOUT",
           args: { name: "file" },
         },
         {
           name: "--export_insert_size",
-          insertValue: "--export_insert_size=",
+          insertValue: "--export_insert_size={cursor}",
           description:
             "Define number of rows in single INSERT statement when doing SQL export. You might want to change this depending on your database configuration (e.g. if you need to do fewer queries). Default: 50",
           args: {
@@ -8302,21 +8302,21 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--skip-tables",
-          insertValue: "--skip-tables=",
+          insertValue: "--skip-tables={cursor}",
           description:
             "Do not perform the replacement on specific tables. Use commas to specify multiple tables. Wildcards are supported, e.g. 'wp_*options' or 'wp_post*'",
           args: { name: "tables" },
         },
         {
           name: "--skip-columns",
-          insertValue: "--skip-columns=",
+          insertValue: "--skip-columns={cursor}",
           description:
             "Do not perform the replacement on specific columns. Use commas to specify multiple columns",
           args: { name: "columns" },
         },
         {
           name: "--include-columns",
-          insertValue: "--include-columns=",
+          insertValue: "--include-columns={cursor}",
           description:
             "Perform the replacement on specific columns. Use commas to specify multiple columns",
           args: { name: "columns" },
@@ -8347,28 +8347,28 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--regex-flags",
-          insertValue: "--regex-flags=",
+          insertValue: "--regex-flags={cursor}",
           description:
             "Pass PCRE modifiers to regex search-replace (e.g. ‘i’ for case-insensitivity)",
           args: { name: "regex-flags" },
         },
         {
           name: "--regex-delimiter",
-          insertValue: "--regex-delimiter=",
+          insertValue: "--regex-delimiter={cursor}",
           description:
             "The delimiter to use for the regex. It must be escaped if it appears in the search string. The default value is the result of chr(1)",
           args: { name: "regex-delimiter" },
         },
         {
           name: "--regex-limit",
-          insertValue: "--regex-limit=",
+          insertValue: "--regex-limit={cursor}",
           description:
             "The maximum possible replacements for the regex per row (or per unserialized data bit per row). Defaults to -1 (no limit)",
           args: { name: "regex-limit" },
         },
         {
           name: "--format",
-          insertValue: "--format=",
+          insertValue: "--format={cursor}",
           description: "Render output in a particular format",
           args: {
             name: "format",
@@ -8386,22 +8386,22 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--log",
-          displayName: "--log=",
-          insertValue: "--log=",
+          displayName: "--log={cursor}",
+          insertValue: "--log={cursor}",
           description:
             "Log the items changed. If <file> is not supplied or is “-“, will output to STDOUT. Warning: causes a significant slow down, similar or worse to enabling –precise or –regex",
           args: { name: "file", isOptional: true },
         },
         {
           name: "--before_context",
-          insertValue: "--before_context=",
+          insertValue: "--before_context={cursor}",
           description:
             "For logging, number of characters to display before the old match and the new replacement. Default 40. Ignored if not logging",
           args: { name: "num" },
         },
         {
           name: "--after_context",
-          insertValue: "--after_context=",
+          insertValue: "--after_context={cursor}",
           description:
             "For logging, number of characters to display after the old match and the new replacement. Default 40. Ignored if not logging",
           args: { name: "num" },
@@ -8434,7 +8434,7 @@ const completionSpec: Fig.Spec = {
       options: [
         {
           name: "--host",
-          insertValue: "--host=",
+          insertValue: "--host={cursor}",
           description: "The hostname to bind the server to",
           args: {
             name: "host",
@@ -8443,7 +8443,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--port",
-          insertValue: "--port=",
+          insertValue: "--port={cursor}",
           description: "The port number to bind the server to",
           args: {
             name: "port",
@@ -8452,14 +8452,14 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--docroot",
-          insertValue: "--docroot=",
+          insertValue: "--docroot={cursor}",
           description:
             "The path to use as the document root. If the path global parameter is set, the default value is it",
           args: { name: "path", template: "folders" },
         },
         {
           name: "--config",
-          insertValue: "--config=",
+          insertValue: "--config={cursor}",
           description: "Config the server with a specific .ini file",
           args: { name: "file" },
         },
@@ -8546,13 +8546,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific row fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -8618,27 +8618,27 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--slug",
-              insertValue: "--slug=",
+              insertValue: "--slug={cursor}",
               description:
                 "Path for the new site. Subdomain on subdomain installs, directory on subdirectory installs",
               args: { name: "slug" },
             },
             {
               name: "--title",
-              insertValue: "--title=",
+              insertValue: "--title={cursor}",
               description: "Title of the new site. Default: prettified slug",
               args: { name: "title" },
             },
             {
               name: "--email",
-              insertValue: "--email=",
+              insertValue: "--email={cursor}",
               description:
                 "Email for Admin user. User will be created if none exists. Assignment to Super Admin if not included",
               args: { name: "email" },
             },
             {
               name: "--network_id",
-              insertValue: "--network_id=",
+              insertValue: "--network_id={cursor}",
               description:
                 "Network to associate new site with. Defaults to current network (typically 1)",
               args: { name: "network-id" },
@@ -8673,7 +8673,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--slug",
-              insertValue: "--slug=",
+              insertValue: "--slug={cursor}",
               description:
                 "Path of the blog to be deleted. Subdomain on subdomain installs, directory on subdirectory installs",
               args: { name: "slug" },
@@ -8712,7 +8712,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--network",
-              insertValue: "--network=",
+              insertValue: "--network={cursor}",
               description: "The network to which the sites belong",
               args: { name: "id" },
             },
@@ -8723,26 +8723,26 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--site_in",
-              insertValue: "--site_in=",
+              insertValue: "--site_in={cursor}",
               description:
                 "Only list the sites with these blog_id values (comma-separated)",
               args: { name: "value" },
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each site",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Comma-separated list of fields to show",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -8791,7 +8791,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -8841,7 +8841,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -8864,13 +8864,13 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--keys",
-                  insertValue: "--keys=",
+                  insertValue: "--keys={cursor}",
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: {
@@ -8880,7 +8880,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -8895,7 +8895,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--orderby",
-                  insertValue: "--orderby=",
+                  insertValue: "--orderby={cursor}",
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -8908,7 +8908,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--order",
-                  insertValue: "--order=",
+                  insertValue: "--order={cursor}",
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -8956,7 +8956,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -8986,7 +8986,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -9020,7 +9020,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9053,7 +9053,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9080,7 +9080,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -9099,31 +9099,31 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--search",
-                  insertValue: "--search=",
+                  insertValue: "--search={cursor}",
                   description: "Use wildcards ( * and ? ) to match option name",
                   args: { name: "pattern" },
                 },
                 {
                   name: "--site_id",
-                  insertValue: "--site_id=",
+                  insertValue: "--site_id={cursor}",
                   description: "Limit options to those of a particular site id",
                   args: { name: "id" },
                 },
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Prints the value of a single field",
                   args: { name: "field" },
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific object fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description:
                     "The serialization format for the value. total_bytes displays the total size of matching options in bytes",
                   args: {
@@ -9171,7 +9171,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9197,7 +9197,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -9227,7 +9227,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9336,7 +9336,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9397,21 +9397,21 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Instead of returning the whole taxonomy, returns the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9437,20 +9437,20 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Prints the value of a single field for each taxonomy",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific taxonomy fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9509,20 +9509,20 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--slug",
-              insertValue: "--slug=",
+              insertValue: "--slug={cursor}",
               description:
                 "A unique slug for the new term. Defaults to sanitized version of name",
               args: { name: "slug" },
             },
             {
               name: "--description",
-              insertValue: "--description=",
+              insertValue: "--description={cursor}",
               description: "A description for the new term",
               args: { name: "description" },
             },
             {
               name: "--parent",
-              insertValue: "--parent=",
+              insertValue: "--parent={cursor}",
               description: "A parent for the new term",
               args: { name: "term-id" },
             },
@@ -9548,7 +9548,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--by",
-              insertValue: "--by=",
+              insertValue: "--by={cursor}",
               description: "Explicitly handle the term value as a slug or id",
               args: {
                 name: "field",
@@ -9567,7 +9567,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--count",
-              insertValue: "--count=",
+              insertValue: "--count={cursor}",
               description: "How many terms to generate?",
               args: {
                 name: "number",
@@ -9576,7 +9576,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--max_depth",
-              insertValue: "--max_depth=",
+              insertValue: "--max_depth={cursor}",
               description: "Generate child terms down to a certain depth",
               args: {
                 name: "number",
@@ -9585,7 +9585,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9610,7 +9610,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--by",
-              insertValue: "--by=",
+              insertValue: "--by={cursor}",
               description: "Explicitly handle the term value as a slug or id",
               args: {
                 name: "field",
@@ -9619,21 +9619,21 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Instead of returning the whole term, returns the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Get value in a particular format",
               args: {
                 name: "format",
@@ -9663,19 +9663,19 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each term",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9716,7 +9716,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9766,7 +9766,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -9789,13 +9789,13 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--keys",
-                  insertValue: "--keys=",
+                  insertValue: "--keys={cursor}",
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: {
@@ -9805,7 +9805,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -9820,7 +9820,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--orderby",
-                  insertValue: "--orderby=",
+                  insertValue: "--orderby={cursor}",
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -9833,7 +9833,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--order",
-                  insertValue: "--order=",
+                  insertValue: "--order={cursor}",
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -9881,7 +9881,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9911,7 +9911,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -9945,7 +9945,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9966,7 +9966,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--by",
-              insertValue: "--by=",
+              insertValue: "--by={cursor}",
               description: "Explicitly handle the term value as a slug or id",
               args: {
                 name: "field",
@@ -9975,13 +9975,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--from",
-              insertValue: "--from=",
+              insertValue: "--from={cursor}",
               description: "Taxonomy slug of the term to migrate",
               args: { name: "taxonomy" },
             },
             {
               name: "--to",
-              insertValue: "--to=",
+              insertValue: "--to={cursor}",
               description: "Taxonomy slug to migrate to",
               args: { name: "taxonomy" },
             },
@@ -10011,7 +10011,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--by",
-              insertValue: "--by=",
+              insertValue: "--by={cursor}",
               description: "Explicitly handle the term value as a slug or id",
               args: {
                 name: "field",
@@ -10020,25 +10020,25 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--name",
-              insertValue: "--name=",
+              insertValue: "--name={cursor}",
               description: "A new name for the term",
               args: { name: "name" },
             },
             {
               name: "--slug",
-              insertValue: "--slug=",
+              insertValue: "--slug={cursor}",
               description: "A new slug for the term",
               args: { name: "slug" },
             },
             {
               name: "--description",
-              insertValue: "--description=",
+              insertValue: "--description={cursor}",
               description: "A new description for the term",
               args: { name: "description" },
             },
             {
               name: "--parent",
-              insertValue: "--parent=",
+              insertValue: "--parent={cursor}",
               description: "A new parent for the term",
               args: { name: "term-id" },
             },
@@ -10150,7 +10150,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Only show the provided field",
                   args: { name: "field" },
                 },
@@ -10222,21 +10222,21 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Instead of returning the whole theme, returns the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10261,7 +10261,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--version",
-              insertValue: "--version=",
+              insertValue: "--version={cursor}",
               description:
                 "If set, get that particular version from wordpress.org, instead of the stable version",
               args: { name: "version" },
@@ -10310,19 +10310,19 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each theme",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10337,7 +10337,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--status",
-              insertValue: "--status=",
+              insertValue: "--status={cursor}",
               description: "Filter the output by theme status",
               args: {
                 name: "status",
@@ -10364,7 +10364,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Returns the value of a single field",
                 },
                 {
@@ -10373,7 +10373,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -10393,13 +10393,13 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description: "Returns the value of a single field",
                   args: { name: "field" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -10469,7 +10469,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--page",
-              insertValue: "--page=",
+              insertValue: "--page={cursor}",
               description: "Optional page to display",
               args: {
                 name: "page",
@@ -10478,7 +10478,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--per-page",
-              insertValue: "--per-page=",
+              insertValue: "--per-page={cursor}",
               description:
                 "Optional number of results to display. Defaults to 10",
               args: {
@@ -10488,13 +10488,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each theme",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description:
                 "Ask for specific fields from the API. Defaults to name,slug,author,rating",
               args: {
@@ -10538,7 +10538,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10576,14 +10576,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--exclude",
-              insertValue: "--exclude=",
+              insertValue: "--exclude={cursor}",
               description:
                 "Comma separated list of theme names that should be excluded from updating",
               args: { name: "theme-names" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10597,7 +10597,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--version",
-              insertValue: "--version=",
+              insertValue: "--version={cursor}",
               description:
                 "If set, the theme will be updated to the specified version",
               args: { name: "version" },
@@ -10674,7 +10674,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10699,13 +10699,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--search",
-              insertValue: "--search=",
+              insertValue: "--search={cursor}",
               description: "Use wildcards ( * and ? ) to match transient name",
               args: { name: "pattern" },
             },
             {
               name: "--exclude",
-              insertValue: "--exclude=",
+              insertValue: "--exclude={cursor}",
               description:
                 "Pattern to exclude. Use wildcards ( * and ? ) to match transient name",
               args: { name: "pattern" },
@@ -10725,13 +10725,13 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10870,7 +10870,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--role",
-              insertValue: "--role=",
+              insertValue: "--role={cursor}",
               description:
                 "The role of the user to create. Default: default role. Possible values include ‘administrator’, ‘editor’, ‘author’, ‘contributor’, ‘subscriber’",
               args: {
@@ -10886,65 +10886,65 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--user_pass",
-              insertValue: "--user_pass=",
+              insertValue: "--user_pass={cursor}",
               description: "The user password. Default: randomly generated",
               args: { name: "password" },
             },
             {
               name: "--user_registered",
-              insertValue: "--user_registered=",
+              insertValue: "--user_registered={cursor}",
               description:
                 "The date the user registered. Default: current date",
               args: { name: "yyyy-mm-dd-hh-ii-ss" },
             },
             {
               name: "--display_name",
-              insertValue: "--display_name=",
+              insertValue: "--display_name={cursor}",
               description: "The display name",
               args: { name: "name" },
             },
             {
               name: "--user_nicename",
-              insertValue: "--user_nicename=",
+              insertValue: "--user_nicename={cursor}",
               description:
                 "A string that contains a URL-friendly name for the user. The default is the user’s username",
               args: { name: "nice_name" },
             },
             {
               name: "--user_url",
-              insertValue: "--user_url=",
+              insertValue: "--user_url={cursor}",
               description:
                 "A string containing the user’s URL for the user’s web site",
               args: { name: "url" },
             },
             {
               name: "--nickname",
-              insertValue: "--nickname=",
+              insertValue: "--nickname={cursor}",
               description:
                 "The user’s nickname, defaults to the user’s username",
               args: { name: "nickname" },
             },
             {
               name: "--first_name",
-              insertValue: "--first_name=",
+              insertValue: "--first_name={cursor}",
               description: "The user’s first name",
               args: { name: "first_name" },
             },
             {
               name: "--last_name",
-              insertValue: "--last_name=",
+              insertValue: "--last_name={cursor}",
               description: "The user’s last name",
               args: { name: "last_name" },
             },
             {
               name: "--description",
-              insertValue: "--description=",
+              insertValue: "--description={cursor}",
               description: "A string containing content about the user",
               args: { name: "description" },
             },
             {
               name: "--rich_editing",
-              insertValue: "--rich_editing=",
+              insertValue: "--rich_editing={cursor}",
               description:
                 "A string for whether to enable the rich editor or not. False if not empty",
               args: { name: "rich_editing" },
@@ -10976,7 +10976,7 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--reassign",
-              insertValue: "--reassign=",
+              insertValue: "--reassign={cursor}",
               description: "User ID to reassign the posts to",
               args: { name: "user-id" },
             },
@@ -10992,7 +10992,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--count",
-              insertValue: "--count=",
+              insertValue: "--count={cursor}",
               description: "How many users to generate?",
               args: {
                 name: "number",
@@ -11001,14 +11001,14 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--role",
-              insertValue: "--role=",
+              insertValue: "--role={cursor}",
               description:
                 "The role of the generated users. Default: default role from WP",
               args: { name: "role" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11027,20 +11027,20 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "Instead of returning the whole user, returns the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Get a specific subset of the user’s fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11080,7 +11080,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--role",
-              insertValue: "--role=",
+              insertValue: "--role={cursor}",
               description: "Only display users with a certain role",
               args: { name: "role" },
             },
@@ -11096,19 +11096,19 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description: "Prints the value of a single field for each user",
               args: { name: "field" },
             },
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11134,7 +11134,7 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11175,7 +11175,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -11221,7 +11221,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -11246,13 +11246,13 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--keys",
-                  insertValue: "--keys=",
+                  insertValue: "--keys={cursor}",
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: {
@@ -11262,7 +11262,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -11277,7 +11277,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--orderby",
-                  insertValue: "--orderby=",
+                  insertValue: "--orderby={cursor}",
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -11290,7 +11290,7 @@ const completionSpec: Fig.Spec = {
                 },
                 {
                   name: "--order",
-                  insertValue: "--order=",
+                  insertValue: "--order={cursor}",
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -11338,7 +11338,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -11368,7 +11368,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -11402,7 +11402,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -11491,13 +11491,13 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -11562,7 +11562,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--by",
-                  insertValue: "--by=",
+                  insertValue: "--by={cursor}",
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -11588,20 +11588,20 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--field",
-                  insertValue: "--field=",
+                  insertValue: "--field={cursor}",
                   description:
                     "Prints the value of a single field for each term",
                   args: { name: "field" },
                 },
                 {
                   name: "--fields",
-                  insertValue: "--fields=",
+                  insertValue: "--fields={cursor}",
                   description: "Limit the output to specific row fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
-                  insertValue: "--format=",
+                  insertValue: "--format={cursor}",
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -11638,7 +11638,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--by",
-                  insertValue: "--by=",
+                  insertValue: "--by={cursor}",
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -11672,7 +11672,7 @@ const completionSpec: Fig.Spec = {
               options: [
                 {
                   name: "--by",
-                  insertValue: "--by=",
+                  insertValue: "--by={cursor}",
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -11703,85 +11703,85 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--user_pass",
-              insertValue: "--user_pass=",
+              insertValue: "--user_pass={cursor}",
               description:
                 "A string that contains the plain text password for the user",
               args: { name: "password" },
             },
             {
               name: "--user_nicename",
-              insertValue: "--user_nicename=",
+              insertValue: "--user_nicename={cursor}",
               description:
                 "A string that contains a URL-friendly name for the user. The default is the user’s username",
               args: { name: "nice_name" },
             },
             {
               name: "--user_url",
-              insertValue: "--user_url=",
+              insertValue: "--user_url={cursor}",
               description:
                 "A string containing the user’s URL for the user’s web site",
               args: { name: "url" },
             },
             {
               name: "--user_email",
-              insertValue: "--user_email=",
+              insertValue: "--user_email={cursor}",
               description: "A string containing the user’s email address",
               args: { name: "email" },
             },
             {
               name: "--display_name",
-              insertValue: "--display_name=",
+              insertValue: "--display_name={cursor}",
               description: "The display name",
               args: { name: "display_name" },
             },
             {
               name: "--nickname",
-              insertValue: "--nickname=",
+              insertValue: "--nickname={cursor}",
               description:
                 "The user’s nickname, defaults to the user’s username",
               args: { name: "nickname" },
             },
             {
               name: "--first_name",
-              insertValue: "--first_name=",
+              insertValue: "--first_name={cursor}",
               description: "The user’s first name",
               args: { name: "first_name" },
             },
             {
               name: "--last_name",
-              insertValue: "--last_name=",
+              insertValue: "--last_name={cursor}",
               description: "The user’s last name",
               args: { name: "last_name" },
             },
             {
               name: "--description",
-              insertValue: "--description=",
+              insertValue: "--description={cursor}",
               description: "A string containing content about the user",
               args: { name: "description" },
             },
             {
               name: "--rich_editing",
-              insertValue: "--rich_editing=",
+              insertValue: "--rich_editing={cursor}",
               description:
                 "A string for whether to enable the rich editor or not. False if not empty",
               args: { name: "rich_editing" },
             },
             {
               name: "--user_registered",
-              insertValue: "--user_registered=",
+              insertValue: "--user_registered={cursor}",
               description:
                 "The date the user registered. Default: current date",
               args: { name: "yyyy-mm-dd-hh-ii-ss" },
             },
             {
               name: "--role",
-              insertValue: "--role=",
+              insertValue: "--role={cursor}",
               description: "A string used to set the user’s role",
               args: { name: "role" },
             },
             {
               name: "--field",
-              insertValue: "--field=",
+              insertValue: "--field={cursor}",
               description:
                 "One or more fields to update. For accepted fields, see wp_update_user()",
               args: { name: "field" },
@@ -11872,13 +11872,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--fields",
-              insertValue: "--fields=",
+              insertValue: "--fields={cursor}",
               description: "Limit the output to specific row fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
-              insertValue: "--format=",
+              insertValue: "--format={cursor}",
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11904,13 +11904,13 @@ const completionSpec: Fig.Spec = {
           options: [
             {
               name: "--position",
-              insertValue: "--position=",
+              insertValue: "--position={cursor}",
               description: "Assign the widget to a new position",
               args: { name: "position" },
             },
             {
               name: "--sidebar-id",
-              insertValue: "--sidebar-id=",
+              insertValue: "--sidebar-id={cursor}",
               description: "Assign the widget to a new sidebars",
               args: { name: "sidebar-id" },
             },

--- a/src/wp.ts
+++ b/src/wp.ts
@@ -77,7 +77,6 @@ const global_parameter_skip_plugins2: Fig.Option = {
   insertValue: "--skip-plugins={cursor}",
   requiresEquals: true,
   displayName: "--skip-plugins={cursor}",
-  requiresEquals: true,
   description:
     "Skip loading all plugins, or a comma-separated list of plugins. Note: mu-plugins are still loaded",
   args: {
@@ -94,8 +93,7 @@ const global_parameter_skip_themes2: Fig.Option = {
   name: "--skip-themes",
   insertValue: "--skip-themes={cursor}",
   requiresEquals: true,
-  displayName: "--skip-themes={cursor}",
-  requiresEquals: true,
+  displayName: "--skip-themes=",
   description: "Skip loading all themes, or a comma-separated list of themes",
   args: {
     name: "themes",
@@ -150,7 +148,6 @@ const global_parameter_debug2: Fig.Option = {
   displayName: "--debug={cursor}",
   requiresEquals: true,
   insertValue: "--debug={cursor}",
-  requiresEquals: true,
   description:
     "Show all PHP errors and add verbosity to WP-CLI output. Built-in groups include: bootstrap, commandfactory, and help",
   args: {
@@ -169,7 +166,6 @@ const global_parameter_prompt2: Fig.Option = {
   insertValue: "--prompt={cursor}",
   requiresEquals: true,
   displayName: "--prompt={cursor}",
-  requiresEquals: true,
   description:
     "Prompt the user to enter values for all command arguments, or a subset specified as comma-separated values",
   args: {
@@ -8841,7 +8837,6 @@ const completionSpec: Fig.Spec = {
           displayName: "--log={cursor}",
           requiresEquals: true,
           insertValue: "--log={cursor}",
-          requiresEquals: true,
           description:
             "Log the items changed. If <file> is not supplied or is “-“, will output to STDOUT. Warning: causes a significant slow down, similar or worse to enabling –precise or –regex",
           args: { name: "file", isOptional: true },

--- a/src/wp.ts
+++ b/src/wp.ts
@@ -6,6 +6,7 @@
 const global_parameter_path: Fig.Option = {
   name: "--path",
   insertValue: "--path={cursor}",
+  requiresEquals: true,
   description: "Path to the WordPress files",
   args: {
     name: "path",
@@ -16,6 +17,7 @@ const global_parameter_path: Fig.Option = {
 const global_parameter_url: Fig.Option = {
   name: "--url",
   insertValue: "--url={cursor}",
+  requiresEquals: true,
   description:
     "Pretend request came from given URL. In multisite, this argument is how the target site is specified",
   args: {
@@ -26,6 +28,7 @@ const global_parameter_url: Fig.Option = {
 const global_parameter_ssh: Fig.Option = {
   name: "--ssh",
   insertValue: "--ssh={cursor}",
+  requiresEquals: true,
   description:
     "Perform operation against a remote server over SSH (or a container using scheme of “docker”, “docker-compose”, “vagrant”)",
   args: {
@@ -44,6 +47,7 @@ const global_parameter_ssh: Fig.Option = {
 const global_parameter_http: Fig.Option = {
   name: "--http",
   insertValue: "--http={cursor}",
+  requiresEquals: true,
   description:
     "Perform operation against a remote WordPress installation over HTTP",
   args: {
@@ -54,6 +58,7 @@ const global_parameter_http: Fig.Option = {
 const global_parameter_user: Fig.Option = {
   name: "--user",
   insertValue: "--user={cursor}",
+  requiresEquals: true,
   description: "Set the WordPress user",
   args: {
     name: "options",
@@ -70,7 +75,9 @@ const global_parameter_skip_plugins1: Fig.Option = {
 const global_parameter_skip_plugins2: Fig.Option = {
   name: "--skip-plugins",
   insertValue: "--skip-plugins={cursor}",
+  requiresEquals: true,
   displayName: "--skip-plugins={cursor}",
+  requiresEquals: true,
   description:
     "Skip loading all plugins, or a comma-separated list of plugins. Note: mu-plugins are still loaded",
   args: {
@@ -86,7 +93,9 @@ const global_parameter_skip_themes1: Fig.Option = {
 const global_parameter_skip_themes2: Fig.Option = {
   name: "--skip-themes",
   insertValue: "--skip-themes={cursor}",
+  requiresEquals: true,
   displayName: "--skip-themes={cursor}",
+  requiresEquals: true,
   description: "Skip loading all themes, or a comma-separated list of themes",
   args: {
     name: "themes",
@@ -101,6 +110,7 @@ const global_parameter_skip_packages: Fig.Option = {
 const global_parameter_require: Fig.Option = {
   name: "--require",
   insertValue: "--require={cursor}",
+  requiresEquals: true,
   description:
     "Load PHP file before running the command (may be used more than once)",
   args: {
@@ -111,6 +121,7 @@ const global_parameter_require: Fig.Option = {
 const global_parameter_exec: Fig.Option = {
   name: "--exec",
   insertValue: "--exec={cursor}",
+  requiresEquals: true,
   description:
     "Execute PHP code before running the command (may be used more than once)",
   args: {
@@ -137,7 +148,9 @@ const global_parameter_debug1: Fig.Option = {
 const global_parameter_debug2: Fig.Option = {
   name: "--debug",
   displayName: "--debug={cursor}",
+  requiresEquals: true,
   insertValue: "--debug={cursor}",
+  requiresEquals: true,
   description:
     "Show all PHP errors and add verbosity to WP-CLI output. Built-in groups include: bootstrap, commandfactory, and help",
   args: {
@@ -154,7 +167,9 @@ const global_parameter_prompt1: Fig.Option = {
 const global_parameter_prompt2: Fig.Option = {
   name: "--prompt",
   insertValue: "--prompt={cursor}",
+  requiresEquals: true,
   displayName: "--prompt={cursor}",
+  requiresEquals: true,
   description:
     "Prompt the user to enter values for all command arguments, or a subset specified as comma-separated values",
   args: {
@@ -420,6 +435,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -498,18 +514,21 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--set-user",
                   insertValue: "--set-user={cursor}",
+                  requiresEquals: true,
                   description: "Set user for alias",
                   args: { name: "user" },
                 },
                 {
                   name: "--set-url",
                   insertValue: "--set-url={cursor}",
+                  requiresEquals: true,
                   description: "Set url for alias",
                   args: { name: "url" },
                 },
                 {
                   name: "--set-path",
                   insertValue: "--set-path={cursor}",
+                  requiresEquals: true,
                   description: "Set path for alias",
                   args: {
                     name: "path",
@@ -519,24 +538,28 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--set-ssh",
                   insertValue: "--set-ssh={cursor}",
+                  requiresEquals: true,
                   description: "Set ssh for alias",
                   args: { name: "ssh" },
                 },
                 {
                   name: "--set-http",
                   insertValue: "--set-http={cursor}",
+                  requiresEquals: true,
                   description: "Set http for alias",
                   args: { name: "http" },
                 },
                 {
                   name: "--grouping",
                   insertValue: "--grouping={cursor}",
+                  requiresEquals: true,
                   description: "For grouping multiple aliases",
                   args: { name: "grouping" },
                 },
                 {
                   name: "--config",
                   insertValue: "--config={cursor}",
+                  requiresEquals: true,
                   description: "Config file to be considered for operations",
                   args: {
                     name: "options",
@@ -556,6 +579,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--config",
                   insertValue: "--config={cursor}",
+                  requiresEquals: true,
                   description: "Config file to be considered for operations",
                   args: {
                     name: "options",
@@ -579,6 +603,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Set user for alias",
                   args: {
                     name: "options",
@@ -602,18 +627,21 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--set-user",
                   insertValue: "--set-user={cursor}",
+                  requiresEquals: true,
                   description: "Set user for alias",
                   args: { name: "user" },
                 },
                 {
                   name: "--set-url",
                   insertValue: "--set-url={cursor}",
+                  requiresEquals: true,
                   description: "Set url for alias",
                   args: { name: "url" },
                 },
                 {
                   name: "--set-path",
                   insertValue: "--set-path={cursor}",
+                  requiresEquals: true,
                   description: "Set path for alias",
                   args: {
                     name: "path",
@@ -623,24 +651,28 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--set-ssh",
                   insertValue: "--set-ssh={cursor}",
+                  requiresEquals: true,
                   description: "Set ssh for alias",
                   args: { name: "ssh" },
                 },
                 {
                   name: "--set-http",
                   insertValue: "--set-http={cursor}",
+                  requiresEquals: true,
                   description: "Set http for alias",
                   args: { name: "http" },
                 },
                 {
                   name: "--grouping",
                   insertValue: "--grouping={cursor}",
+                  requiresEquals: true,
                   description: "For grouping multiple aliases",
                   args: { name: "grouping" },
                 },
                 {
                   name: "--config",
                   insertValue: "--config={cursor}",
+                  requiresEquals: true,
                   description: "Config file to be considered for operations",
                   args: {
                     name: "options",
@@ -685,12 +717,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each update",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific object fields. Defaults to version,update_type,package_url",
               args: { name: "fields" },
@@ -698,6 +732,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -723,12 +758,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--line",
               insertValue: "--line={cursor}",
+              requiresEquals: true,
               description: "The current command line to be executed",
               args: { name: "line" },
             },
             {
               name: "--point",
               insertValue: "--point={cursor}",
+              requiresEquals: true,
               description:
                 "The index to the current cursor position relative to the beginning of the command",
               args: { name: "point" },
@@ -750,6 +787,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -770,6 +808,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -908,6 +947,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--count",
               insertValue: "--count={cursor}",
+              requiresEquals: true,
               description: "How many comments to generate?",
               args: {
                 name: "default",
@@ -917,6 +957,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_id",
               insertValue: "--post_id={cursor}",
+              requiresEquals: true,
               description: "Assign comments to a specific post",
               args: {
                 name: "post-id",
@@ -925,6 +966,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -944,6 +986,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Instead of returning the whole comment, returns the value of a single field",
               args: {
@@ -953,6 +996,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: {
@@ -962,6 +1006,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -987,6 +1032,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Prints the value of a single field for each comment",
               args: {
@@ -996,6 +1042,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific object fields",
               args: {
                 name: "fields",
@@ -1004,6 +1051,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -1046,6 +1094,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "options",
@@ -1096,6 +1145,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Get value in a particular format",
                   args: {
                     name: "options",
@@ -1119,6 +1169,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--keys",
                   insertValue: "--keys={cursor}",
+                  requiresEquals: true,
                   description: "Limit output to metadata of specific keys",
                   args: {
                     name: "keys",
@@ -1127,6 +1178,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: {
@@ -1136,6 +1188,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "options",
@@ -1151,6 +1204,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--orderby",
                   insertValue: "--orderby={cursor}",
+                  requiresEquals: true,
                   description: "Set orderby which field",
                   args: {
                     name: "options",
@@ -1164,6 +1218,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--order",
                   insertValue: "--order={cursor}",
+                  requiresEquals: true,
                   description: "Set ascending or descending order",
                   args: {
                     name: "options",
@@ -1212,6 +1267,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "options",
@@ -1242,6 +1298,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The output format of the value",
                   args: {
                     name: "options",
@@ -1276,6 +1333,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "options",
@@ -1393,18 +1451,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbname",
               insertValue: "--dbname={cursor}",
+              requiresEquals: true,
               description: "Set the database name",
               args: { name: "dbname" },
             },
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description: "Set the database user",
               args: { name: "dbuser" },
             },
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description: "Set the database password",
               args: {
                 name: "options",
@@ -1414,6 +1475,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbhost",
               insertValue: "--dbhost={cursor}",
+              requiresEquals: true,
               description: "Set the database host",
               args: {
                 name: "default",
@@ -1423,6 +1485,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbprefix",
               insertValue: "--dbprefix={cursor}",
+              requiresEquals: true,
               description: "Set the database table prefix",
               args: {
                 name: "default",
@@ -1432,6 +1495,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbcharset",
               insertValue: "--dbcharset={cursor}",
+              requiresEquals: true,
               description: "Set the database charset",
               args: {
                 name: "default",
@@ -1441,12 +1505,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbcollate",
               insertValue: "--dbcollate={cursor}",
+              requiresEquals: true,
               description: "Set the database collation",
               args: { name: "dbcollate" },
             },
             {
               name: "--locale",
               insertValue: "--locale={cursor}",
+              requiresEquals: true,
               description:
                 "Set the WPLANG constant. Defaults to $wp_local_package variable",
               args: { name: "locale" },
@@ -1488,6 +1554,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--type",
               insertValue: "--type={cursor}",
+              requiresEquals: true,
               description:
                 "Type of the config value to delete. Defaults to ‘all’",
               args: {
@@ -1517,6 +1584,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--type",
               insertValue: "--type={cursor}",
+              requiresEquals: true,
               description:
                 "Type of the config value to delete. Defaults to ‘all’",
               args: {
@@ -1531,6 +1599,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Get value in a particular format",
               args: {
                 name: "options",
@@ -1555,6 +1624,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--type",
               insertValue: "--type={cursor}",
+              requiresEquals: true,
               description:
                 "Type of the config value to delete. Defaults to ‘all’",
               args: {
@@ -1580,6 +1650,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -1587,6 +1658,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -1642,6 +1714,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--anchor",
               insertValue: "--anchor={cursor}",
+              requiresEquals: true,
               description:
                 "Anchor string where additions of new values are anchored around. Defaults to “/* That’s all, stop editing!”",
               args: { name: "anchor" },
@@ -1649,6 +1722,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--placement",
               insertValue: "--placement={cursor}",
+              requiresEquals: true,
               description:
                 "Where to place the new values in relation to the anchor string",
               args: {
@@ -1659,6 +1733,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--separator",
               insertValue: "--separator={cursor}",
+              requiresEquals: true,
               description:
                 "Separator string to put between an added value and its anchor string. The following escape sequences will be recognized and properly interpreted: ‘\n’ => newline, ‘\r’ => carriage return, ‘\t’ => tab. Defaults to a single EOL (“\n” on *nix and “\r\n” on Windows)",
               args: { name: "separator" },
@@ -1666,6 +1741,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--type",
               insertValue: "--type={cursor}",
+              requiresEquals: true,
               description: "Type of the config value to set. Defaults to ‘all’",
               args: {
                 name: "options",
@@ -1743,12 +1819,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each update",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific object fields. Defaults to version,update_type,package_url",
               args: { name: "fields" },
@@ -1756,6 +1834,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -1782,6 +1861,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--path",
               insertValue: "--path={cursor}",
+              requiresEquals: true,
               description:
                 "Specify the path in which to install WordPress. Defaults to current directory",
               args: { name: "path", template: "folders" },
@@ -1789,12 +1869,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--locale",
               insertValue: "--locale={cursor}",
+              requiresEquals: true,
               description: "Select which language you want to download",
               args: { name: "locale" },
             },
             {
               name: "--version",
               insertValue: "--version={cursor}",
+              requiresEquals: true,
               description:
                 "Select which version you want to download. Accepts a version number, ‘latest’ or ‘nightly’",
               args: {
@@ -1828,24 +1910,28 @@ const completionSpec: Fig.Spec = {
             {
               name: "--url",
               insertValue: "--url={cursor}",
+              requiresEquals: true,
               description: "The address of the new site",
               args: { name: "url" },
             },
             {
               name: "--title",
               insertValue: "--title={cursor}",
+              requiresEquals: true,
               description: "The title of the new site",
               args: { name: "site-title" },
             },
             {
               name: "--admin_user",
               insertValue: "--admin_user={cursor}",
+              requiresEquals: true,
               description: "The name of the admin user",
               args: { name: "username" },
             },
             {
               name: "--admin_password",
               insertValue: "--admin_password={cursor}",
+              requiresEquals: true,
               description:
                 "The password for the admin user. Defaults to randomly generated string",
               args: { name: "password" },
@@ -1853,6 +1939,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--admin_email",
               insertValue: "--admin_email={cursor}",
+              requiresEquals: true,
               description: "The email address for the admin user",
               args: { name: "email" },
             },
@@ -1881,12 +1968,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--title",
               insertValue: "--title={cursor}",
+              requiresEquals: true,
               description: "The title of the new network",
               args: { name: "network-title" },
             },
             {
               name: "--base",
               insertValue: "--base={cursor}",
+              requiresEquals: true,
               description:
                 "Base path after the domain name that each site url will start with",
               args: {
@@ -1908,12 +1997,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--url",
               insertValue: "--url={cursor}",
+              requiresEquals: true,
               description: "The address of the new site",
               args: { name: "url" },
             },
             {
               name: "--base",
               insertValue: "--base={cursor}",
+              requiresEquals: true,
               description:
                 "Base path after the domain name that each site url will start with",
               args: {
@@ -1929,12 +2020,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--title",
               insertValue: "--title={cursor}",
+              requiresEquals: true,
               description: "The title of the new site",
               args: { name: "site-title" },
             },
             {
               name: "--admin_user",
               insertValue: "--admin_user={cursor}",
+              requiresEquals: true,
               description: "The name of the admin user",
               args: {
                 name: "username",
@@ -1944,6 +2037,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--admin_password",
               insertValue: "--admin_password={cursor}",
+              requiresEquals: true,
               description:
                 "The password for the admin user. Defaults to randomly generated string",
               args: { name: "password" },
@@ -1951,6 +2045,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--admin_email",
               insertValue: "--admin_email={cursor}",
+              requiresEquals: true,
               description: "The email address for the admin user",
               args: { name: "email" },
             },
@@ -1983,6 +2078,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--version",
               insertValue: "--version={cursor}",
+              requiresEquals: true,
               description:
                 "Update to a specific version, instead of to the latest version. Alternatively accepts ‘nightly’",
               args: { name: "version" },
@@ -1995,6 +2091,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--locale",
               insertValue: "--locale={cursor}",
+              requiresEquals: true,
               description: "Select which language you want to download",
               args: { name: "locale" },
             },
@@ -2028,6 +2125,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--version",
               insertValue: "--version={cursor}",
+              requiresEquals: true,
               description:
                 "Verify checksums against a specific version of WordPress",
               args: { name: "version" },
@@ -2035,6 +2133,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--locale",
               insertValue: "--locale={cursor}",
+              requiresEquals: true,
               description:
                 "Verify checksums against a specific locale of WordPress",
               args: { name: "locale" },
@@ -2104,6 +2203,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific object fields",
                   args: { name: "fields" },
                 },
@@ -2115,6 +2215,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description:
                     "Prints the value of a single field for each term",
                   args: { name: "field" },
@@ -2122,6 +2223,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "options",
@@ -2206,12 +2308,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific object fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description:
                     "Prints the value of a single field for each schedule",
                   args: { name: "field" },
@@ -2219,6 +2323,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "options",
@@ -2275,6 +2380,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description:
                 "Username to pass to mysqlcheck. Defaults to DB_USER",
               args: { name: "value" },
@@ -2282,6 +2388,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description:
                 "Password to pass to mysqlcheck. Defaults to DB_PASSWORD",
               args: { name: "value" },
@@ -2307,6 +2414,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description:
                 "Username to pass to mysqlcheck. Defaults to DB_USER",
               args: { name: "value" },
@@ -2314,6 +2422,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description:
                 "Password to pass to mysqlcheck. Defaults to DB_PASSWORD",
               args: { name: "value" },
@@ -2332,12 +2441,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--database",
               insertValue: "--database={cursor}",
+              requiresEquals: true,
               description: "Use a specific database. Defaults to DB_NAME",
               args: { name: "database" },
             },
             {
               name: "--default-character-set",
               insertValue: "--default-character-set={cursor}",
+              requiresEquals: true,
               description:
                 "Use a specific character set. Defaults to DB_CHARSET when defined",
               args: { name: "character-set" },
@@ -2345,12 +2456,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: { name: "value" },
             },
@@ -2378,6 +2491,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -2398,12 +2512,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: { name: "value" },
             },
@@ -2416,12 +2532,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: { name: "value" },
             },
@@ -2443,12 +2561,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description: "Username to pass to mysqldump. Defaults to DB_USER",
               args: { name: "value" },
             },
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description:
                 "Password to pass to mysqldump. Defaults to DB_PASSWORD",
               args: { name: "value" },
@@ -2462,6 +2582,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--tables",
               insertValue: "--tables={cursor}",
+              requiresEquals: true,
               description:
                 "The comma separated list of specific tables to export. Excluding this parameter will export all tables in the database",
               args: { name: "tables" },
@@ -2469,6 +2590,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--exclude_tables",
               insertValue: "--exclude_tables={cursor}",
+              requiresEquals: true,
               description:
                 "The comma separated list of specific tables that should be skipped from exporting. Excluding this parameter will export all tables in the database",
               args: { name: "tables" },
@@ -2501,6 +2623,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: {
                 name: "value",
@@ -2510,6 +2633,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: {
                 name: "value",
@@ -2541,6 +2665,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description:
                 "Username to pass to mysqlcheck. Defaults to DB_USER",
               args: {
@@ -2551,6 +2676,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description:
                 "Password to pass to mysqlcheck. Defaults to DB_PASSWORD",
               args: {
@@ -2587,6 +2713,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: {
                 name: "value",
@@ -2596,6 +2723,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: {
                 name: "value",
@@ -2622,6 +2750,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description:
                 "Username to pass to mysqlcheck. Defaults to DB_USER",
               args: {
@@ -2632,6 +2761,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description:
                 "Password to pass to mysqlcheck. Defaults to DB_PASSWORD",
               args: {
@@ -2659,6 +2789,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbuser",
               insertValue: "--dbuser={cursor}",
+              requiresEquals: true,
               description: "Username to pass to mysql. Defaults to DB_USER",
               args: {
                 name: "value",
@@ -2668,6 +2799,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dbpass",
               insertValue: "--dbpass={cursor}",
+              requiresEquals: true,
               description: "Password to pass to mysql. Defaults to DB_PASSWORD",
               args: {
                 name: "value",
@@ -2714,6 +2846,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--before_context",
               insertValue: "--before_context={cursor}",
+              requiresEquals: true,
               description: "Number of characters to display before the match",
               args: {
                 name: "num",
@@ -2723,6 +2856,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--after_context",
               insertValue: "--after_context={cursor}",
+              requiresEquals: true,
               description: "Number of characters to display after the match",
               args: {
                 name: "num",
@@ -2737,6 +2871,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--regex-flags",
               insertValue: "--regex-flags={cursor}",
+              requiresEquals: true,
               description:
                 "Pass PCRE modifiers to the regex search (e.g. ‘i’ for case-insensitivity)",
               args: { name: "regex-flags" },
@@ -2744,6 +2879,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--regex-delimiter",
               insertValue: "--regex-delimiter={cursor}",
+              requiresEquals: true,
               description:
                 "The delimiter to use for the regex. It must be escaped if it appears in the search string. The default value is the result of chr(1)",
               args: { name: "regex-delimiter" },
@@ -2771,6 +2907,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--table_column_color",
               insertValue: "--table_column_color={cursor}",
+              requiresEquals: true,
               description:
                 "Percent color code to use for the ‘table:column’ output. For a list of available percent color codes, see below. Default ‘%G’ (bright green)",
               args: { name: "table_column_color" },
@@ -2778,6 +2915,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--id_color",
               insertValue: "--id_color={cursor}",
+              requiresEquals: true,
               description:
                 "Percent color code to use for the row id output. For a list of available percent color codes, see below. Default ‘%Y’ (bright yellow)",
               args: { name: "id_color" },
@@ -2785,6 +2923,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--match_color",
               insertValue: "--match_color={cursor}",
+              requiresEquals: true,
               description:
                 "Percent color code to use for the match (unless both before and after context are 0, when no color code is used). For a list of available percent color codes, see below. Default ‘%3%k’ (black on a mustard background)",
               args: { name: "match_color" },
@@ -2798,6 +2937,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--size_format",
               insertValue: "--size_format={cursor}",
+              requiresEquals: true,
               description: "Display the database size only, as a bare number",
               args: {
                 name: "format",
@@ -2831,6 +2971,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -2845,6 +2986,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--scope",
               insertValue: "--scope={cursor}",
+              requiresEquals: true,
               description:
                 "Can be all, global, ms_global, blog, or old tables. Defaults to all",
               args: { name: "scope" },
@@ -2877,6 +3019,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--scope",
               insertValue: "--scope={cursor}",
+              requiresEquals: true,
               description:
                 "Can be all, global, ms_global, blog, or old tables. Defaults to all",
               args: { name: "scope" },
@@ -2898,6 +3041,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "options",
@@ -2933,6 +3077,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--format",
           insertValue: "--format={cursor}",
+          requiresEquals: true,
           description: "Choose the format for the archive",
           args: {
             name: "options",
@@ -3008,6 +3153,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--width",
                   insertValue: "--width={cursor}",
+                  requiresEquals: true,
                   description:
                     "Width of the embed in pixels. Part of cache key so must match. Defaults to content_width if set else 500px, so is theme and context dependent",
                   args: { name: "width" },
@@ -3015,6 +3161,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--height",
                   insertValue: "--height={cursor}",
+                  requiresEquals: true,
                   description:
                     "Height of the embed in pixels. Part of cache key so must match. Defaults to 1.5 * default width (content_width or 500px), to a maximum of 1000px",
                   args: { name: "height" },
@@ -3048,18 +3195,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--width",
               insertValue: "--width={cursor}",
+              requiresEquals: true,
               description: "Width of the embed in pixels",
               args: { name: "width" },
             },
             {
               name: "--height",
               insertValue: "--height={cursor}",
+              requiresEquals: true,
               description: "Height of the embed in pixels",
               args: { name: "height" },
             },
             {
               name: "--post-id",
               insertValue: "--post-id={cursor}",
+              requiresEquals: true,
               description: "Cache oEmbed response for a given post",
               args: { name: "id" },
             },
@@ -3085,6 +3235,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--limit-response-size",
               insertValue: "--limit-response-size={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the size of the resulting HTML when using discovery. Default 150 KB (the standard WordPress limit). Not compatible with ‘no-discover’",
               args: { name: "size" },
@@ -3097,6 +3248,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--raw-format",
               insertValue: "--raw-format={cursor}",
+              requiresEquals: true,
               description: "The serialization format for the value",
               args: {
                 name: "json|xml",
@@ -3116,18 +3268,21 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -3153,18 +3308,21 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -3193,6 +3351,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--limit-response-size",
                   insertValue: "--limit-response-size={cursor}",
+                  requiresEquals: true,
                   description:
                     "Limit the size of the resulting HTML when using discovery. Default 150 KB (the standard WordPress limit). Not compatible with ‘no-discover’",
                   args: { name: "size" },
@@ -3200,6 +3359,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--link-type",
                   insertValue: "--link-type={cursor}",
+                  requiresEquals: true,
                   description:
                     "Whether to accept only a certain link type when using discovery. Defaults to any (json or xml), preferring json. Not compatible with ‘no-discover’",
                   args: {
@@ -3294,6 +3454,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--dir",
           insertValue: "--dir={cursor}",
+          requiresEquals: true,
           description:
             "Full path to directory where WXR export files should be stored. Defaults to current working directory",
           args: { name: "dirname", template: "folders" },
@@ -3310,6 +3471,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--max_file_size",
           insertValue: "--max_file_size={cursor}",
+          requiresEquals: true,
           description:
             "A single export file should have this many megabytes. -1 for unlimited",
           args: {
@@ -3320,6 +3482,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--start_date",
           insertValue: "--start_date={cursor}",
+          requiresEquals: true,
           description:
             "Export only posts published after this date, in format YYYY-MM-DD",
           args: { name: "date" },
@@ -3327,6 +3490,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--end_date",
           insertValue: "--end_date={cursor}",
+          requiresEquals: true,
           description:
             "Export only posts published before this date, in format YYYY-MM-DD",
           args: { name: "date" },
@@ -3334,6 +3498,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--post_type",
           insertValue: "--post_type={cursor}",
+          requiresEquals: true,
           description:
             "Export only posts with this post_type. Separate multiple post types with a comma",
           args: {
@@ -3344,6 +3509,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--post_type__not_in",
           insertValue: "--post_type__not_in={cursor}",
+          requiresEquals: true,
           description:
             "Export all post types except those identified. Separate multiple post types with a comma. Defaults to none",
           args: { name: "post-type" },
@@ -3351,6 +3517,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--post_in",
           insertValue: "--post_in={cursor}",
+          requiresEquals: true,
           description:
             "Export all posts specified as a comma- or space-separated list of IDs. Post’s attachments won’t be exported unless –with_attachments is specified",
           args: { name: "pid" },
@@ -3363,6 +3530,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--start_id",
           insertValue: "--start_id={cursor}",
+          requiresEquals: true,
           description:
             "Export only posts with IDs greater than or equal to this post ID",
           args: { name: "pid" },
@@ -3370,6 +3538,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--max_num_posts",
           insertValue: "--max_num_posts={cursor}",
+          requiresEquals: true,
           description:
             "Export no more than <num> posts (excluding attachments)",
           args: { name: "num" },
@@ -3377,6 +3546,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--author",
           insertValue: "--author={cursor}",
+          requiresEquals: true,
           description:
             "Export only posts by this author. Can be either user login or user ID",
           args: { name: "author" },
@@ -3384,18 +3554,21 @@ const completionSpec: Fig.Spec = {
         {
           name: "--category",
           insertValue: "--category={cursor}",
+          requiresEquals: true,
           description: "Export only posts in this category",
           args: { name: "category" },
         },
         {
           name: "--post_status",
           insertValue: "--post_status={cursor}",
+          requiresEquals: true,
           description: "Export only posts with this status",
           args: { name: "status" },
         },
         {
           name: "--filename_format",
           insertValue: "--filename_format={cursor}",
+          requiresEquals: true,
           description:
             "Use a custom format for export filenames. Defaults to ‘{site}.wordpress.{date}.{n}.xml’",
           args: { name: "format" },
@@ -3418,6 +3591,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--include_ignored_paths",
           insertValue: "--include_ignored_paths={cursor}",
+          requiresEquals: true,
           description:
             "Include additional ignored paths as CSV (e.g. ‘/sys-backup/,/temp/’)",
           args: { name: "paths" },
@@ -3425,24 +3599,28 @@ const completionSpec: Fig.Spec = {
         {
           name: "--max_depth",
           insertValue: "--max_depth={cursor}",
+          requiresEquals: true,
           description: "Only recurse to a specified depth, inclusive",
           args: { name: "max-depth" },
         },
         {
           name: "--fields",
           insertValue: "--fields={cursor}",
+          requiresEquals: true,
           description: "Limit the output to specific row fields",
           args: { name: "fields" },
         },
         {
           name: "--field",
           insertValue: "--field={cursor}",
+          requiresEquals: true,
           description: "Output a specific field for each row",
           args: { name: "field" },
         },
         {
           name: "--format",
           insertValue: "--format={cursor}",
+          requiresEquals: true,
           description: "Render output in a particular format",
           args: {
             name: "options",
@@ -3595,6 +3773,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--slug",
               insertValue: "--slug={cursor}",
+              requiresEquals: true,
               description:
                 "Plugin or theme slug. Defaults to the source directory’s basename",
               args: { name: "slug" },
@@ -3602,6 +3781,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--domain",
               insertValue: "--domain={cursor}",
+              requiresEquals: true,
               description:
                 "Text domain to look for in the source code, unless the --ignore-domain option is used. By default, the “Text Domain” header of the plugin or theme is used. If none is provided, it falls back to the project slug",
               args: { name: "domain" },
@@ -3614,6 +3794,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--merge",
               insertValue: "--merge={cursor}",
+              requiresEquals: true,
               description:
                 "Comma-separated list of POT files whose contents should be merged with the extracted strings. If left empty, defaults to the destination POT file. POT file headers will be ignored",
               args: { name: "paths" },
@@ -3621,6 +3802,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--subtract",
               insertValue: "--subtract={cursor}",
+              requiresEquals: true,
               description:
                 "Comma-separated list of POT files whose contents should act as some sort of blacklist for string extraction. Any string which is found on that blacklist will not be extracted. This can be useful when you want to create multiple POT files from the same source directory with slightly different content and no duplicate strings between them",
               args: { name: "paths" },
@@ -3628,6 +3810,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--include",
               insertValue: "--include={cursor}",
+              requiresEquals: true,
               description:
                 "Comma-separated list of files and paths that should be used for string extraction. If provided, only these files and folders will be taken into account for string extraction. For example, --include='src,my-file.php will ignore anything besides my-file.php and files in the src directory. Simple glob patterns can be used, i.e. --include=foo-*.php includes any PHP file with the foo- prefix. Leading and trailing slashes are ignored, i.e. /my/directory/ is the same as my/directory",
               args: { name: "paths" },
@@ -3635,6 +3818,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--exclude",
               insertValue: "--exclude={cursor}",
+              requiresEquals: true,
               description:
                 "Comma-separated list of files and paths that should be skipped for string extraction. For example, --exclude='.github,myfile.php would ignore any strings found within myfile.php or the .github folder. Simple glob patterns can be used, i.e. --exclude=foo-*.php excludes any PHP file with the foo- prefix. Leading and trailing slashes are ignored, i.e. /my/directory/ is the same as my/directory. The following files and folders are always excluded: node_modules, .git, .svn, .CVS, .hg, vendor, *.min.js",
               args: { name: "paths" },
@@ -3642,6 +3826,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--headers",
               insertValue: "--headers={cursor}",
+              requiresEquals: true,
               description:
                 "Array in JSON format of custom headers which will be added to the POT file. Defaults to empty array",
               args: { name: "headers" },
@@ -3667,6 +3852,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--file-comment",
               insertValue: "--file-comment={cursor}",
+              requiresEquals: true,
               description:
                 "String that should be added as a comment to the top of the resulting POT file. By default, a copyright comment is added for WordPress plugins and themes in the following manner: Copyright (C) 2018 Example Plugin Author. This file is distributed under the same license as the Example Plugin package. If a plugin or theme specifies a license in their main plugin file or stylesheet, the comment looks like this: Copyright (C) 2018 Example Plugin Author. This file is distributed under the GPLv2",
               args: { name: "file-comment" },
@@ -3674,6 +3860,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--package-name",
               insertValue: "--package-name={cursor}",
+              requiresEquals: true,
               description:
                 "Name to use for package name in the resulting POT file’s Project-Id-Version header. Overrides plugin or theme name, if applicable",
               args: { name: "name" },
@@ -3695,6 +3882,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--authors",
           insertValue: "--authors={cursor}",
+          requiresEquals: true,
           description:
             "How the author mapping should be handled. Options are ‘create’, ‘mapping.csv’, or ‘skip’. The first will create any non-existent users from the WXR file. The second will read author mapping associations from a CSV, or create a CSV for editing if the file path doesn’t exist. The CSV requires two columns, and a header row like “old_user_login,new_user_login”. The last option will skip any author mapping",
           args: { name: "authors" },
@@ -3702,6 +3890,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--skip",
           insertValue: "--skip={cursor}",
+          requiresEquals: true,
           description:
             "Skip importing specific data. Supported options are: ‘attachment’ and ‘image_resize’ (skip time-consuming thumbnail generation)",
           args: { name: "data-type" },
@@ -3794,6 +3983,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
@@ -3805,12 +3995,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -3869,6 +4061,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description:
                     "Render output in a particular format. Used when installing languages for all plugins",
                   args: {
@@ -3914,6 +4107,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
@@ -3925,12 +4119,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4005,6 +4201,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description:
                     "Render output in a particular format. Used when installing languages for all themes",
                   args: {
@@ -4050,6 +4247,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Display the value of a single field",
                   args: { name: "field" },
                 },
@@ -4061,12 +4259,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4214,6 +4414,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -4221,6 +4422,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -4248,30 +4450,35 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_id",
               insertValue: "--post_id={cursor}",
+              requiresEquals: true,
               description: "ID of the post to attach the imported files to",
               args: { name: "post_id" },
             },
             {
               name: "--title",
               insertValue: "--title={cursor}",
+              requiresEquals: true,
               description: "Attachment title (post title field)",
               args: { name: "title" },
             },
             {
               name: "--caption",
               insertValue: "--caption={cursor}",
+              requiresEquals: true,
               description: "Caption for attachent (post excerpt field)",
               args: { name: "caption" },
             },
             {
               name: "--alt",
               insertValue: "--alt={cursor}",
+              requiresEquals: true,
               description: "Alt text for image (saved as post meta)",
               args: { name: "alt_text" },
             },
             {
               name: "--desc",
               insertValue: "--desc={cursor}",
+              requiresEquals: true,
               description:
                 "'Description' field (post content) of attachment post",
               args: { name: "description" },
@@ -4308,6 +4515,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--image_size",
               insertValue: "--image_size={cursor}",
+              requiresEquals: true,
               description:
                 "Name of the image size to regenerate. Only thumbnails of this image size will be regenerated, thumbnails of other image sizes will not",
               args: { name: "image_size" },
@@ -4404,36 +4612,42 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--description",
                   insertValue: "--description={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom description for the menu item",
                   args: { name: "description" },
                 },
                 {
                   name: "--attr-title",
                   insertValue: "--attr-title={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom title attribute for the menu item",
                   args: { name: "attr-title" },
                 },
                 {
                   name: "--target",
                   insertValue: "--target={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom link target for the menu item",
                   args: { name: "target" },
                 },
                 {
                   name: "--classes",
                   insertValue: "--classes={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom link classes for the menu item",
                   args: { name: "classes" },
                 },
                 {
                   name: "--position",
                   insertValue: "--position={cursor}",
+                  requiresEquals: true,
                   description: "Specify the position of this menu item",
                   args: { name: "position" },
                 },
                 {
                   name: "--parent-id",
                   insertValue: "--parent-id={cursor}",
+                  requiresEquals: true,
                   description:
                     "Make this menu item a child of another menu item",
                   args: { name: "parent-id" },
@@ -4461,48 +4675,56 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--title",
                   insertValue: "--title={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom title for the menu item",
                   args: { name: "title" },
                 },
                 {
                   name: "--link",
                   insertValue: "--link={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom url for the menu item",
                   args: { name: "link" },
                 },
                 {
                   name: "--description",
                   insertValue: "--description={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom description for the menu item",
                   args: { name: "description" },
                 },
                 {
                   name: "--attr-title",
                   insertValue: "--attr-title={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom title attribute for the menu item",
                   args: { name: "attr-title" },
                 },
                 {
                   name: "--target",
                   insertValue: "--target={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom link target for the menu item",
                   args: { name: "target" },
                 },
                 {
                   name: "--classes",
                   insertValue: "--classes={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom link classes for the menu item",
                   args: { name: "classes" },
                 },
                 {
                   name: "--position",
                   insertValue: "--position={cursor}",
+                  requiresEquals: true,
                   description: "Specify the position of this menu item",
                   args: { name: "position" },
                 },
                 {
                   name: "--parent-id",
                   insertValue: "--parent-id={cursor}",
+                  requiresEquals: true,
                   description:
                     "Make this menu item a child of another menu item",
                   args: { name: "parent-id" },
@@ -4534,48 +4756,56 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--title",
                   insertValue: "--title={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom title for the menu item",
                   args: { name: "title" },
                 },
                 {
                   name: "--link",
                   insertValue: "--link={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom url for the menu item",
                   args: { name: "link" },
                 },
                 {
                   name: "--description",
                   insertValue: "--description={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom description for the menu item",
                   args: { name: "description" },
                 },
                 {
                   name: "--attr-title",
                   insertValue: "--attr-title={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom title attribute for the menu item",
                   args: { name: "attr-title" },
                 },
                 {
                   name: "--target",
                   insertValue: "--target={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom link target for the menu item",
                   args: { name: "target" },
                 },
                 {
                   name: "--classes",
                   insertValue: "--classes={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom link classes for the menu item",
                   args: { name: "classes" },
                 },
                 {
                   name: "--position",
                   insertValue: "--position={cursor}",
+                  requiresEquals: true,
                   description: "Specify the position of this menu item",
                   args: { name: "position" },
                 },
                 {
                   name: "--parent-id",
                   insertValue: "--parent-id={cursor}",
+                  requiresEquals: true,
                   description:
                     "Make this menu item a child of another menu item",
                   args: { name: "parent-id" },
@@ -4605,12 +4835,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific object fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4637,48 +4869,56 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--title",
                   insertValue: "--title={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom title for the menu item",
                   args: { name: "title" },
                 },
                 {
                   name: "--link",
                   insertValue: "--link={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom url for the menu item",
                   args: { name: "link" },
                 },
                 {
                   name: "--description",
                   insertValue: "--description={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom description for the menu item",
                   args: { name: "description" },
                 },
                 {
                   name: "--attr-title",
                   insertValue: "--attr-title={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom title attribute for the menu item",
                   args: { name: "attr-title" },
                 },
                 {
                   name: "--target",
                   insertValue: "--target={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom link target for the menu item",
                   args: { name: "target" },
                 },
                 {
                   name: "--classes",
                   insertValue: "--classes={cursor}",
+                  requiresEquals: true,
                   description: "Set a custom link classes for the menu item",
                   args: { name: "classes" },
                 },
                 {
                   name: "--position",
                   insertValue: "--position={cursor}",
+                  requiresEquals: true,
                   description: "Specify the position of this menu item",
                   args: { name: "position" },
                 },
                 {
                   name: "--parent-id",
                   insertValue: "--parent-id={cursor}",
+                  requiresEquals: true,
                   description:
                     "Make this menu item a child of another menu item",
                   args: { name: "parent-id" },
@@ -4694,12 +4934,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -4740,6 +4982,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4825,6 +5068,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -4875,6 +5119,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -4898,12 +5143,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--keys",
                   insertValue: "--keys={cursor}",
+                  requiresEquals: true,
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: { name: "fields" },
@@ -4911,6 +5158,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -4926,6 +5174,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--orderby",
                   insertValue: "--orderby={cursor}",
+                  requiresEquals: true,
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -4939,6 +5188,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--order",
                   insertValue: "--order={cursor}",
+                  requiresEquals: true,
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -4987,6 +5237,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -5017,6 +5268,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -5051,6 +5303,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -5107,6 +5360,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "The serialization format for the value",
               args: {
                 name: "format",
@@ -5116,6 +5370,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--autoload",
               insertValue: "--autoload={cursor}",
+              requiresEquals: true,
               description: "Should this option be automatically loaded",
               args: {
                 name: "autoload",
@@ -5143,6 +5398,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Get value in a particular format",
               args: {
                 name: "format",
@@ -5162,12 +5418,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--search",
               insertValue: "--search={cursor}",
+              requiresEquals: true,
               description: "Use wildcards ( * and ? ) to match option name",
               args: { name: "search" },
             },
             {
               name: "--exclude",
               insertValue: "--exclude={cursor}",
+              requiresEquals: true,
               description:
                 "Pattern to exclude. Use wildcards ( * and ? ) to match option name",
               args: { name: "exclude" },
@@ -5175,6 +5433,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--autoload",
               insertValue: "--autoload={cursor}",
+              requiresEquals: true,
               description:
                 "Match only autoload options when value is on, and only not-autoload option when off",
               args: { name: "autoload" },
@@ -5196,18 +5455,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description:
                 "The serialization format for the value. total_bytes displays the total size of matching options in bytes",
               args: {
@@ -5225,6 +5487,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--orderby",
               insertValue: "--orderby={cursor}",
+              requiresEquals: true,
               description: "Set orderby which field",
               args: {
                 name: "fields",
@@ -5238,6 +5501,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--order",
               insertValue: "--order={cursor}",
+              requiresEquals: true,
               description: "Set ascending or descending order",
               args: {
                 name: "order",
@@ -5278,6 +5542,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "The serialization format for the value",
               args: {
                 name: "format",
@@ -5304,6 +5569,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "The output format for the value",
               args: {
                 name: "format",
@@ -5334,6 +5600,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--autoload",
               insertValue: "--autoload={cursor}",
+              requiresEquals: true,
               description:
                 "Requires WP 4.2. Should this option be automatically loaded",
               args: {
@@ -5344,6 +5611,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "The serialization format for the value",
               args: {
                 name: "format",
@@ -5386,6 +5654,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -5393,6 +5662,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5430,6 +5700,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -5437,6 +5708,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5592,6 +5864,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Only show the provided field",
                   args: { name: "field" },
                 },
@@ -5648,6 +5921,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Instead of returning the whole plugin, returns the value of a single field",
               args: { name: "field" },
@@ -5655,6 +5929,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -5662,6 +5937,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5687,6 +5963,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--version",
               insertValue: "--version={cursor}",
+              requiresEquals: true,
               description:
                 "If set, get that particular version from wordpress.org, instead of the stable version",
               args: { name: "version" },
@@ -5747,18 +6024,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each plugin",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5774,6 +6054,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--status",
               insertValue: "--status={cursor}",
+              requiresEquals: true,
               description: "Filter the output by plugin status",
               args: {
                 name: "status",
@@ -5815,6 +6096,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--page",
               insertValue: "--page={cursor}",
+              requiresEquals: true,
               description: "Optional page to display",
               args: {
                 name: "page",
@@ -5824,6 +6106,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--per-page",
               insertValue: "--per-page={cursor}",
+              requiresEquals: true,
               description: "Optional number of results to display",
               args: {
                 name: "per-page",
@@ -5833,12 +6116,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each plugin",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Ask for specific fields from the API. Defaults to name,slug,author_profile,rating. Acceptable values:",
               args: {
@@ -5877,6 +6162,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5955,6 +6241,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--exclude",
               insertValue: "--exclude={cursor}",
+              requiresEquals: true,
               description:
                 "Comma separated list of plugin names that should be excluded from updating",
               args: { name: "name" },
@@ -5972,6 +6259,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -5986,6 +6274,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--version",
               insertValue: "--version={cursor}",
+              requiresEquals: true,
               description:
                 "If set, the plugin will be updated to the specified version",
             },
@@ -6022,6 +6311,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -6080,6 +6370,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_author",
               insertValue: "--post_author={cursor}",
+              requiresEquals: true,
               description:
                 "The ID of the user who added the post. Default is the current user ID",
               args: { name: "post_author" },
@@ -6087,12 +6378,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_date",
               insertValue: "--post_date={cursor}",
+              requiresEquals: true,
               description: "The date of the post. Default is the current time",
               args: { name: "post_date" },
             },
             {
               name: "--post_date_gmt",
               insertValue: "--post_date_gmt={cursor}",
+              requiresEquals: true,
               description:
                 "The date of the post in the GMT timezone. Default is the value of $post_date",
               args: { name: "post_date_gmt" },
@@ -6100,42 +6393,49 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_content",
               insertValue: "--post_content={cursor}",
+              requiresEquals: true,
               description: "The post content. Default empty",
               args: { name: "post_content" },
             },
             {
               name: "--post_content_filtered",
               insertValue: "--post_content_filtered={cursor}",
+              requiresEquals: true,
               description: "The filtered post content. Default empty",
               args: { name: "post_content_filtered" },
             },
             {
               name: "--post_title",
               insertValue: "--post_title={cursor}",
+              requiresEquals: true,
               description: "The post title. Default empty",
               args: { name: "post_title" },
             },
             {
               name: "--post_excerpt",
               insertValue: "--post_excerpt={cursor}",
+              requiresEquals: true,
               description: "The post excerpt. Default empty",
               args: { name: "post_excerpt" },
             },
             {
               name: "--post_status",
               insertValue: "--post_status={cursor}",
+              requiresEquals: true,
               description: "The post status. Default ‘draft’",
               args: { name: "post_status" },
             },
             {
               name: "--post_type",
               insertValue: "--post_type={cursor}",
+              requiresEquals: true,
               description: "The post type. Default ‘post’",
               args: { name: "post_type" },
             },
             {
               name: "--comment_status",
               insertValue: "--comment_status={cursor}",
+              requiresEquals: true,
               description:
                 "Whether the post can accept comments. Accepts ‘open’ or ‘closed’. Default is the value of ‘default_comment_status’ option",
               args: {
@@ -6146,6 +6446,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--ping_status",
               insertValue: "--ping_status={cursor}",
+              requiresEquals: true,
               description:
                 "Whether the post can accept pings. Accepts ‘open’ or ‘closed’. Default is the value of ‘default_ping_status’ option",
               args: {
@@ -6156,12 +6457,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_password",
               insertValue: "--post_password={cursor}",
+              requiresEquals: true,
               description: "The password to access the post. Default empty",
               args: { name: "post_password" },
             },
             {
               name: "--post_name",
               insertValue: "--post_name={cursor}",
+              requiresEquals: true,
               description:
                 "The post name. Default is the sanitized post title when creating a new post",
               args: { name: "post_name" },
@@ -6169,12 +6472,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--from-post",
               insertValue: "--from-post={cursor}",
+              requiresEquals: true,
               description: "Post id of a post to be duplicated",
               args: { name: "post_id" },
             },
             {
               name: "--to_ping",
               insertValue: "--to_ping={cursor}",
+              requiresEquals: true,
               description:
                 "Space or carriage return-separated list of URLs to ping. Default empty",
               args: { name: "to_ping" },
@@ -6182,6 +6487,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--pinged",
               insertValue: "--pinged={cursor}",
+              requiresEquals: true,
               description:
                 "Space or carriage return-separated list of URLs that have been pinged. Default empty",
               args: { name: "pinged" },
@@ -6189,6 +6495,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_modified",
               insertValue: "--post_modified={cursor}",
+              requiresEquals: true,
               description:
                 "The date when the post was last modified. Default is the current time",
               args: { name: "post_modified" },
@@ -6196,6 +6503,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_modified_gmt",
               insertValue: "--post_modified_gmt={cursor}",
+              requiresEquals: true,
               description:
                 "The date when the post was last modified in the GMT timezone. Default is the current time",
               args: { name: "post_modified_gmt" },
@@ -6203,6 +6511,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_parent",
               insertValue: "--post_parent={cursor}",
+              requiresEquals: true,
               description:
                 "Set this for the post it belongs to, if any. Default 0",
               args: {
@@ -6213,6 +6522,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--menu_order",
               insertValue: "--menu_order={cursor}",
+              requiresEquals: true,
               description:
                 "The order the post should be displayed in. Default 0",
               args: {
@@ -6223,12 +6533,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_mime_type",
               insertValue: "--post_mime_type={cursor}",
+              requiresEquals: true,
               description: "The mime type of the post. Default empty",
               args: { name: "post_mime_type" },
             },
             {
               name: "--guid",
               insertValue: "--guid={cursor}",
+              requiresEquals: true,
               description:
                 "Global Unique ID for referencing the post. Default empty",
               args: { name: "guid" },
@@ -6236,6 +6548,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_category",
               insertValue: "--post_category={cursor}",
+              requiresEquals: true,
               description:
                 "Array of category names, slugs, or IDs. Defaults to value of the ‘default_category’ option",
               args: { name: "post_category" },
@@ -6243,12 +6556,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--tags_input",
               insertValue: "--tags_input={cursor}",
+              requiresEquals: true,
               description: "Array of tag names, slugs, or IDs. Default empty",
               args: { name: "tags_input" },
             },
             {
               name: "--tax_input",
               insertValue: "--tax_input={cursor}",
+              requiresEquals: true,
               description:
                 "Array of taxonomy terms keyed by their taxonomy name. Default empty",
               args: { name: "tax_input" },
@@ -6256,6 +6571,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--meta_input",
               insertValue: "--meta_input={cursor}",
+              requiresEquals: true,
               description:
                 "Array in JSON format of post meta values keyed by their post meta key. Default empty",
               args: { name: "meta_input" },
@@ -6319,6 +6635,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--count",
               insertValue: "--count={cursor}",
+              requiresEquals: true,
               description: "How many posts to generate?",
               args: {
                 name: "number",
@@ -6328,6 +6645,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_type",
               insertValue: "--post_type={cursor}",
+              requiresEquals: true,
               description: "The type of the generated posts",
               args: {
                 name: "type",
@@ -6337,6 +6655,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_status",
               insertValue: "--post_status={cursor}",
+              requiresEquals: true,
               description: "The status of the generated posts",
               args: {
                 name: "status",
@@ -6346,18 +6665,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_title",
               insertValue: "--post_title={cursor}",
+              requiresEquals: true,
               description: "The post title",
               args: { name: "post_title" },
             },
             {
               name: "--post_author",
               insertValue: "--post_author={cursor}",
+              requiresEquals: true,
               description: "The author of the generated posts",
               args: { name: "login" },
             },
             {
               name: "--post_date",
               insertValue: "--post_date={cursor}",
+              requiresEquals: true,
               description:
                 "The date of the generated posts. Default: current date",
               args: { name: "yyyy-mm-dd-hh-ii-ss" },
@@ -6365,6 +6687,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_date_gmt",
               insertValue: "--post_date_gmt={cursor}",
+              requiresEquals: true,
               description:
                 "The GMT date of the generated posts. Default: value of post_date (or current date if it’s not set)",
               args: { name: "yyyy-mm-dd-hh-ii-ss" },
@@ -6377,6 +6700,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--max_depth",
               insertValue: "--max_depth={cursor}",
+              requiresEquals: true,
               description:
                 "For hierarchical post types, generate child posts down to a certain depth",
               args: {
@@ -6387,6 +6711,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -6406,6 +6731,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Instead of returning the whole post, returns the value of a single field",
               args: { name: "field" },
@@ -6413,6 +6739,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -6420,6 +6747,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -6445,6 +6773,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each post",
               args: {
                 name: "fields",
@@ -6480,6 +6809,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific object fields",
               args: {
                 name: "fields",
@@ -6515,6 +6845,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -6556,6 +6887,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -6606,6 +6938,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -6629,12 +6962,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--keys",
                   insertValue: "--keys={cursor}",
+                  requiresEquals: true,
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: { name: "fields" },
@@ -6642,6 +6977,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -6657,6 +6993,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--orderby",
                   insertValue: "--orderby={cursor}",
+                  requiresEquals: true,
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -6670,6 +7007,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--order",
                   insertValue: "--order={cursor}",
+                  requiresEquals: true,
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -6718,6 +7056,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -6748,6 +7087,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -6782,6 +7122,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -6817,6 +7158,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--by",
                   insertValue: "--by={cursor}",
+                  requiresEquals: true,
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -6843,6 +7185,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description:
                     "Prints the value of a single field for each term",
                   args: {
@@ -6863,6 +7206,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific row fields",
                   args: {
                     name: "fields",
@@ -6882,6 +7226,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -6919,6 +7264,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--by",
                   insertValue: "--by={cursor}",
+                  requiresEquals: true,
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -6953,6 +7299,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--by",
                   insertValue: "--by={cursor}",
+                  requiresEquals: true,
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -6981,6 +7328,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_author",
               insertValue: "--post_author={cursor}",
+              requiresEquals: true,
               description:
                 "The ID of the user who added the post. Default is the current user ID",
               args: { name: "post_author" },
@@ -6988,12 +7336,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_date",
               insertValue: "--post_date={cursor}",
+              requiresEquals: true,
               description: "The date of the post. Default is the current time",
               args: { name: "post_date" },
             },
             {
               name: "--post_date_gmt",
               insertValue: "--post_date_gmt={cursor}",
+              requiresEquals: true,
               description:
                 "The date of the post in the GMT timezone. Default is the value of $post_date",
               args: { name: "post_date_gmt" },
@@ -7001,42 +7351,49 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_content",
               insertValue: "--post_content={cursor}",
+              requiresEquals: true,
               description: "The post content. Default empty",
               args: { name: "post_content" },
             },
             {
               name: "--post_content_filtered",
               insertValue: "--post_content_filtered={cursor}",
+              requiresEquals: true,
               description: "The filtered post content. Default empty",
               args: { name: "post_content_filtered" },
             },
             {
               name: "--post_title",
               insertValue: "--post_title={cursor}",
+              requiresEquals: true,
               description: "The post title. Default empty",
               args: { name: "post_title" },
             },
             {
               name: "--post_excerpt",
               insertValue: "--post_excerpt={cursor}",
+              requiresEquals: true,
               description: "The post excerpt. Default empty",
               args: { name: "post_excerpt" },
             },
             {
               name: "--post_status",
               insertValue: "--post_status={cursor}",
+              requiresEquals: true,
               description: "The post status. Default ‘draft’",
               args: { name: "post_status" },
             },
             {
               name: "--post_type",
               insertValue: "--post_type={cursor}",
+              requiresEquals: true,
               description: "The post type. Default ‘post’",
               args: { name: "post_type" },
             },
             {
               name: "--comment_status",
               insertValue: "--comment_status={cursor}",
+              requiresEquals: true,
               description:
                 "Whether the post can accept comments. Accepts ‘open’ or ‘closed’. Default is the value of ‘default_comment_status’ option",
               args: {
@@ -7047,6 +7404,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--ping_status",
               insertValue: "--ping_status={cursor}",
+              requiresEquals: true,
               description:
                 "Whether the post can accept pings. Accepts ‘open’ or ‘closed’. Default is the value of ‘default_ping_status’ option",
               args: {
@@ -7057,12 +7415,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_password",
               insertValue: "--post_password={cursor}",
+              requiresEquals: true,
               description: "The password to access the post. Default empty",
               args: { name: "post_password" },
             },
             {
               name: "--post_name",
               insertValue: "--post_name={cursor}",
+              requiresEquals: true,
               description:
                 "The post name. Default is the sanitized post title when creating a new post",
               args: { name: "post_name" },
@@ -7070,6 +7430,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--to_ping",
               insertValue: "--to_ping={cursor}",
+              requiresEquals: true,
               description:
                 "Space or carriage return-separated list of URLs to ping. Default empty",
               args: { name: "to_ping" },
@@ -7077,6 +7438,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--pinged",
               insertValue: "--pinged={cursor}",
+              requiresEquals: true,
               description:
                 "Space or carriage return-separated list of URLs that have been pinged. Default empty",
               args: { name: "pinged" },
@@ -7084,6 +7446,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_modified",
               insertValue: "--post_modified={cursor}",
+              requiresEquals: true,
               description:
                 "The date when the post was last modified. Default is the current time",
               args: { name: "post_modified" },
@@ -7091,6 +7454,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_modified_gmt",
               insertValue: "--post_modified_gmt={cursor}",
+              requiresEquals: true,
               description:
                 "The date when the post was last modified in the GMT timezone. Default is the current time",
               args: { name: "post_modified_gmt" },
@@ -7098,6 +7462,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_parent",
               insertValue: "--post_parent={cursor}",
+              requiresEquals: true,
               description:
                 "Set this for the post it belongs to, if any. Default 0",
               args: {
@@ -7108,6 +7473,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--menu_order",
               insertValue: "--menu_order={cursor}",
+              requiresEquals: true,
               description:
                 "The order the post should be displayed in. Default 0",
               args: {
@@ -7118,12 +7484,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_mime_type",
               insertValue: "--post_mime_type={cursor}",
+              requiresEquals: true,
               description: "The mime type of the post. Default empty",
               args: { name: "post_mime_type" },
             },
             {
               name: "--guid",
               insertValue: "--guid={cursor}",
+              requiresEquals: true,
               description:
                 "Global Unique ID for referencing the post. Default empty",
               args: { name: "guid" },
@@ -7131,6 +7499,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_category",
               insertValue: "--post_category={cursor}",
+              requiresEquals: true,
               description:
                 "Array of category names, slugs, or IDs. Defaults to value of the ‘default_category’ option",
               args: { name: "post_category" },
@@ -7138,12 +7507,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--tags_input",
               insertValue: "--tags_input={cursor}",
+              requiresEquals: true,
               description: "Array of tag names, slugs, or IDs. Default empty",
               args: { name: "tags_input" },
             },
             {
               name: "--tax_input",
               insertValue: "--tax_input={cursor}",
+              requiresEquals: true,
               description:
                 "Array of taxonomy terms keyed by their taxonomy name. Default empty",
               args: { name: "tax_input" },
@@ -7151,6 +7522,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--meta_input",
               insertValue: "--meta_input={cursor}",
+              requiresEquals: true,
               description:
                 "Array in JSON format of post meta values keyed by their post meta key. Default empty",
               args: { name: "meta_input" },
@@ -7158,6 +7530,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "One or more fields to update. See wp_insert_post()",
             },
             {
@@ -7205,6 +7578,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Instead of returning the whole taxonomy, returns the value of a single field",
               args: { name: "field" },
@@ -7212,6 +7586,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -7219,6 +7594,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7245,6 +7621,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Prints the value of a single field for each post type",
               args: { name: "field" },
@@ -7252,12 +7629,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific post type fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7310,6 +7689,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--hook",
               insertValue: "--hook={cursor}",
+              requiresEquals: true,
               description:
                 "Focus on key metrics for all hooks, or callbacks on a specific hook",
               args: { name: "hook" },
@@ -7317,12 +7697,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Display one or more fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7337,6 +7719,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--order",
               insertValue: "--order={cursor}",
+              requiresEquals: true,
               description: "Ascending or descending order",
               args: {
                 name: "order",
@@ -7346,6 +7729,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--orderby",
               insertValue: "--orderby={cursor}",
+              requiresEquals: true,
               description: "Order by fields",
               args: { name: "orderby" },
             },
@@ -7363,6 +7747,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--hook",
               insertValue: "--hook={cursor}",
+              requiresEquals: true,
               description:
                 "Focus on key metrics for all hooks, or callbacks on a specific hook",
               args: { name: "hook" },
@@ -7370,12 +7755,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Display one or more fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7390,6 +7777,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--order",
               insertValue: "--order={cursor}",
+              requiresEquals: true,
               description: "Ascending or descending order",
               args: {
                 name: "order",
@@ -7399,6 +7787,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--orderby",
               insertValue: "--orderby={cursor}",
+              requiresEquals: true,
               description: "Order by fields",
               args: { name: "orderby" },
             },
@@ -7425,6 +7814,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--url",
               insertValue: "--url={cursor}",
+              requiresEquals: true,
               description:
                 "Execute a request against a specified URL. Defaults to the home URL",
               args: { name: "url" },
@@ -7432,12 +7822,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Display one or more fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7452,6 +7844,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--order",
               insertValue: "--order={cursor}",
+              requiresEquals: true,
               description: "Ascending or descending order",
               args: {
                 name: "order",
@@ -7461,6 +7854,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--orderby",
               insertValue: "--orderby={cursor}",
+              requiresEquals: true,
               description: "Order by fields",
               args: { name: "orderby" },
             },
@@ -7486,6 +7880,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--url",
               insertValue: "--url={cursor}",
+              requiresEquals: true,
               description:
                 "Execute a request against a specified URL. Defaults to the home URL",
               args: { name: "url" },
@@ -7493,6 +7888,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Default is all fields",
               args: { name: "fields" },
@@ -7500,6 +7896,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7514,6 +7911,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--order",
               insertValue: "--order={cursor}",
+              requiresEquals: true,
               description: "Ascending or descending order",
               args: {
                 name: "order",
@@ -7523,6 +7921,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--orderby",
               insertValue: "--orderby={cursor}",
+              requiresEquals: true,
               description: "Order by fields",
               args: { name: "orderby" },
             },
@@ -7574,18 +7973,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--match",
               insertValue: "--match={cursor}",
+              requiresEquals: true,
               description: "Show rewrite rules matching a particular URL",
               args: { name: "url" },
             },
             {
               name: "--source",
               insertValue: "--source={cursor}",
+              requiresEquals: true,
               description: "Show rewrite rules from a particular source",
               args: { name: "source" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to match,query,source",
               args: { name: "fields" },
@@ -7593,6 +7995,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7618,6 +8021,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--category-base",
               insertValue: "--category-base={cursor}",
+              requiresEquals: true,
               description:
                 "Set the base for category permalinks, i.e. ‘/category/’",
               args: { name: "base" },
@@ -7625,6 +8029,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--tag-base",
               insertValue: "--tag-base={cursor}",
+              requiresEquals: true,
               description: "Set the base for tag permalinks, i.e. ‘/tag/’",
               args: { name: "base" },
             },
@@ -7680,6 +8085,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--clone",
               insertValue: "--clone={cursor}",
+              requiresEquals: true,
               description: "Clone capabilities from an existing role",
               args: { name: "role" },
             },
@@ -7708,18 +8114,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific row fields",
               args: { name: "fields" },
             },
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field",
               args: { name: "field" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -7788,12 +8197,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--title",
               insertValue: "--title={cursor}",
+              requiresEquals: true,
               description: "The display title for your block",
               args: { name: "title" },
             },
             {
               name: "--dashicon",
               insertValue: "--dashicon={cursor}",
+              requiresEquals: true,
               description:
                 "The dashicon to make it easier to identify your block",
               args: { name: "dashicon" },
@@ -7801,6 +8212,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--category",
               insertValue: "--category={cursor}",
+              requiresEquals: true,
               description:
                 "The category name to help users browse and discover your block",
               args: {
@@ -7822,6 +8234,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--plugin",
               insertValue: "--plugin={cursor}",
+              requiresEquals: true,
               description: "Create files in the given plugin’s directory",
               args: { name: "plugin" },
             },
@@ -7842,6 +8255,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--parent_theme",
               insertValue: "--parent_theme={cursor}",
+              requiresEquals: true,
               description:
                 "What to put in the ‘Template:’ header in ‘style.css’",
               args: { name: "slug" },
@@ -7849,6 +8263,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--theme_name",
               insertValue: "--theme_name={cursor}",
+              requiresEquals: true,
               description:
                 "What to put in the ‘Theme Name:’ header in ‘style.css’",
               args: { name: "title" },
@@ -7856,12 +8271,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--author",
               insertValue: "--author={cursor}",
+              requiresEquals: true,
               description: "What to put in the ‘Author:’ header in ‘style.css’",
               args: { name: "full-name" },
             },
             {
               name: "--author_uri",
               insertValue: "--author_uri={cursor}",
+              requiresEquals: true,
               description:
                 "What to put in the ‘Author URI:’ header in ‘style.css’",
               args: { name: "uri" },
@@ -7869,6 +8286,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--theme_uri",
               insertValue: "--theme_uri={cursor}",
+              requiresEquals: true,
               description:
                 "What to put in the ‘Theme URI:’ header in ‘style.css’",
               args: { name: "uri" },
@@ -7899,6 +8317,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dir",
               insertValue: "--dir={cursor}",
+              requiresEquals: true,
               description:
                 "Put the new plugin in some arbitrary directory path. Plugin directory will be path plus supplied slug",
               args: { name: "dirname", template: "folders" },
@@ -7906,30 +8325,35 @@ const completionSpec: Fig.Spec = {
             {
               name: "--plugin_name",
               insertValue: "--plugin_name={cursor}",
+              requiresEquals: true,
               description: "What to put in the ‘Plugin Name:’ header",
               args: { name: "title" },
             },
             {
               name: "--plugin_description",
               insertValue: "--plugin_description={cursor}",
+              requiresEquals: true,
               description: "What to put in the ‘Description:’ header",
               args: { name: "description" },
             },
             {
               name: "--plugin_author",
               insertValue: "--plugin_author={cursor}",
+              requiresEquals: true,
               description: "What to put in the ‘Author:’ header",
               args: { name: "author" },
             },
             {
               name: "--plugin_author_uri",
               insertValue: "--plugin_author_uri={cursor}",
+              requiresEquals: true,
               description: "What to put in the ‘Author URI:’ header",
               args: { name: "uri" },
             },
             {
               name: "--plugin_uri",
               insertValue: "--plugin_uri={cursor}",
+              requiresEquals: true,
               description: "What to put in the ‘Plugin URI:’ header",
               args: { name: "uri" },
             },
@@ -7940,6 +8364,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--ci",
               insertValue: "--ci={cursor}",
+              requiresEquals: true,
               description:
                 "Choose a configuration file for a continuous integration provider",
               args: {
@@ -7977,6 +8402,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dir",
               insertValue: "--dir={cursor}",
+              requiresEquals: true,
               description:
                 "Generate test files for a non-standard plugin path. If no plugin slug is specified, the directory name is used",
               args: { name: "dirname", template: "folders" },
@@ -7984,6 +8410,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--ci",
               insertValue: "--ci={cursor}",
+              requiresEquals: true,
               description:
                 "Choose a configuration file for a continuous integration provider",
               args: {
@@ -8013,18 +8440,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--label",
               insertValue: "--label={cursor}",
+              requiresEquals: true,
               description: "The text used to translate the update messages",
               args: { name: "label" },
             },
             {
               name: "--textdomain",
               insertValue: "--textdomain={cursor}",
+              requiresEquals: true,
               description: "The textdomain to use for the labels",
               args: { name: "textdomain" },
             },
             {
               name: "--dashicon",
               insertValue: "--dashicon={cursor}",
+              requiresEquals: true,
               description: "The dashicon to use in the menu",
               args: { name: "dashicon" },
             },
@@ -8036,6 +8466,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--plugin",
               insertValue: "--plugin={cursor}",
+              requiresEquals: true,
               description:
                 "Create a file in the given plugin’s directory, instead of sending to STDOUT",
               args: { name: "plugin" },
@@ -8062,18 +8493,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--post_types",
               insertValue: "--post_types={cursor}",
+              requiresEquals: true,
               description: "Post types to register for use with the taxonomy",
               args: { name: "post_types" },
             },
             {
               name: "--label",
               insertValue: "--label={cursor}",
+              requiresEquals: true,
               description: "The text used to translate the update messages",
               args: { name: "label" },
             },
             {
               name: "--textdomain",
               insertValue: "--textdomain={cursor}",
+              requiresEquals: true,
               description: "The textdomain to use for the labels",
               args: { name: "textdomain" },
             },
@@ -8085,6 +8519,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--plugin",
               insertValue: "--plugin={cursor}",
+              requiresEquals: true,
               description:
                 "Create a file in the given plugin’s directory, instead of sending to STDOUT",
               args: { name: "plugin" },
@@ -8112,6 +8547,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--dir",
               insertValue: "--dir={cursor}",
+              requiresEquals: true,
               description:
                 "Generate test files for a non-standard theme path. If no theme slug is specified, the directory name is used",
               args: { name: "dirname", template: "folders" },
@@ -8119,6 +8555,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--ci",
               insertValue: "--ci={cursor}",
+              requiresEquals: true,
               description:
                 "Choose a configuration file for a continuous integration provider",
               args: {
@@ -8158,6 +8595,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--theme_name",
               insertValue: "--theme_name={cursor}",
+              requiresEquals: true,
               description:
                 "What to put in the ‘Theme Name:’ header in ‘style.css’",
               args: { name: "title" },
@@ -8165,12 +8603,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--author",
               insertValue: "--author={cursor}",
+              requiresEquals: true,
               description: "What to put in the ‘Author:’ header in ‘style.css’",
               args: { name: "full-name" },
             },
             {
               name: "--author_uri",
               insertValue: "--author_uri={cursor}",
+              requiresEquals: true,
               description:
                 "What to put in the ‘Author URI:’ header in ‘style.css’",
               args: { name: "uri" },
@@ -8210,6 +8650,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--theme_name",
               insertValue: "--theme_name={cursor}",
+              requiresEquals: true,
               description:
                 "What to put in the ‘Theme Name:’ header in ‘style.css’",
               args: { name: "title" },
@@ -8217,12 +8658,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--author",
               insertValue: "--author={cursor}",
+              requiresEquals: true,
               description: "What to put in the ‘Author:’ header in ‘style.css’",
               args: { name: "full-name" },
             },
             {
               name: "--author_uri",
               insertValue: "--author_uri={cursor}",
+              requiresEquals: true,
               description:
                 "What to put in the ‘Author URI:’ header in ‘style.css’",
               args: { name: "uri" },
@@ -8286,6 +8729,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--export",
           insertValue: "--export={cursor}",
+          requiresEquals: true,
           description:
             "Write transformed data as SQL file instead of saving replacements to the database. If <file> is not supplied, will output to STDOUT",
           args: { name: "file" },
@@ -8293,6 +8737,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--export_insert_size",
           insertValue: "--export_insert_size={cursor}",
+          requiresEquals: true,
           description:
             "Define number of rows in single INSERT statement when doing SQL export. You might want to change this depending on your database configuration (e.g. if you need to do fewer queries). Default: 50",
           args: {
@@ -8303,6 +8748,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--skip-tables",
           insertValue: "--skip-tables={cursor}",
+          requiresEquals: true,
           description:
             "Do not perform the replacement on specific tables. Use commas to specify multiple tables. Wildcards are supported, e.g. 'wp_*options' or 'wp_post*'",
           args: { name: "tables" },
@@ -8310,6 +8756,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--skip-columns",
           insertValue: "--skip-columns={cursor}",
+          requiresEquals: true,
           description:
             "Do not perform the replacement on specific columns. Use commas to specify multiple columns",
           args: { name: "columns" },
@@ -8317,6 +8764,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--include-columns",
           insertValue: "--include-columns={cursor}",
+          requiresEquals: true,
           description:
             "Perform the replacement on specific columns. Use commas to specify multiple columns",
           args: { name: "columns" },
@@ -8348,6 +8796,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--regex-flags",
           insertValue: "--regex-flags={cursor}",
+          requiresEquals: true,
           description:
             "Pass PCRE modifiers to regex search-replace (e.g. ‘i’ for case-insensitivity)",
           args: { name: "regex-flags" },
@@ -8355,6 +8804,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--regex-delimiter",
           insertValue: "--regex-delimiter={cursor}",
+          requiresEquals: true,
           description:
             "The delimiter to use for the regex. It must be escaped if it appears in the search string. The default value is the result of chr(1)",
           args: { name: "regex-delimiter" },
@@ -8362,6 +8812,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--regex-limit",
           insertValue: "--regex-limit={cursor}",
+          requiresEquals: true,
           description:
             "The maximum possible replacements for the regex per row (or per unserialized data bit per row). Defaults to -1 (no limit)",
           args: { name: "regex-limit" },
@@ -8369,6 +8820,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--format",
           insertValue: "--format={cursor}",
+          requiresEquals: true,
           description: "Render output in a particular format",
           args: {
             name: "format",
@@ -8387,7 +8839,9 @@ const completionSpec: Fig.Spec = {
         {
           name: "--log",
           displayName: "--log={cursor}",
+          requiresEquals: true,
           insertValue: "--log={cursor}",
+          requiresEquals: true,
           description:
             "Log the items changed. If <file> is not supplied or is “-“, will output to STDOUT. Warning: causes a significant slow down, similar or worse to enabling –precise or –regex",
           args: { name: "file", isOptional: true },
@@ -8395,6 +8849,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--before_context",
           insertValue: "--before_context={cursor}",
+          requiresEquals: true,
           description:
             "For logging, number of characters to display before the old match and the new replacement. Default 40. Ignored if not logging",
           args: { name: "num" },
@@ -8402,6 +8857,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--after_context",
           insertValue: "--after_context={cursor}",
+          requiresEquals: true,
           description:
             "For logging, number of characters to display after the old match and the new replacement. Default 40. Ignored if not logging",
           args: { name: "num" },
@@ -8435,6 +8891,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--host",
           insertValue: "--host={cursor}",
+          requiresEquals: true,
           description: "The hostname to bind the server to",
           args: {
             name: "host",
@@ -8444,6 +8901,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--port",
           insertValue: "--port={cursor}",
+          requiresEquals: true,
           description: "The port number to bind the server to",
           args: {
             name: "port",
@@ -8453,6 +8911,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--docroot",
           insertValue: "--docroot={cursor}",
+          requiresEquals: true,
           description:
             "The path to use as the document root. If the path global parameter is set, the default value is it",
           args: { name: "path", template: "folders" },
@@ -8460,6 +8919,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--config",
           insertValue: "--config={cursor}",
+          requiresEquals: true,
           description: "Config the server with a specific .ini file",
           args: { name: "file" },
         },
@@ -8547,12 +9007,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific row fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -8619,6 +9081,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--slug",
               insertValue: "--slug={cursor}",
+              requiresEquals: true,
               description:
                 "Path for the new site. Subdomain on subdomain installs, directory on subdirectory installs",
               args: { name: "slug" },
@@ -8626,12 +9089,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--title",
               insertValue: "--title={cursor}",
+              requiresEquals: true,
               description: "Title of the new site. Default: prettified slug",
               args: { name: "title" },
             },
             {
               name: "--email",
               insertValue: "--email={cursor}",
+              requiresEquals: true,
               description:
                 "Email for Admin user. User will be created if none exists. Assignment to Super Admin if not included",
               args: { name: "email" },
@@ -8639,6 +9104,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--network_id",
               insertValue: "--network_id={cursor}",
+              requiresEquals: true,
               description:
                 "Network to associate new site with. Defaults to current network (typically 1)",
               args: { name: "network-id" },
@@ -8674,6 +9140,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--slug",
               insertValue: "--slug={cursor}",
+              requiresEquals: true,
               description:
                 "Path of the blog to be deleted. Subdomain on subdomain installs, directory on subdirectory installs",
               args: { name: "slug" },
@@ -8713,6 +9180,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--network",
               insertValue: "--network={cursor}",
+              requiresEquals: true,
               description: "The network to which the sites belong",
               args: { name: "id" },
             },
@@ -8724,6 +9192,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--site_in",
               insertValue: "--site_in={cursor}",
+              requiresEquals: true,
               description:
                 "Only list the sites with these blog_id values (comma-separated)",
               args: { name: "value" },
@@ -8731,18 +9200,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each site",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Comma-separated list of fields to show",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -8792,6 +9264,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -8842,6 +9315,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -8865,12 +9339,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--keys",
                   insertValue: "--keys={cursor}",
+                  requiresEquals: true,
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: {
@@ -8881,6 +9357,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -8896,6 +9373,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--orderby",
                   insertValue: "--orderby={cursor}",
+                  requiresEquals: true,
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -8909,6 +9387,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--order",
                   insertValue: "--order={cursor}",
+                  requiresEquals: true,
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -8957,6 +9436,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -8987,6 +9467,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -9021,6 +9502,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9054,6 +9536,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9081,6 +9564,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -9100,30 +9584,35 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--search",
                   insertValue: "--search={cursor}",
+                  requiresEquals: true,
                   description: "Use wildcards ( * and ? ) to match option name",
                   args: { name: "pattern" },
                 },
                 {
                   name: "--site_id",
                   insertValue: "--site_id={cursor}",
+                  requiresEquals: true,
                   description: "Limit options to those of a particular site id",
                   args: { name: "id" },
                 },
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Prints the value of a single field",
                   args: { name: "field" },
                 },
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific object fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description:
                     "The serialization format for the value. total_bytes displays the total size of matching options in bytes",
                   args: {
@@ -9172,6 +9661,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9198,6 +9688,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -9228,6 +9719,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9337,6 +9829,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9398,6 +9891,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Instead of returning the whole taxonomy, returns the value of a single field",
               args: { name: "field" },
@@ -9405,6 +9899,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -9412,6 +9907,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9438,6 +9934,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Prints the value of a single field for each taxonomy",
               args: { name: "field" },
@@ -9445,12 +9942,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific taxonomy fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9510,6 +10009,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--slug",
               insertValue: "--slug={cursor}",
+              requiresEquals: true,
               description:
                 "A unique slug for the new term. Defaults to sanitized version of name",
               args: { name: "slug" },
@@ -9517,12 +10017,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--description",
               insertValue: "--description={cursor}",
+              requiresEquals: true,
               description: "A description for the new term",
               args: { name: "description" },
             },
             {
               name: "--parent",
               insertValue: "--parent={cursor}",
+              requiresEquals: true,
               description: "A parent for the new term",
               args: { name: "term-id" },
             },
@@ -9549,6 +10051,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--by",
               insertValue: "--by={cursor}",
+              requiresEquals: true,
               description: "Explicitly handle the term value as a slug or id",
               args: {
                 name: "field",
@@ -9568,6 +10071,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--count",
               insertValue: "--count={cursor}",
+              requiresEquals: true,
               description: "How many terms to generate?",
               args: {
                 name: "number",
@@ -9577,6 +10081,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--max_depth",
               insertValue: "--max_depth={cursor}",
+              requiresEquals: true,
               description: "Generate child terms down to a certain depth",
               args: {
                 name: "number",
@@ -9586,6 +10091,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9611,6 +10117,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--by",
               insertValue: "--by={cursor}",
+              requiresEquals: true,
               description: "Explicitly handle the term value as a slug or id",
               args: {
                 name: "field",
@@ -9620,6 +10127,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Instead of returning the whole term, returns the value of a single field",
               args: { name: "field" },
@@ -9627,6 +10135,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -9634,6 +10143,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Get value in a particular format",
               args: {
                 name: "format",
@@ -9664,18 +10174,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each term",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -9717,6 +10230,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9767,6 +10281,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Get value in a particular format",
                   args: {
                     name: "format",
@@ -9790,12 +10305,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--keys",
                   insertValue: "--keys={cursor}",
+                  requiresEquals: true,
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: {
@@ -9806,6 +10323,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -9821,6 +10339,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--orderby",
                   insertValue: "--orderby={cursor}",
+                  requiresEquals: true,
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -9834,6 +10353,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--order",
                   insertValue: "--order={cursor}",
+                  requiresEquals: true,
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -9882,6 +10402,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9912,6 +10433,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -9946,6 +10468,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -9967,6 +10490,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--by",
               insertValue: "--by={cursor}",
+              requiresEquals: true,
               description: "Explicitly handle the term value as a slug or id",
               args: {
                 name: "field",
@@ -9976,12 +10500,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--from",
               insertValue: "--from={cursor}",
+              requiresEquals: true,
               description: "Taxonomy slug of the term to migrate",
               args: { name: "taxonomy" },
             },
             {
               name: "--to",
               insertValue: "--to={cursor}",
+              requiresEquals: true,
               description: "Taxonomy slug to migrate to",
               args: { name: "taxonomy" },
             },
@@ -10012,6 +10538,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--by",
               insertValue: "--by={cursor}",
+              requiresEquals: true,
               description: "Explicitly handle the term value as a slug or id",
               args: {
                 name: "field",
@@ -10021,24 +10548,28 @@ const completionSpec: Fig.Spec = {
             {
               name: "--name",
               insertValue: "--name={cursor}",
+              requiresEquals: true,
               description: "A new name for the term",
               args: { name: "name" },
             },
             {
               name: "--slug",
               insertValue: "--slug={cursor}",
+              requiresEquals: true,
               description: "A new slug for the term",
               args: { name: "slug" },
             },
             {
               name: "--description",
               insertValue: "--description={cursor}",
+              requiresEquals: true,
               description: "A new description for the term",
               args: { name: "description" },
             },
             {
               name: "--parent",
               insertValue: "--parent={cursor}",
+              requiresEquals: true,
               description: "A new parent for the term",
               args: { name: "term-id" },
             },
@@ -10151,6 +10682,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Only show the provided field",
                   args: { name: "field" },
                 },
@@ -10223,6 +10755,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Instead of returning the whole theme, returns the value of a single field",
               args: { name: "field" },
@@ -10230,6 +10763,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Limit the output to specific fields. Defaults to all fields",
               args: { name: "fields" },
@@ -10237,6 +10771,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10262,6 +10797,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--version",
               insertValue: "--version={cursor}",
+              requiresEquals: true,
               description:
                 "If set, get that particular version from wordpress.org, instead of the stable version",
               args: { name: "version" },
@@ -10311,18 +10847,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each theme",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10338,6 +10877,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--status",
               insertValue: "--status={cursor}",
+              requiresEquals: true,
               description: "Filter the output by theme status",
               args: {
                 name: "status",
@@ -10365,6 +10905,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Returns the value of a single field",
                 },
                 {
@@ -10374,6 +10915,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -10394,12 +10936,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description: "Returns the value of a single field",
                   args: { name: "field" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -10470,6 +11014,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--page",
               insertValue: "--page={cursor}",
+              requiresEquals: true,
               description: "Optional page to display",
               args: {
                 name: "page",
@@ -10479,6 +11024,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--per-page",
               insertValue: "--per-page={cursor}",
+              requiresEquals: true,
               description:
                 "Optional number of results to display. Defaults to 10",
               args: {
@@ -10489,12 +11035,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each theme",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description:
                 "Ask for specific fields from the API. Defaults to name,slug,author,rating",
               args: {
@@ -10539,6 +11087,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10577,6 +11126,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--exclude",
               insertValue: "--exclude={cursor}",
+              requiresEquals: true,
               description:
                 "Comma separated list of theme names that should be excluded from updating",
               args: { name: "theme-names" },
@@ -10584,6 +11134,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10598,6 +11149,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--version",
               insertValue: "--version={cursor}",
+              requiresEquals: true,
               description:
                 "If set, the theme will be updated to the specified version",
               args: { name: "version" },
@@ -10675,6 +11227,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10700,12 +11253,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--search",
               insertValue: "--search={cursor}",
+              requiresEquals: true,
               description: "Use wildcards ( * and ? ) to match transient name",
               args: { name: "pattern" },
             },
             {
               name: "--exclude",
               insertValue: "--exclude={cursor}",
+              requiresEquals: true,
               description:
                 "Pattern to exclude. Use wildcards ( * and ? ) to match transient name",
               args: { name: "pattern" },
@@ -10726,12 +11281,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -10871,6 +11428,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--role",
               insertValue: "--role={cursor}",
+              requiresEquals: true,
               description:
                 "The role of the user to create. Default: default role. Possible values include ‘administrator’, ‘editor’, ‘author’, ‘contributor’, ‘subscriber’",
               args: {
@@ -10887,12 +11445,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--user_pass",
               insertValue: "--user_pass={cursor}",
+              requiresEquals: true,
               description: "The user password. Default: randomly generated",
               args: { name: "password" },
             },
             {
               name: "--user_registered",
               insertValue: "--user_registered={cursor}",
+              requiresEquals: true,
               description:
                 "The date the user registered. Default: current date",
               args: { name: "yyyy-mm-dd-hh-ii-ss" },
@@ -10900,12 +11460,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--display_name",
               insertValue: "--display_name={cursor}",
+              requiresEquals: true,
               description: "The display name",
               args: { name: "name" },
             },
             {
               name: "--user_nicename",
               insertValue: "--user_nicename={cursor}",
+              requiresEquals: true,
               description:
                 "A string that contains a URL-friendly name for the user. The default is the user’s username",
               args: { name: "nice_name" },
@@ -10913,6 +11475,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--user_url",
               insertValue: "--user_url={cursor}",
+              requiresEquals: true,
               description:
                 "A string containing the user’s URL for the user’s web site",
               args: { name: "url" },
@@ -10920,6 +11483,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--nickname",
               insertValue: "--nickname={cursor}",
+              requiresEquals: true,
               description:
                 "The user’s nickname, defaults to the user’s username",
               args: { name: "nickname" },
@@ -10927,24 +11491,28 @@ const completionSpec: Fig.Spec = {
             {
               name: "--first_name",
               insertValue: "--first_name={cursor}",
+              requiresEquals: true,
               description: "The user’s first name",
               args: { name: "first_name" },
             },
             {
               name: "--last_name",
               insertValue: "--last_name={cursor}",
+              requiresEquals: true,
               description: "The user’s last name",
               args: { name: "last_name" },
             },
             {
               name: "--description",
               insertValue: "--description={cursor}",
+              requiresEquals: true,
               description: "A string containing content about the user",
               args: { name: "description" },
             },
             {
               name: "--rich_editing",
               insertValue: "--rich_editing={cursor}",
+              requiresEquals: true,
               description:
                 "A string for whether to enable the rich editor or not. False if not empty",
               args: { name: "rich_editing" },
@@ -10977,6 +11545,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--reassign",
               insertValue: "--reassign={cursor}",
+              requiresEquals: true,
               description: "User ID to reassign the posts to",
               args: { name: "user-id" },
             },
@@ -10993,6 +11562,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--count",
               insertValue: "--count={cursor}",
+              requiresEquals: true,
               description: "How many users to generate?",
               args: {
                 name: "number",
@@ -11002,6 +11572,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--role",
               insertValue: "--role={cursor}",
+              requiresEquals: true,
               description:
                 "The role of the generated users. Default: default role from WP",
               args: { name: "role" },
@@ -11009,6 +11580,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11028,6 +11600,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "Instead of returning the whole user, returns the value of a single field",
               args: { name: "field" },
@@ -11035,12 +11608,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Get a specific subset of the user’s fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11081,6 +11656,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--role",
               insertValue: "--role={cursor}",
+              requiresEquals: true,
               description: "Only display users with a certain role",
               args: { name: "role" },
             },
@@ -11097,18 +11673,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description: "Prints the value of a single field for each user",
               args: { name: "field" },
             },
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific object fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11135,6 +11714,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11176,6 +11756,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -11222,6 +11803,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -11247,12 +11829,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--keys",
                   insertValue: "--keys={cursor}",
+                  requiresEquals: true,
                   description: "Limit output to metadata of specific keys",
                   args: { name: "keys" },
                 },
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description:
                     "Limit the output to specific row fields. Defaults to id,meta_key,meta_value",
                   args: {
@@ -11263,6 +11847,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -11278,6 +11863,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--orderby",
                   insertValue: "--orderby={cursor}",
+                  requiresEquals: true,
                   description: "Set orderby which field",
                   args: {
                     name: "fields",
@@ -11291,6 +11877,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--order",
                   insertValue: "--order={cursor}",
+                  requiresEquals: true,
                   description: "Set ascending or descending order",
                   args: {
                     name: "order",
@@ -11339,6 +11926,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -11369,6 +11957,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The output format of the value",
                   args: {
                     name: "format",
@@ -11403,6 +11992,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "The serialization format for the value",
                   args: {
                     name: "format",
@@ -11492,12 +12082,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -11563,6 +12155,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--by",
                   insertValue: "--by={cursor}",
+                  requiresEquals: true,
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -11589,6 +12182,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--field",
                   insertValue: "--field={cursor}",
+                  requiresEquals: true,
                   description:
                     "Prints the value of a single field for each term",
                   args: { name: "field" },
@@ -11596,12 +12190,14 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--fields",
                   insertValue: "--fields={cursor}",
+                  requiresEquals: true,
                   description: "Limit the output to specific row fields",
                   args: { name: "fields" },
                 },
                 {
                   name: "--format",
                   insertValue: "--format={cursor}",
+                  requiresEquals: true,
                   description: "Render output in a particular format",
                   args: {
                     name: "format",
@@ -11639,6 +12235,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--by",
                   insertValue: "--by={cursor}",
+                  requiresEquals: true,
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -11673,6 +12270,7 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--by",
                   insertValue: "--by={cursor}",
+                  requiresEquals: true,
                   description:
                     "Explicitly handle the term value as a slug or id",
                   args: {
@@ -11704,6 +12302,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--user_pass",
               insertValue: "--user_pass={cursor}",
+              requiresEquals: true,
               description:
                 "A string that contains the plain text password for the user",
               args: { name: "password" },
@@ -11711,6 +12310,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--user_nicename",
               insertValue: "--user_nicename={cursor}",
+              requiresEquals: true,
               description:
                 "A string that contains a URL-friendly name for the user. The default is the user’s username",
               args: { name: "nice_name" },
@@ -11718,6 +12318,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--user_url",
               insertValue: "--user_url={cursor}",
+              requiresEquals: true,
               description:
                 "A string containing the user’s URL for the user’s web site",
               args: { name: "url" },
@@ -11725,18 +12326,21 @@ const completionSpec: Fig.Spec = {
             {
               name: "--user_email",
               insertValue: "--user_email={cursor}",
+              requiresEquals: true,
               description: "A string containing the user’s email address",
               args: { name: "email" },
             },
             {
               name: "--display_name",
               insertValue: "--display_name={cursor}",
+              requiresEquals: true,
               description: "The display name",
               args: { name: "display_name" },
             },
             {
               name: "--nickname",
               insertValue: "--nickname={cursor}",
+              requiresEquals: true,
               description:
                 "The user’s nickname, defaults to the user’s username",
               args: { name: "nickname" },
@@ -11744,24 +12348,28 @@ const completionSpec: Fig.Spec = {
             {
               name: "--first_name",
               insertValue: "--first_name={cursor}",
+              requiresEquals: true,
               description: "The user’s first name",
               args: { name: "first_name" },
             },
             {
               name: "--last_name",
               insertValue: "--last_name={cursor}",
+              requiresEquals: true,
               description: "The user’s last name",
               args: { name: "last_name" },
             },
             {
               name: "--description",
               insertValue: "--description={cursor}",
+              requiresEquals: true,
               description: "A string containing content about the user",
               args: { name: "description" },
             },
             {
               name: "--rich_editing",
               insertValue: "--rich_editing={cursor}",
+              requiresEquals: true,
               description:
                 "A string for whether to enable the rich editor or not. False if not empty",
               args: { name: "rich_editing" },
@@ -11769,6 +12377,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--user_registered",
               insertValue: "--user_registered={cursor}",
+              requiresEquals: true,
               description:
                 "The date the user registered. Default: current date",
               args: { name: "yyyy-mm-dd-hh-ii-ss" },
@@ -11776,12 +12385,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--role",
               insertValue: "--role={cursor}",
+              requiresEquals: true,
               description: "A string used to set the user’s role",
               args: { name: "role" },
             },
             {
               name: "--field",
               insertValue: "--field={cursor}",
+              requiresEquals: true,
               description:
                 "One or more fields to update. For accepted fields, see wp_update_user()",
               args: { name: "field" },
@@ -11873,12 +12484,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--fields",
               insertValue: "--fields={cursor}",
+              requiresEquals: true,
               description: "Limit the output to specific row fields",
               args: { name: "fields" },
             },
             {
               name: "--format",
               insertValue: "--format={cursor}",
+              requiresEquals: true,
               description: "Render output in a particular format",
               args: {
                 name: "format",
@@ -11905,12 +12518,14 @@ const completionSpec: Fig.Spec = {
             {
               name: "--position",
               insertValue: "--position={cursor}",
+              requiresEquals: true,
               description: "Assign the widget to a new position",
               args: { name: "position" },
             },
             {
               name: "--sidebar-id",
               insertValue: "--sidebar-id={cursor}",
+              requiresEquals: true,
               description: "Assign the widget to a new sidebars",
               args: { name: "sidebar-id" },
             },


### PR DESCRIPTION
Related: https://github.com/withfig/fig/issues/1031

This was a quick regex find-replace, please let me know if I missed anything.