### PR TITLE
feat(npm): improvements

### DIFF
--- a/src/npm.ts
+++ b/src/npm.ts
@@ -942,7 +942,18 @@ const completionSpec: Fig.Spec = {
     uninstallSubcommand("remove"),
     uninstallSubcommand("unlink"),
     { name: "unpublish", description: "Remove a package from the registry" },
-    { name: "unstar", description: "Unmark your package" },
+    {
+      name: "unstar",
+      description: "Remove an item from your favorite packages",
+      options: [
+        registryOption,
+        otpOption,
+        {
+          name: "--no-unicode",
+          description: "Do not use unicode characters in the tree output",
+        },
+      ],
+    },
     {
       name: ["update", "upgrade", "up"],
       description: "Update a package",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -856,6 +856,22 @@ const completionSpec: Fig.Spec = {
     { name: "search", description: "Search for packages" },
     { name: "set", description: "Sets the config key to the value" },
     {
+      name: "set-script",
+      description: "Set tasks in the scripts section of package.json",
+      args: [
+        {
+          name: "script",
+          description:
+            "Name of the task to be added to the scripts section of package.json",
+        },
+        {
+          name: "command",
+          description: "Command to run when script is called",
+        },
+      ],
+      options: workSpaceOptions,
+    },
+    {
       name: "shrinkwrap",
       description: "Lock down dependency versions for publication",
     },

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -876,6 +876,41 @@ const completionSpec: Fig.Spec = {
     {
       name: "team",
       description: "Manage organization teams and team memberships",
+      subcommands: [
+        {
+          name: "create",
+          args: { name: "scope:team" },
+          options: [registryOption, otpOption],
+        },
+        {
+          name: "destroy",
+          args: { name: "scope:team" },
+          options: [registryOption, otpOption],
+        },
+        {
+          name: "add",
+          args: [{ name: "scope:team" }, { name: "user" }],
+          options: [registryOption, otpOption],
+        },
+        {
+          name: "rm",
+          args: [{ name: "scope:team" }, { name: "user" }],
+          options: [registryOption, otpOption],
+        },
+        {
+          name: "ls",
+          args: { name: "scope|scope:team" },
+          options: [
+            registryOption,
+            jsonOption,
+            {
+              name: ["-p", "--parseable"],
+              description:
+                "Output parseable results from commands that write to standard output",
+            },
+          ],
+        },
+      ],
     },
     {
       name: ["test", "tst", "t"],

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -936,7 +936,6 @@ const completionSpec: Fig.Spec = {
       options: [registryOption, otpOption],
     },
     uninstallSubcommand("uninstall"),
-    uninstallSubcommand("remove"),
     uninstallSubcommand(["r", "rm"]),
     uninstallSubcommand("un"),
     uninstallSubcommand("remove"),

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -325,6 +325,13 @@ const ignoreScriptsOption: Fig.Option = {
     "If true, npm does not run scripts specified in package.json files",
 };
 
+const scriptShellOption: Fig.Option = {
+  name: "--script-shell",
+  description:
+    "The shell to use for scripts run with the npm exec, npm run and npm init <pkg> commands",
+  args: { name: "script-shell" },
+};
+
 const completionSpec: Fig.Spec = {
   name: "npm",
   parserDirectives: {
@@ -435,10 +442,7 @@ const completionSpec: Fig.Spec = {
           description: "",
         },
         ignoreScriptsOption,
-        {
-          name: "--script-shell",
-          args: { name: "shell" },
-        },
+        scriptShellOption,
       ],
       args: {
         name: "script",
@@ -593,11 +597,7 @@ const completionSpec: Fig.Spec = {
           exclusiveOn: ["--audit"],
         },
         ignoreScriptsOption,
-        {
-          name: "--script-shell",
-          description:
-            "The shell to use for scripts run with the npm exec, npm run and npm init <pkg> commands",
-        },
+        scriptShellOption,
       ],
     },
     {
@@ -864,13 +864,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "start",
       description: "Start a package",
-      options: [
-        ignoreScriptsOption,
-        {
-          name: "--script-shell",
-          args: { name: "shell" },
-        },
-      ],
+      options: [ignoreScriptsOption, scriptShellOption],
     },
     { name: "stop", description: "Stop a package" },
     {
@@ -915,15 +909,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["test", "tst", "t"],
       description: "Test a package",
-      options: [
-        ignoreScriptsOption,
-        {
-          name: "--script-shell",
-          description:
-            "The shell to use for scripts run with the npm exec, npm run and npm init <pkg> commands",
-          args: { name: "shell" },
-        },
-      ],
+      options: [ignoreScriptsOption, scriptShellOption],
     },
     {
       name: "token",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -829,8 +829,23 @@ const completionSpec: Fig.Spec = {
         otpOption,
       ],
     },
-    { name: "rb", description: "Rebuild a package" },
-    { name: "rebuild", description: "Rebuild a package" },
+    {
+      name: ["rebuild", "rb"],
+      description: "Rebuild a package",
+      args: {
+        name: "[<@scope>/]<pkg>[@<version>]",
+      },
+      options: [
+        globalOption,
+        ...workSpaceOptions,
+        ignoreScriptsOption,
+        {
+          name: "--no-bin-links",
+          description:
+            "Tells npm to not create symlinks (or .cmd shims on Windows) for package executables",
+        },
+      ],
+    },
     {
       name: "repo",
       description: "Open package repository page in the browser",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -536,8 +536,11 @@ const completionSpec: Fig.Spec = {
       name: ["bugs", "issues"],
       description: "Report bugs for a package in a web browser",
       args: {
-        name: "pkgname",
+        name: "package",
         isOptional: true,
+        generators: npmSearchGenerator,
+        debounce: true,
+        isVariadic: true,
       },
       options: [
         {

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -839,7 +839,23 @@ const completionSpec: Fig.Spec = {
         isOptional: true,
         generators: npmSearchGenerator,
         debounce: true,
+        isVariadic: true,
       },
+      options: [
+        ...workSpaceOptions,
+        {
+          name: "--no-browser",
+          description: "Display in command line instead of browser",
+          exclusiveOn: ["--browser"],
+        },
+        {
+          name: "--browser",
+          description:
+            "The browser that is called by the npm repo command to open websites",
+          args: { name: "browser" },
+          exclusiveOn: ["--no-browser"],
+        },
+      ],
     },
     {
       name: "restart",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -860,7 +860,16 @@ const completionSpec: Fig.Spec = {
       description: "Lock down dependency versions for publication",
     },
     { name: "star", description: "Mark your favorite packages" },
-    { name: "stars", description: "View packages marked as favorites" },
+    {
+      name: "stars",
+      description: "View packages marked as favorites",
+      args: {
+        name: "user",
+        isOptional: true,
+        description: "View packages marked as favorites by <user>",
+      },
+      options: [registryOption],
+    },
     {
       name: "start",
       description: "Start a package",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -805,6 +805,11 @@ const completionSpec: Fig.Spec = {
     {
       name: "publish",
       description: "Publish a package",
+      args: {
+        name: "tarball|folder",
+        description:
+          "A url or file path to a gzipped tar archive containing a single folder with a package.json file inside | A folder containing a package.json file",
+      },
       options: [
         {
           name: "--tag",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -847,7 +847,7 @@ const completionSpec: Fig.Spec = {
       description: "Display npm root",
       options: [
         {
-          name: "-g",
+          name: ["-g", "--global"],
           description:
             "Print the effective global node_modules folder to standard out",
         },

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -941,7 +941,27 @@ const completionSpec: Fig.Spec = {
     uninstallSubcommand("un"),
     uninstallSubcommand("remove"),
     uninstallSubcommand("unlink"),
-    { name: "unpublish", description: "Remove a package from the registry" },
+    {
+      name: "unpublish",
+      description: "Remove a package from the registry",
+      args: {
+        name: "[<@scope>/]<pkg>[@<version>]",
+      },
+      options: [
+        {
+          name: "--dry-run",
+          description:
+            "Indicates that you don't want npm to make any changes and that it should only report what it would have done",
+        },
+        {
+          name: ["-f", "--force"],
+          description:
+            "Allow unpublishing all versions of a published package. Removes various protections against unfortunate side effects, common mistakes, unnecessary performance degradation, and malicious input",
+          isDangerous: true,
+        },
+        ...workSpaceOptions,
+      ],
+    },
     {
       name: "unstar",
       description: "Remove an item from your favorite packages",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -435,7 +435,7 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: "run",
+      name: ["run", "run-script"],
       description: "Run arbitrary package scripts",
       options: [
         ...workSpaceOptions,
@@ -853,7 +853,6 @@ const completionSpec: Fig.Spec = {
         },
       ],
     },
-    { name: "run-script", description: "Run arbitrary package scripts" },
     {
       name: ["search", "s", "se", "find"],
       description: "Search for packages",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -995,7 +995,38 @@ const completionSpec: Fig.Spec = {
     {
       name: "version",
       description: "Bump a package version",
-      options: [...workSpaceOptions, jsonOption],
+      options: [
+        ...workSpaceOptions,
+        jsonOption,
+        {
+          name: "--allow-same-version",
+          description:
+            "Prevents throwing an error when npm version is used to set the new version to the same value as the current version",
+        },
+        {
+          name: "--no-commit-hooks",
+          description:
+            "Do not run git commit hooks when using the npm version command",
+        },
+        {
+          name: "--no-git-tag-version",
+          description:
+            "Do not tag the commit when using the npm version command",
+        },
+        {
+          name: "--preid",
+          description:
+            'The "prerelease identifier" to use as a prefix for the "prerelease" part of a semver. Like the rc in 1.2.0-rc.8',
+          args: {
+            name: "prerelease-id",
+          },
+        },
+        {
+          name: "--sign-git-tag",
+          description:
+            "If set to true, then the npm version command will tag the version using -s to add a signature",
+        },
+      ],
     },
     {
       name: ["view", "v", "info", "show"],

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -841,7 +841,21 @@ const completionSpec: Fig.Spec = {
         debounce: true,
       },
     },
-    { name: "restart", description: "Restart a package" },
+    {
+      name: "restart",
+      description: "Restart a package",
+      options: [
+        ignoreScriptsOption,
+        scriptShellOption,
+        {
+          name: "--",
+          args: {
+            name: "arg",
+            description: "Arguments to be passed to the restart script",
+          },
+        },
+      ],
+    },
     {
       name: "root",
       description: "Display npm root",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -339,6 +339,12 @@ const scriptShellOption: Fig.Option = {
   args: { name: "script-shell" },
 };
 
+const dryRunOption: Fig.Option = {
+  name: "--dry-run",
+  description:
+    "Indicates that you don't want npm to make any changes and that it should only report what it would have done",
+};
+
 const completionSpec: Fig.Spec = {
   name: "npm",
   parserDirectives: {
@@ -426,11 +432,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Hides the message at the end of each npm install acknowledging the number of dependencies looking for funding",
         },
-        {
-          name: "--dry-run",
-          description:
-            "Indicates that you don't want npm to make any changes and that it should only report what it would have done",
-        },
+        dryRunOption,
         ...workSpaceOptions,
       ],
     },
@@ -487,11 +489,7 @@ const completionSpec: Fig.Spec = {
           description:
             "If the fix argument is provided, then remediations will be applied to the package tree",
           options: [
-            {
-              name: "--dry-run",
-              description:
-                "Indicates that you don't want npm to make any changes and that it should only report what it would have done",
-            },
+            dryRunOption,
             {
               name: ["-f", "--force"],
               description:
@@ -790,11 +788,7 @@ const completionSpec: Fig.Spec = {
       name: "prune",
       description: "Remove extraneous packages",
       options: [
-        {
-          name: "--dry-run",
-          description:
-            "Indicates that you don't want npm to make any changes and that it should only report what it would have done",
-        },
+        dryRunOption,
         jsonOption,
         {
           name: "--production",
@@ -826,11 +820,7 @@ const completionSpec: Fig.Spec = {
             suggestions: ["restricted", "public"],
           },
         },
-        {
-          name: "--dry-run",
-          description:
-            "Indicates that you don't want npm to make any changes and that it should only report what it would have done",
-        },
+        dryRunOption,
         otpOption,
       ],
     },
@@ -1132,11 +1122,7 @@ const completionSpec: Fig.Spec = {
         name: "[<@scope>/]<pkg>[@<version>]",
       },
       options: [
-        {
-          name: "--dry-run",
-          description:
-            "Indicates that you don't want npm to make any changes and that it should only report what it would have done",
-        },
+        dryRunOption,
         {
           name: ["-f", "--force"],
           description:
@@ -1203,11 +1189,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Hides the message at the end of each npm install acknowledging the number of dependencies looking for funding",
         },
-        {
-          name: "--dry-run",
-          description:
-            "Indicates that you don't want npm to make any changes and that it should only report what it would have done",
-        },
+        dryRunOption,
         ...workSpaceOptions,
       ],
     },

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -810,8 +810,10 @@ const completionSpec: Fig.Spec = {
       description: "Publish a package",
       args: {
         name: "tarball|folder",
+        isOptional: true,
         description:
           "A url or file path to a gzipped tar archive containing a single folder with a package.json file inside | A folder containing a package.json file",
+        template: ["folders"],
       },
       options: [
         {

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -230,6 +230,17 @@ const omitOption: Fig.Option = {
   isRepeatable: 3,
 };
 
+const parseableOption: Fig.Option = {
+  name: ["-p", "--parseable"],
+  description:
+    "Output parseable results from commands that write to standard output",
+};
+
+const longOption: Fig.Option = {
+  name: ["-l", "--long"],
+  description: "Show extended information",
+};
+
 const workSpaceOptions: Fig.Option[] = [
   {
     name: ["-w", "--workspace"],
@@ -278,12 +289,8 @@ const npmListOptions: Fig.Option[] = [
     description: "Show all outdated or installed packages",
   },
   jsonOption,
-  { name: ["-l", "--long"], description: "Show extended information" },
-  {
-    name: ["-p", "--parseable"],
-    description:
-      "Output parseable results from commands that write to standard output",
-  },
+  longOption,
+  parseableOption,
   {
     name: "--depth",
     description: "The depth to go when recursing packages",
@@ -723,12 +730,8 @@ const completionSpec: Fig.Spec = {
           description: "Show all outdated or installed packages",
         },
         jsonOption,
-        { name: ["-l", "--long"], description: "Show extended information" },
-        {
-          name: ["-p", "--parseable"],
-          description:
-            "Output parseable results from commands that write to standard output",
-        },
+        longOption,
+        parseableOption,
         {
           name: "-g",
           description: "Checks globally",
@@ -851,9 +854,73 @@ const completionSpec: Fig.Spec = {
       ],
     },
     { name: "run-script", description: "Run arbitrary package scripts" },
-    { name: "s", description: "Search for packages" },
-    { name: "se", description: "Search for packages" },
-    { name: "search", description: "Search for packages" },
+    {
+      name: ["search", "s", "se", "find"],
+      description: "Search for packages",
+      args: {
+        name: "search terms",
+        isVariadic: true,
+      },
+      options: [
+        longOption,
+        jsonOption,
+        {
+          name: "--color",
+          description: "Show colors",
+          args: {
+            name: "always",
+            suggestions: ["always"],
+            description: "Always show colors",
+          },
+          exclusiveOn: ["--no-color"],
+        },
+        {
+          name: "--no-color",
+          description: "Do not show colors",
+          exclusiveOn: ["--color"],
+        },
+        parseableOption,
+        {
+          name: "--no-description",
+          description: "Do not show descriptions",
+        },
+        {
+          name: "--searchopts",
+          description:
+            "Space-separated options that are always passed to search",
+          args: {
+            name: "searchopts",
+          },
+        },
+        {
+          name: "--searchexclude",
+          description:
+            "Space-separated options that limit the results from search",
+          args: {
+            name: "searchexclude",
+          },
+        },
+        registryOption,
+        {
+          name: "--prefer-online",
+          description:
+            "If true, staleness checks for cached data will be forced, making the CLI look for updates immediately even for fresh package data",
+          exclusiveOn: ["--prefer-offline", "--offline"],
+        },
+        {
+          name: "--prefer-offline",
+          description:
+            "If true, staleness checks for cached data will be bypassed, but missing data will be requested from the server",
+          exclusiveOn: ["--prefer-online", "--offline"],
+        },
+        {
+          name: "--offline",
+          description:
+            "Force offline mode: no network requests will be done during install",
+          exclusiveOn: ["--prefer-online", "--prefer-offline"],
+        },
+      ],
+    },
     { name: "set", description: "Sets the config key to the value" },
     {
       name: "set-script",
@@ -957,15 +1024,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "ls",
           args: { name: "scope|scope:team" },
-          options: [
-            registryOption,
-            jsonOption,
-            {
-              name: ["-p", "--parseable"],
-              description:
-                "Output parseable results from commands that write to standard output",
-            },
-          ],
+          options: [registryOption, jsonOption, parseableOption],
         },
       ],
     },
@@ -981,14 +1040,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "list",
           description: "Shows a table of all active authentication tokens",
-          options: [
-            jsonOption,
-            {
-              name: ["-p", "--parseable"],
-              description:
-                "Output parseable results from commands that write to standard output",
-            },
-          ],
+          options: [jsonOption, parseableOption],
         },
         {
           name: "create",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -866,7 +866,21 @@ const completionSpec: Fig.Spec = {
       description: "Start a package",
       options: [ignoreScriptsOption, scriptShellOption],
     },
-    { name: "stop", description: "Stop a package" },
+    {
+      name: "stop",
+      description: "Stop a package",
+      options: [
+        ignoreScriptsOption,
+        scriptShellOption,
+        {
+          name: "--",
+          args: {
+            name: "arg",
+            description: "Arguments to be passed to the stop script",
+          },
+        },
+      ],
+    },
     {
       name: "team",
       description: "Manage organization teams and team memberships",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -864,7 +864,17 @@ const completionSpec: Fig.Spec = {
     {
       name: "start",
       description: "Start a package",
-      options: [ignoreScriptsOption, scriptShellOption],
+      options: [
+        ignoreScriptsOption,
+        scriptShellOption,
+        {
+          name: "--",
+          args: {
+            name: "arg",
+            description: "Arguments to be passed to the start script",
+          },
+        },
+      ],
     },
     {
       name: "stop",

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -859,7 +859,21 @@ const completionSpec: Fig.Spec = {
       name: "shrinkwrap",
       description: "Lock down dependency versions for publication",
     },
-    { name: "star", description: "Mark your favorite packages" },
+    {
+      name: "star",
+      description: "Mark your favorite packages",
+      args: {
+        name: "pkg",
+        description: "Package to mark as favorite",
+      },
+      options: [
+        registryOption,
+        {
+          name: "--no-unicode",
+          description: "Do not use unicode characters in the tree output",
+        },
+      ],
+    },
     {
       name: "stars",
       description: "View packages marked as favorites",
@@ -1018,6 +1032,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "unstar",
       description: "Remove an item from your favorite packages",
+      args: {
+        name: "pkg",
+        description: "Package to unmark as favorite",
+      },
       options: [
         registryOption,
         otpOption,

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -790,13 +790,19 @@ const completionSpec: Fig.Spec = {
     {
       name: "prune",
       description: "Remove extraneous packages",
+      args: {
+        name: "[<@scope>/]<pkg>",
+        isOptional: true,
+      },
       options: [
+        omitOption,
         dryRunOption,
         jsonOption,
         {
           name: "--production",
           description: "Remove the packages specified in your devDependencies",
         },
+        ...workSpaceOptions,
       ],
     },
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Improve completion spec of `npm`

**What is the current behavior? (You can also link to an open issue here)**
Several commands are incorrectly grouped. Several options are missing
Partially fixes issue: https://github.com/withfig/autocomplete/issues/983

**What is the new behavior (if this is a feature change)?**
Improves multiple subcommands

**Additional info:**
NOTE: Though this improves the whole npm spec by adding options to certain subcommands and by grouping aliased subcommands together, this is in no way exhaustive and further improvements would be needed
Follow up of: https://github.com/withfig/autocomplete/pull/1001