### PR TITLE
feat(open): improve generators

### DIFF
--- a/src/open.ts
+++ b/src/open.ts
@@ -1,11 +1,39 @@
-const appGenerator = (path: string): Fig.Generator => ({
-  script: `\ls -1 ${path}`,
+export const generateApps = (unquotedPath: string): Fig.Generator => ({
+  cache: { strategy: "stale-while-revalidate" },
+  script: `mdfind kMDItemContentTypeTree=com.apple.application-bundle -onlyin ${unquotedPath}`,
   postProcess: (out) => {
-    return out.split("\n").map((line) => ({
-      name: line,
-      icon: `fig://${path}/${line}`,
-      priority: line.endsWith(".app") && 76,
-    }));
+    return out.split("\n").map((path) => {
+      const basename = path.slice(path.lastIndexOf("/") + 1);
+      return {
+        name: basename,
+        icon: `fig://${path}`,
+        priority: path.endsWith(`/Applications/${basename}`) ? 76 : 50,
+      };
+    });
+  },
+});
+
+export const generateBundleIds = (unquotedPath: string): Fig.Generator => ({
+  scriptTimeout: 15000,
+  cache: { strategy: "stale-while-revalidate" },
+  script: `mdfind kMDItemContentTypeTree=com.apple.application-bundle -onlyin ${unquotedPath} | while read line; do echo $(mdls -name kMDItemCFBundleIdentifier -r "$line") $line; done`,
+  postProcess: (out) => {
+    const ids = new Map(
+      out.split("\n").map((line) => {
+        const sep = line.indexOf(" ");
+        return [line.slice(0, sep), line.slice(sep + 1)] as const;
+      })
+    );
+    ids.delete("(null)");
+    const suggestions: Fig.Suggestion[] = [];
+    for (const [id, path] of ids.entries()) {
+      suggestions.push({
+        name: id,
+        description: path,
+        icon: `fig://${path}`,
+      });
+    }
+    return suggestions;
   },
 });
 
@@ -18,10 +46,7 @@ const completionSpec: Fig.Spec = {
       description: "Specify the application to use for opening the file",
       args: {
         name: "Application",
-        generators: [
-          appGenerator("/Applications"),
-          appGenerator("~/Applications"),
-        ],
+        generators: generateApps("/"),
       },
     },
     {
@@ -30,6 +55,7 @@ const completionSpec: Fig.Spec = {
         "Specify the bundle identifier of the app to use to open the file",
       args: {
         name: "Bundle Identifier",
+        generators: generateBundleIds("/"),
       },
     },
     {

--- a/src/open.ts
+++ b/src/open.ts
@@ -6,8 +6,13 @@ export const generateApps = (unquotedPath: string): Fig.Generator => ({
       const basename = path.slice(path.lastIndexOf("/") + 1);
       return {
         name: basename,
+        description: path,
         icon: `fig://${path}`,
-        priority: path.endsWith(`/Applications/${basename}`) ? 76 : 50,
+        priority: path.endsWith(`/Applications/${basename}`)
+          ? 80
+          : path.startsWith("/Applications")
+          ? 76
+          : 50,
       };
     });
   },

--- a/src/tccutil.ts
+++ b/src/tccutil.ts
@@ -1,3 +1,5 @@
+import { generateBundleIds } from "./open";
+
 const commands: Fig.Suggestion[] = [
   {
     name: "reset",
@@ -141,30 +143,6 @@ const services: Fig.Suggestion[] = [
       "Allow app to run software that doesn't meet the system's security policy",
   },
 ].map((item) => Object.assign(item, { icon: "⚙️" }));
-
-const generateBundleIds = (path: string): Fig.Generator => ({
-  scriptTimeout: 15000,
-  cache: { strategy: "stale-while-revalidate" },
-  script: `mdfind kMDItemContentTypeTree=com.apple.application-bundle -onlyin ${path} | while read line; do echo $(mdls -name kMDItemCFBundleIdentifier -r "$line") $line; done`,
-  postProcess: (out) => {
-    const ids = new Map(
-      out.split("\n").map((line) => {
-        const sep = line.indexOf(" ");
-        return [line.slice(0, sep), line.slice(sep + 1)] as const;
-      })
-    );
-    ids.delete("(null)");
-    const suggestions: Fig.Suggestion[] = [];
-    for (const [id, path] of ids.entries()) {
-      suggestions.push({
-        name: id,
-        description: path,
-        icon: `fig://${path}`,
-      });
-    }
-    return suggestions;
-  },
-});
 
 const completionSpec: Fig.Spec = {
   name: "tccutil",


### PR DESCRIPTION
`open -a` now lists all apps on your system - this is surprisingly fast. `open` can open all of these, not just apps in /Applications or ~/Applications

<img width="474" alt="image" src="https://user-images.githubusercontent.com/52195359/160760089-82e44330-f4e3-46c4-9b3e-ea4f9cadefe6.png">

Adds completions for `open -b`. This is surprisingly slow. Moved generator from tccutil

<img width="439" alt="image" src="https://user-images.githubusercontent.com/52195359/160760211-0b41742c-240c-40f0-9081-82f631373f53.png">
