### PR TITLE
[wasm-bindgen] suggest current token for `--out-name` option

### DIFF
--- a/src/wasm-bindgen.ts
+++ b/src/wasm-bindgen.ts
@@ -29,6 +29,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "filename",
         description: "Output filename",
+        suggestCurrentToken: true,
         template: ["filepaths"],
       },
     },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
UX enhancement to the `--out-name` option in the `wasm-bindgen` CLI tool.

**What is the current behavior? (You can also link to an open issue here)**
Does not current suggest token.

**What is the new behavior (if this is a feature change)?**
When the user types a file when passing an `--out-name` flag/option, the user input will be prioritized in the list of autocomplete suggestions by being listed at the very top.

Documentation: https://fig.io/docs/reference/arg#suggestcurrenttoken

**Additional info:**
Follows-up #1073 (5759ec1), suggestion by @mschrage 