### PR TITLE
feat: add `projj` spec

### DIFF
--- a/src/projj.ts
+++ b/src/projj.ts
@@ -1,0 +1,72 @@
+const repoGenerator: Fig.Generator = {
+  script: "cat ~/.projj/cache.json",
+  postProcess: function (out) {
+    const cache = JSON.parse(out);
+    return Object.keys(cache).map((key) => ({
+      name: key.split("/").pop(),
+      description: cache[key].repo,
+    }));
+  },
+};
+
+const completionSpec: Fig.Spec = {
+  name: "projj",
+  description: "Manage repository easily",
+  subcommands: [
+    {
+      name: "completion",
+      description: "Generate completion script",
+    },
+    {
+      name: "add",
+      description: "Add repository",
+      args: {
+        name: "repository url",
+      },
+    },
+    {
+      name: "find",
+      description: "Find repository",
+      args: {
+        name: "repository name",
+        generators: repoGenerator,
+      },
+    },
+    {
+      name: "import",
+      description: "Import repositories from existing directory",
+    },
+    {
+      name: "init",
+      description: "Initialize configuration",
+    },
+    {
+      name: "remove",
+      description: "Remove repository",
+    },
+    {
+      name: "run",
+      description: "Run hook in current directory",
+    },
+    {
+      name: "runall",
+      description: "Run hook in every repository",
+    },
+    {
+      name: "sync",
+      description: "Sync data from directory",
+    },
+  ],
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for projj",
+    },
+    {
+      name: ["--version", "-v"],
+      description: "Show version number",
+    },
+  ],
+};
+
+export default completionSpec;


### PR DESCRIPTION
### What kind of change does this PR introduce?

Feature: Add spec of [projj](https://github.com/popomore/projj) autocomplete.

[projj](https://github.com/popomore/projj) is an awesome opensource command line tool to manage git repository in local machine.

### What is the current behavior?

Currently, Fig shows no suggestions when using [projj](https://github.com/popomore/projj). 

However, it would be great if Fig can autocomplete the git repository name in `projj find` commands.

### What is the new behavior (if this is a feature change)?

<img width="720" alt="Screen Shot 2022-03-08 at 10 51 52" src="https://user-images.githubusercontent.com/21105863/157156880-6ff6db3f-0750-40ea-881a-7b38690b1162.png">


### Additional info:

For more information about `projj` command, please visit https://github.com/popomore/projj