### PR TITLE
feat(man): variadic args, fish pages, correct path handling

### DIFF
--- a/src/man.ts
+++ b/src/man.ts
@@ -36,7 +36,7 @@ const generateManualPages: Fig.Generator = {
     const maybeSection = tokens[tokens.length - 2];
     const sectionGlob = sectionNames.has(maybeSection) ? maybeSection : "[18]";
     const out = await executeShellCommand(
-      `while IFS=':' read -ra manpath; do for path in "\${manpath[@]}"; do ls -1 "$path/man"${sectionGlob} 2>/dev/null; done; done <<< "$(${manpathCommand})" | sort -u`.trim()
+      `while IFS=':' read -ra manpath; do for path in "\${manpath[@]}"; do \\ls -1 "$path/man"${sectionGlob} 2>/dev/null; done; done <<< "$(${manpathCommand})" | sort -u`.trim()
     );
 
     const suggestions: Fig.Suggestion[] = [];


### PR DESCRIPTION
Also fixes slightly incorrect manpath handling, and if your login shell is fish then it shows fish-specific completions.

Uses possibly the longest shell script we've added in autocomplete to date! (this is the evaluated version, the raw version is even worse)

```bash
while IFS=':' read -ra manpath; do
  for path in "${manpath[@]}"; do
    ls -1 "$path/man"[18] 2>/dev/null
  done
done <<< "$(man -w)" | sort -u
```

<img width="447" alt="image" src="https://user-images.githubusercontent.com/52195359/159846516-f829b191-d4cc-4ffc-a3a8-70612a4b2c64.png">
