### PR TITLE
fix(kubectl): lowercase some suggestions

### DIFF
--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -223,7 +223,7 @@ const sharedOpts: Record<string, Fig.Option> = {
       'Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource',
     args: {
       name: "Strategy",
-      suggestions: ["None", "Server", "Client"],
+      suggestions: ["none", "server", "client"],
     },
   },
   fieldSelector: {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix kubectl suggestions

**What is the current behavior? (You can also link to an open issue here)**
The suggestions aren't correct
<img width="675" alt="image" src="https://user-images.githubusercontent.com/32052228/160002484-085e8acf-ef50-4f98-91d7-bd724220d369.png">


**What is the new behavior (if this is a feature change)?**
The suggestions should to be lowercase
