### PR TITLE
chore: replace deprecated `String.prototype.substr()`

### DIFF
--- a/src/yo.ts
+++ b/src/yo.ts
@@ -3,7 +3,7 @@ function toTitleCase(str: string): string {
     .trim()
     .replace(
       /\w\S*/g,
-      (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+      (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase()
     );
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

No user facing change

**Additional info:**