### PR TITLE
chore: add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "author": "",
   "license": "ISC",
   "bugs": "https://github.com/withfig/autocomplete/issues",
+  "repository": "https://github.com/withfig/autocomplete",
   "devDependencies": {
     "@fig/autocomplete-generators": "^1.0.0",
     "@types/inquirer": "^7.3.1",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Updates package metadata

**What is the current behavior? (You can also link to an open issue here)**
`npm repo` does not return repository url
Closes: https://github.com/withfig/autocomplete/issues/1020

**What is the new behavior (if this is a feature change)?**
`npm repo` returns repository url 

**Additional info:**