### PR TITLE
feat(deno): update to 1.20, improve doc generator

### DIFF
--- a/src/deno.ts
+++ b/src/deno.ts
@@ -699,7 +699,7 @@ function getUniqueValues<T, U>(input: readonly T[], fn: (item: T) => U): T[] {
   return out;
 }
 
-function getDocNodeChildren(node: Node): Node[] {
+function getNodeChildren(node: Node): Node[] {
   if (!("kind" in node)) {
     return [];
   }
@@ -720,11 +720,13 @@ function findDocNodes(nodes: Node[], path: string[]): Node[] {
   if (!head) {
     return nodes;
   }
-  const foundNode = nodes.find((node) => node.name === head);
-  if (!foundNode) {
+  const foundNodes = nodes.filter((node) => node.name === head);
+  if (foundNodes.length === 0) {
     return [];
   }
-  return findDocNodes(getDocNodeChildren(foundNode), tail);
+  return foundNodes.flatMap((node) =>
+    findDocNodes(getNodeChildren(node), tail)
+  );
 }
 
 function getPriorityByNodeName(name: string): number {

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -1223,7 +1223,7 @@ const denoBench: Fig.Subcommand = {
 };
 
 type DenoConfigurationFile = DenoConfigurationFileSchema & {
-  fig: {
+  fig?: {
     [key: string]: {
       displayName?: string | undefined;
       description?: string | undefined;
@@ -1300,13 +1300,17 @@ const denoTask: Fig.Subcommand = {
           if (config === null) {
             return [];
           }
-          return Object.entries(config.tasks).map(([name, command]) => ({
-            name,
-            displayName: config.fig?.[name]?.displayName || name,
-            description: config.fig?.[name]?.description || command,
-            icon: config.fig?.[name]?.icon || "⚙️",
-            priority: config.fig?.[name]?.priority,
-          }));
+          return Object.entries(config.tasks).map(([name, command]) => {
+            const fig = config.fig?.[name] || {};
+            return {
+              name,
+              displayName: fig.displayName,
+              description: fig.description || command,
+              icon: fig.icon || "⚙️",
+              priority: fig.priority,
+              hidden: fig.hidden,
+            };
+          });
         },
       },
     },

--- a/src/deno/config_schema.d.ts
+++ b/src/deno/config_schema.d.ts
@@ -1,0 +1,218 @@
+/* eslint-disable @withfig/fig-linter/no-missing-default-export */
+
+// This file was generated automatically from the source schema:
+// https://github.com/denoland/deno/blob/7c27222/cli/schemas/config-file.v1.json
+// Using this tool: https://transform.tools/json-schema-to-typescript
+
+/**
+ * A JSON representation of a Deno configuration file.
+ */
+export interface DenoConfigurationFileSchema {
+  /**
+   * Instructs the TypeScript compiler how to compile .ts files.
+   */
+  compilerOptions?: {
+    /**
+     * Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.
+     */
+    allowJs?: boolean;
+    /**
+     * Disable error reporting for unreachable code.
+     */
+    allowUnreachableCode?: boolean;
+    /**
+     * Disable error reporting for unused labels.
+     */
+    allowUnusedLabels?: boolean;
+    /**
+     * Enable error reporting in type-checked JavaScript files.
+     */
+    checkJs?: boolean;
+    /**
+     * Enable experimental support for TC39 stage 2 draft decorators.
+     */
+    experimentalDecorators?: boolean;
+    /**
+     * Specify what JSX code is generated.
+     */
+    jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | "react-native";
+    /**
+     * Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'
+     */
+    jsxFactory?: string;
+    /**
+     * Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.
+     */
+    jsxFragmentFactory?: string;
+    /**
+     * Specify module specifier used to import the JSX factory functions when using jsx: 'react-jsx*'.
+     */
+    jsxImportSource?: string;
+    /**
+     * Make keyof only return strings instead of string, numbers or symbols. Legacy option.
+     */
+    keyofStringsOnly?: boolean;
+    /**
+     * Specify a set of bundled library declaration files that describe the target runtime environment.
+     */
+    lib?: string[];
+    /**
+     * Enable error reporting for fallthrough cases in switch statements.
+     */
+    noFallthroughCasesInSwitch?: boolean;
+    /**
+     * Enable error reporting for expressions and declarations with an implied `any` type..
+     */
+    noImplicitAny?: boolean;
+    /**
+     * Ensure overriding members in derived classes are marked with an override modifier.
+     */
+    noImplicitOverride?: boolean;
+    /**
+     * Enable error reporting for codepaths that do not explicitly return in a function.
+     */
+    noImplicitReturns?: boolean;
+    /**
+     * Enable error reporting when `this` is given the type `any`.
+     */
+    noImplicitThis?: boolean;
+    /**
+     * Disable adding 'use strict' directives in emitted JavaScript files.
+     */
+    noImplicitUseStrict?: boolean;
+    /**
+     * Disable strict checking of generic signatures in function types.
+     */
+    noStrictGenericChecks?: boolean;
+    /**
+     * Enable error reporting when a local variables aren't read.
+     */
+    noUnusedLocals?: boolean;
+    /**
+     * Raise an error when a function parameter isn't read
+     */
+    noUnusedParameters?: boolean;
+    /**
+     * Add `undefined` to a type when accessed using an index.
+     */
+    noUncheckedIndexedAccess?: boolean;
+    /**
+     * Enable all strict type checking options.
+     */
+    strict?: boolean;
+    /**
+     * Check that the arguments for `bind`, `call`, and `apply` methods match the original function.
+     */
+    strictBindCallApply?: boolean;
+    /**
+     * When assigning functions, check to ensure parameters and the return values are subtype-compatible.
+     */
+    strictFunctionTypes?: boolean;
+    /**
+     * Check for class properties that are declared but not set in the constructor.
+     */
+    strictPropertyInitialization?: boolean;
+    /**
+     * When type checking, take into account `null` and `undefined`.
+     */
+    strictNullChecks?: boolean;
+    /**
+     * Disable reporting of excess property errors during the creation of object literals.
+     */
+    suppressExcessPropertyErrors?: boolean;
+    /**
+     * Suppress `noImplicitAny` errors when indexing objects that lack index signatures.
+     */
+    suppressImplicitAnyIndexErrors?: boolean;
+    [k: string]: unknown;
+  };
+  /**
+   * The location of an import map to be used when resolving modules. If an import map is explicitly specified, it will override this value.
+   */
+  importMap?: string;
+  /**
+   * Configuration for linter
+   */
+  lint?: {
+    files?: {
+      /**
+       * List of files or directories that will be linted.
+       */
+      include?: string[];
+      /**
+       * List of files or directories that will not be linted.
+       */
+      exclude?: string[];
+      [k: string]: unknown;
+    };
+    rules?: {
+      /**
+       * List of tag names that will be run. Empty list disables all tags and will only use rules from `include`.
+       */
+      tags?: string[];
+      /**
+       * List of rule names that will be excluded from configured tag sets. If the same rule is in `include` it be run.
+       */
+      exclude?: string[];
+      /**
+       * List of rule names that will be run. Even if the same rule is in `exclude` it will be run.
+       */
+      include?: string[];
+      [k: string]: unknown;
+    };
+    [k: string]: unknown;
+  };
+  /**
+   * Configuration for formatter
+   */
+  fmt?: {
+    files?: {
+      /**
+       * List of files or directories that will be formatted.
+       */
+      include?: string[];
+      /**
+       * List of files or directories that will not be formatted.
+       */
+      exclude?: string[];
+      [k: string]: unknown;
+    };
+    options?: {
+      /**
+       * Whether to use tabs (true) or spaces (false) for indentation.
+       */
+      useTabs?: boolean;
+      /**
+       * The width of a line the printer will try to stay under. Note that the printer may exceed this width in certain cases.
+       */
+      lineWidth?: number;
+      /**
+       * The number of characters for an indent.
+       */
+      indentWidth?: number;
+      /**
+       * Whether to use single quote (true) or double quote (false) for quotation.
+       */
+      singleQuote?: boolean;
+      /**
+       * Define how prose should be wrapped in Markdown files.
+       */
+      proseWrap?: "always" | "never" | "preserve";
+      [k: string]: unknown;
+    };
+    [k: string]: unknown;
+  };
+  /**
+   * Configuration for deno task
+   */
+  tasks?: {
+    /**
+     * Command to execute for this task name.
+     *
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[A-Za-z][A-Za-z0-9_\-:]*$".
+     */
+    [k: string]: string;
+  };
+  [k: string]: unknown;
+}

--- a/src/deno/deno_doc.d.ts
+++ b/src/deno/deno_doc.d.ts
@@ -1,0 +1,724 @@
+/* eslint-disable @withfig/fig-linter/no-missing-default-export */
+
+/*
+https://github.com/denoland/deno_doc/blob/efe4939ebbcdcd36ac1a2969e3a9db72fcfe49db/lib/types.d.ts
+
+MIT License
+
+Copyright (c) 2020-2022 the Deno authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// Copyright 2020-2022 the Deno authors. All rights reserved. MIT license.
+
+export type DocNode =
+  | DocNodeModuleDoc
+  | DocNodeFunction
+  | DocNodeVariable
+  | DocNodeEnum
+  | DocNodeClass
+  | DocNodeTypeAlias
+  | DocNodeNamespace
+  | DocNodeInterface
+  | DocNodeImport;
+
+/** Indicates how the documentation node was declared. `"private"` indicates
+ * the node is un-exported. `"export"` indicates it is exported from the current
+ * module. `"declare"` indicates that it is a type only declaration. */
+export type DeclarationKind = "private" | "export" | "declare";
+
+interface DocNodeBase {
+  kind: DocNodeKind;
+  name: string;
+  location: Location;
+  declarationKind: DeclarationKind;
+  jsDoc?: JsDoc;
+}
+
+export type DocNodeKind =
+  | "moduleDoc"
+  | "function"
+  | "variable"
+  | "enum"
+  | "class"
+  | "typeAlias"
+  | "namespace"
+  | "interface"
+  | "import";
+
+export interface DocNodeModuleDoc extends DocNodeBase {
+  kind: "moduleDoc";
+  jsDoc: JsDoc;
+}
+
+export interface DocNodeFunction extends DocNodeBase {
+  kind: "function";
+  functionDef: FunctionDef;
+}
+
+export interface DocNodeVariable extends DocNodeBase {
+  kind: "variable";
+  variableDef: VariableDef;
+}
+
+export interface DocNodeEnum extends DocNodeBase {
+  kind: "enum";
+  enumDef: EnumDef;
+}
+
+export interface DocNodeClass extends DocNodeBase {
+  kind: "class";
+  classDef: ClassDef;
+}
+
+export interface DocNodeTypeAlias extends DocNodeBase {
+  kind: "typeAlias";
+  typeAliasDef: TypeAliasDef;
+}
+
+export interface DocNodeNamespace extends DocNodeBase {
+  kind: "namespace";
+  namespaceDef: NamespaceDef;
+}
+
+export interface DocNodeInterface extends DocNodeBase {
+  kind: "interface";
+  interfaceDef: InterfaceDef;
+}
+
+export interface DocNodeImport extends DocNodeBase {
+  kind: "import";
+  importDef: ImportDef;
+}
+
+export type Accessibility = "public" | "protected" | "private";
+
+export interface ClassDef {
+  isAbstract: boolean;
+  constructors: ClassConstructorDef[];
+  properties: ClassPropertyDef[];
+  indexSignatures: ClassIndexSignatureDef[];
+  methods: ClassMethodDef[];
+  extends?: string;
+  implements: TsTypeDef[];
+  typeParams: TsTypeParamDef[];
+  superTypeParams: TsTypeDef[];
+  decorators?: DecoratorDef[];
+}
+
+export interface ClassConstructorDef {
+  jsDoc?: JsDoc;
+  accessibility?: Accessibility;
+  name: string;
+  params: ParamDef[];
+  location: Location;
+}
+
+export interface ClassIndexSignatureDef {
+  readonly: boolean;
+  params: ParamDef[];
+  tsType?: TsTypeDef;
+}
+
+export interface ClassMethodDef {
+  jsDoc?: JsDoc;
+  accessibility?: Accessibility;
+  optional: boolean;
+  isAbstract: boolean;
+  isStatic: boolean;
+  name: string;
+  kind: MethodKind;
+  functionDef: FunctionDef;
+  location: Location;
+}
+
+export interface ClassPropertyDef {
+  jsDoc?: JsDoc;
+  tsType?: TsTypeDef;
+  readonly: boolean;
+  accessibility?: Accessibility;
+  optional: boolean;
+  isAbstract: boolean;
+  isStatic: boolean;
+  name: string;
+  decorators?: DecoratorDef[];
+  location: Location;
+}
+
+export interface DecoratorDef {
+  name: string;
+  args?: string[];
+  location: Location;
+}
+
+export interface EnumDef {
+  members: EnumMemberDef[];
+}
+
+export interface EnumMemberDef {
+  name: string;
+  init?: TsTypeDef;
+  jsDoc?: JsDoc;
+}
+
+export interface FunctionDef {
+  params: ParamDef[];
+  returnType?: TsTypeDef;
+  isAsync: boolean;
+  isGenerator: boolean;
+  typeParams: TsTypeParamDef[];
+  decorators?: DecoratorDef[];
+}
+
+export interface ImportDef {
+  src: string;
+  imported?: string;
+}
+
+export interface InterfaceDef {
+  extends: TsTypeDef[];
+  methods: InterfaceMethodDef[];
+  properties: InterfacePropertyDef[];
+  callSignatures: InterfaceCallSignatureDef[];
+  indexSignatures: InterfaceIndexSignatureDef[];
+  typeParams: TsTypeParamDef[];
+}
+
+export interface InterfaceCallSignatureDef {
+  location: Location;
+  jsDoc?: JsDoc;
+  params: ParamDef[];
+  tsType?: TsTypeDef;
+  typeParams: TsTypeParamDef[];
+}
+
+export interface InterfaceIndexSignatureDef {
+  readonly: boolean;
+  params: ParamDef[];
+  tsType?: TsTypeDef;
+}
+
+export interface InterfaceMethodDef {
+  name: string;
+  kind: MethodKind;
+  location: Location;
+  jsDoc?: JsDoc;
+  computed?: boolean;
+  optional: boolean;
+  params: ParamDef[];
+  returnType?: TsTypeDef;
+  typeParams: TsTypeParamDef[];
+}
+
+export interface InterfacePropertyDef {
+  name: string;
+  location: Location;
+  jsDoc?: JsDoc;
+  params: ParamDef[];
+  readonly?: boolean;
+  computed: boolean;
+  optional: boolean;
+  tsType?: TsTypeDef;
+  typeParams: TsTypeParamDef[];
+}
+
+export interface JsDoc {
+  doc?: string;
+  tags?: JsDocTag[];
+}
+
+export type JsDocTagKind =
+  | "callback"
+  | "constructor"
+  | "deprecated"
+  | "enum"
+  | "example"
+  | "extends"
+  | "module"
+  | "param"
+  | "public"
+  | "private"
+  | "property"
+  | "protected"
+  | "readonly"
+  | "return"
+  | "template"
+  | "this"
+  | "typedef"
+  | "type"
+  | "unsupported";
+
+export type JsDocTag =
+  | JsDocTagOnly
+  | JsDocTagDoc
+  | JsDocTagNamed
+  | JsDocTagTyped
+  | JsDocTagNamedTyped
+  | JsDocTagParam
+  | JsDocTagReturn
+  | JsDocTagUnsupported;
+
+export interface JsDocTagBase {
+  kind: JsDocTagKind;
+}
+
+export interface JsDocTagOnly extends JsDocTagBase {
+  kind:
+    | "constructor"
+    | "module"
+    | "public"
+    | "private"
+    | "protected"
+    | "readonly";
+}
+
+export interface JsDocTagDoc extends JsDocTagBase {
+  kind: "deprecated" | "example";
+  doc?: string;
+}
+
+export interface JsDocTagNamed extends JsDocTagBase {
+  kind: "callback" | "template";
+  name: string;
+  doc?: string;
+}
+
+export interface JsDocTagTyped extends JsDocTagBase {
+  kind: "enum" | "extends" | "this" | "type";
+  type: string;
+  doc?: string;
+}
+
+export interface JsDocTagNamedTyped extends JsDocTagBase {
+  kind: "property" | "typedef";
+  name: string;
+  type: string;
+  doc?: string;
+}
+
+export interface JsDocTagParam extends JsDocTagBase {
+  kind: "param";
+  name: string;
+  type?: string;
+  doc?: string;
+}
+
+export interface JsDocTagReturn extends JsDocTagBase {
+  kind: "return";
+  type?: string;
+  doc?: string;
+}
+
+export interface JsDocTagUnsupported extends JsDocTagBase {
+  kind: "unsupported";
+  value: string;
+}
+
+export interface LiteralCallSignatureDef {
+  params: ParamDef[];
+  tsType?: TsTypeDef;
+  typeParams: TsTypeParamDef[];
+}
+
+export type LiteralDefKind =
+  | "number"
+  | "string"
+  | "template"
+  | "boolean"
+  | "bigInt";
+
+export type LiteralDef =
+  | LiteralDefNumber
+  | LiteralDefBigInt
+  | LiteralDefString
+  | LiteralDefTemplate
+  | LiteralDefBoolean;
+
+interface LiteralDefBase {
+  kind: LiteralDefKind;
+}
+
+export interface LiteralDefNumber extends LiteralDefBase {
+  kind: "number";
+  number: number;
+}
+
+export interface LiteralDefBigInt extends LiteralDefBase {
+  kind: "bigInt";
+  string: string;
+}
+
+export interface LiteralDefString extends LiteralDefBase {
+  kind: "string";
+  string: string;
+}
+
+export interface LiteralDefTemplate extends LiteralDefBase {
+  kind: "template";
+  tsTypes: TsTypeDef[];
+}
+
+export interface LiteralDefBoolean extends LiteralDefBase {
+  kind: "boolean";
+  boolean: boolean;
+}
+
+export interface LiteralIndexSignatureDef {
+  readonly: boolean;
+  params: ParamDef[];
+  tsType?: TsTypeDef;
+}
+
+export interface LiteralMethodDef {
+  name: string;
+  kind: MethodKind;
+  params: ParamDef[];
+  computed?: boolean;
+  optional: boolean;
+  returnType?: TsTypeDef;
+  typeParams: TsTypeParamDef[];
+}
+
+export interface LiteralPropertyDef {
+  name: string;
+  params: ParamDef[];
+  readonly?: boolean;
+  computed: boolean;
+  optional: boolean;
+  tsType?: TsTypeDef;
+  typeParams: TsTypeParamDef[];
+}
+
+export interface Location {
+  filename: string;
+  line: number;
+  col: number;
+}
+
+export type MethodKind = "method" | "getter" | "setter";
+
+export interface NamespaceDef {
+  elements: DocNode[];
+}
+
+export type ObjectPatPropDef =
+  | ObjectPatPropAssignDef
+  | ObjectPatPropKeyValueDef
+  | ObjectPatPropRestDef;
+
+export interface ObjectPatPropAssignDef {
+  kind: "assign";
+  key: string;
+  value?: string;
+}
+
+export interface ObjectPatPropKeyValueDef {
+  kind: "keyValue";
+  key: string;
+  value: ParamDef;
+}
+
+export interface ObjectPatPropRestDef {
+  kind: "rest";
+  arg: ParamDef;
+}
+
+export type ParamDef =
+  | ParamArrayDef
+  | ParamAssignDef
+  | ParamIdentifierDef
+  | ParamObjectDef
+  | ParamRestDef;
+
+export interface ParamArrayDef {
+  kind: "array";
+  elements: (ParamDef | undefined)[];
+  optional: boolean;
+  decorators?: DecoratorDef[];
+  tsType?: TsTypeDef;
+}
+
+export interface ParamAssignDef {
+  kind: "assign";
+  left: ParamDef;
+  right: string;
+  decorators?: DecoratorDef[];
+  tsType?: TsTypeDef;
+}
+
+export interface ParamIdentifierDef {
+  kind: "identifier";
+  name: string;
+  optional: boolean;
+  decorators?: DecoratorDef[];
+  tsType?: TsTypeDef;
+}
+
+export interface ParamObjectDef {
+  kind: "object";
+  props: ObjectPatPropDef[];
+  optional: boolean;
+  decorators?: DecoratorDef[];
+  tsType?: TsTypeDef;
+}
+
+export interface ParamRestDef {
+  kind: "rest";
+  arg: ParamDef;
+  decorators?: DecoratorDef[];
+  tsType?: TsTypeDef;
+}
+
+export type TruePlusMinus = true | "+" | "-";
+
+export interface TsConditionalDef {
+  checkType: TsTypeDef;
+  extendsType: TsTypeDef;
+  trueType: TsTypeDef;
+  falseType: TsTypeDef;
+}
+
+export interface TsFnOrConstructorDef {
+  constructor: boolean;
+  tsType: TsTypeDef;
+  params: ParamDef[];
+  typeParams: TsTypeParamDef[];
+}
+
+export interface TsImportTypeDef {
+  specifier: string;
+  qualifier?: string;
+  typeParams?: TsTypeDef[];
+}
+
+export interface TsIndexedAccessDef {
+  readonly: boolean;
+  objType: TsTypeDef;
+  indexType: TsTypeDef;
+}
+
+export interface TsInferDef {
+  typeParam: TsTypeParamDef;
+}
+
+export interface TsMappedTypeDef {
+  readonly?: TruePlusMinus;
+  typeParam: TsTypeParamDef;
+  nameType?: TsTypeDef;
+  optional?: TruePlusMinus;
+  tsType?: TsTypeDef;
+}
+
+export interface TsTypeLiteralDef {
+  methods: LiteralMethodDef[];
+  properties: LiteralPropertyDef[];
+  callSignatures: LiteralCallSignatureDef[];
+  indexSignatures: LiteralIndexSignatureDef[];
+}
+
+export interface TsTypeOperatorDef {
+  operator: string;
+  tsType: TsTypeDef;
+}
+
+export interface TsTypeParamDef {
+  name: string;
+  constraint?: TsTypeDef;
+  default?: TsTypeDef;
+}
+
+export interface TsTypePredicateDef {
+  asserts: boolean;
+  param: { type: "this" | "identifier"; name?: string };
+  type?: TsTypeDef;
+}
+
+export type TsTypeDef =
+  | TsTypeKeywordDef
+  | TsTypeDefLiteral
+  | TsTypeTypeRefDef
+  | TsTypeUnionDef
+  | TsTypeIntersectionDef
+  | TsTypeArrayDef
+  | TsTypeTupleDef
+  | TsTypeTypeOperatorDef
+  | TsTypeParenthesizedDef
+  | TsTypeRestDef
+  | TsTypeOptionalDef
+  | TsTypeQueryDef
+  | TsTypeThisDef
+  | TsTypeFnOrConstructorDef
+  | TsTypeConditionalDef
+  | TsTypeImportTypeDef
+  | TsTypeInferDef
+  | TsTypeIndexedAccessDef
+  | TsTypeMappedDef
+  | TsTypeTypeLiteralDef
+  | TsTypeTypePredicateDef;
+
+interface TsTypeDefBase {
+  repr: string;
+  kind: TsTypeDefKind;
+}
+
+export interface TsTypeKeywordDef extends TsTypeDefBase {
+  kind: "keyword";
+  keyword: string;
+}
+
+export interface TsTypeDefLiteral extends TsTypeDefBase {
+  kind: "literal";
+  literal: LiteralDef;
+}
+
+export interface TsTypeTypeRefDef extends TsTypeDefBase {
+  kind: "typeRef";
+  typeRef: TsTypeRefDef;
+}
+
+export interface TsTypeUnionDef extends TsTypeDefBase {
+  kind: "union";
+  union: TsTypeDef[];
+}
+
+export interface TsTypeIntersectionDef extends TsTypeDefBase {
+  kind: "intersection";
+  intersection: TsTypeDef[];
+}
+
+export interface TsTypeArrayDef extends TsTypeDefBase {
+  kind: "array";
+  array: TsTypeDef;
+}
+
+export interface TsTypeTupleDef extends TsTypeDefBase {
+  kind: "tuple";
+  tuple: TsTypeDef[];
+}
+
+export interface TsTypeTypeOperatorDef extends TsTypeDefBase {
+  kind: "typeOperator";
+  typeOperator: TsTypeOperatorDef;
+}
+
+export interface TsTypeParenthesizedDef extends TsTypeDefBase {
+  kind: "parenthesized";
+  parenthesized: TsTypeDef;
+}
+
+export interface TsTypeRestDef extends TsTypeDefBase {
+  kind: "rest";
+  rest: TsTypeDef;
+}
+
+export interface TsTypeOptionalDef extends TsTypeDefBase {
+  kind: "optional";
+  optional: TsTypeDef;
+}
+
+export interface TsTypeQueryDef extends TsTypeDefBase {
+  kind: "typeQuery";
+  typeQuery: string;
+}
+
+export interface TsTypeThisDef extends TsTypeDefBase {
+  kind: "this";
+  this: boolean;
+}
+
+export interface TsTypeFnOrConstructorDef extends TsTypeDefBase {
+  kind: "fnOrConstructor";
+  fnOrConstructor: TsFnOrConstructorDef;
+}
+
+export interface TsTypeConditionalDef extends TsTypeDefBase {
+  kind: "conditional";
+  conditionalType: TsConditionalDef;
+}
+
+export interface TsTypeInferDef extends TsTypeDefBase {
+  kind: "infer";
+  infer: TsInferDef;
+}
+
+export interface TsTypeMappedDef extends TsTypeDefBase {
+  kind: "mapped";
+  mappedType: TsMappedTypeDef;
+}
+
+export interface TsTypeImportTypeDef extends TsTypeDefBase {
+  kind: "importType";
+  importType: TsImportTypeDef;
+}
+
+export interface TsTypeIndexedAccessDef extends TsTypeDefBase {
+  kind: "indexedAccess";
+  indexedAccess: TsIndexedAccessDef;
+}
+
+export interface TsTypeTypeLiteralDef extends TsTypeDefBase {
+  kind: "typeLiteral";
+  typeLiteral: TsTypeLiteralDef;
+}
+
+export interface TsTypeTypePredicateDef extends TsTypeDefBase {
+  kind: "typePredicate";
+  typePredicate: TsTypePredicateDef;
+}
+
+export type TsTypeDefKind =
+  | "keyword"
+  | "literal"
+  | "typeRef"
+  | "union"
+  | "intersection"
+  | "array"
+  | "tuple"
+  | "typeOperator"
+  | "parenthesized"
+  | "rest"
+  | "optional"
+  | "typeQuery"
+  | "this"
+  | "fnOrConstructor"
+  | "conditional"
+  | "importType"
+  | "infer"
+  | "indexedAccess"
+  | "mapped"
+  | "typeLiteral"
+  | "typePredicate";
+
+export interface TsTypeRefDef {
+  typeParams?: TsTypeDef[];
+  typeName: string;
+}
+
+export interface TypeAliasDef {
+  tsType: TsTypeDef;
+  typeParams: TsTypeParamDef[];
+}
+
+export type VariableDeclKind = "var" | "let" | "const";
+
+export interface VariableDef {
+  tsType?: TsTypeDef;
+  kind: VariableDeclKind;
+}


### PR DESCRIPTION
Adds `deno task` and `deno bench`, improves (and simplifies) the logic for the `deno doc` suggestion generator.

The deno config JSON schema also allows for additional keys. This spec uses the `"fig"` property to customize the:
* Priority
* Display name
* Icon
* Description
* Hidden status

This PR also adds a deno directory with supporting files:
1. Vendored type definitions for deno doc (please let me know if I need to do this differently)
2. Automatically generated types for the config JSON schema

## Images

Fig 1. Task suggestions
<img width="481" alt="Task suggestions" src="https://user-images.githubusercontent.com/52195359/159103037-6bc007ea-3195-4de7-8889-70f2f3e8e37c.png">

Fig 2. Example config for the above
<img width="944" alt="Configuration file containing fig property" src="https://user-images.githubusercontent.com/52195359/159103097-9841a9f1-ca9d-4491-83c4-3584228d67e7.png">

Fig 3. `deno doc` suggesting something it couldn't before
<img width="594" alt="Documentation suggestions" src="https://user-images.githubusercontent.com/52195359/159167925-57a5bf4b-c581-4164-97b3-53df25ec517e.png">
