### PR TITLE
feat(valet): add isolation subcommands

### DIFF
--- a/src/valet.ts
+++ b/src/valet.ts
@@ -780,7 +780,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "isolated",
       description:
-          "List all sites using isolated versions of PHP.",
+          "List all sites using isolated versions of PHP",
       options: [
         global_option_help,
         global_option_quiet,
@@ -822,7 +822,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "which-php",
       description:
-          "Get the PHP executable path for a site.",
+          "Get the PHP executable path for a site",
       options: [
         global_option_help,
         global_option_quiet,

--- a/src/valet.ts
+++ b/src/valet.ts
@@ -745,6 +745,39 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
+      name: "isolate",
+      description:
+          "Isolate the current project",
+      args: {
+        name: "phpVersion",
+        suggestions: [
+          { name: "php@7.2" },
+          { name: "php@7.3" },
+          { name: "php@7.4" },
+          { name: "php@8.0" },
+        ],
+      },
+      options: [
+        {
+          name: "--site",
+          insertValue: "--site={cursor}",
+          requiresEquals: true,
+          description:
+              "Name of the website you want to isolate",
+          args: {
+            name: "SITE",
+          },
+        },
+        global_option_help,
+        global_option_quiet,
+        global_option_version,
+        global_option_ansi,
+        global_option_noansi,
+        global_option_nointeraction,
+        global_option_verbose,
+      ],
+    },
+    {
       name: "php",
       description:
           "Proxy PHP commands to the \"php\" executable on the isolated site",

--- a/src/valet.ts
+++ b/src/valet.ts
@@ -1,7 +1,7 @@
-// https://laravel.com/docs/8.x/valet
-// laravel version 8
-// valet version 2.15.x
-// 19 June 2021
+// https://laravel.com/docs/9.x/valet
+// laravel version 9
+// valet version 3.1.X
+// 4 April 2022
 
 const global_option_help: Fig.Option = {
   name: ["-h", "--help"],
@@ -734,6 +734,48 @@ const completionSpec: Fig.Spec = {
       name: "which",
       description:
         "Determine which Valet driver serves the current working directory",
+      options: [
+        global_option_help,
+        global_option_quiet,
+        global_option_version,
+        global_option_ansi,
+        global_option_noansi,
+        global_option_nointeraction,
+        global_option_verbose,
+      ],
+    },
+    {
+      name: "php",
+      description:
+          "Proxy PHP commands to the \"php\" executable on the isolated site",
+      options: [
+        global_option_help,
+        global_option_quiet,
+        global_option_version,
+        global_option_ansi,
+        global_option_noansi,
+        global_option_nointeraction,
+        global_option_verbose,
+      ],
+    },
+    {
+      name: "composer",
+      description:
+          "Proxy Composer commands with the \"php\" executable on the isolated site",
+      options: [
+        global_option_help,
+        global_option_quiet,
+        global_option_version,
+        global_option_ansi,
+        global_option_noansi,
+        global_option_nointeraction,
+        global_option_verbose,
+      ],
+    },
+    {
+      name: "which-php",
+      description:
+          "Get the PHP executable path for a site.",
       options: [
         global_option_help,
         global_option_quiet,

--- a/src/valet.ts
+++ b/src/valet.ts
@@ -717,6 +717,7 @@ const completionSpec: Fig.Spec = {
           { name: "php@7.3" },
           { name: "php@7.4" },
           { name: "php@8.0" },
+          { name: "php@8.1" },
         ],
       },
       options: [
@@ -755,6 +756,7 @@ const completionSpec: Fig.Spec = {
           { name: "php@7.3" },
           { name: "php@7.4" },
           { name: "php@8.0" },
+          { name: "php@8.1" },
         ],
       },
       options: [

--- a/src/valet.ts
+++ b/src/valet.ts
@@ -747,7 +747,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "isolate",
       description:
-          "Isolate the current project",
+          "Change the version of PHP used by Valet to serve the current working directory",
       args: {
         name: "phpVersion",
         suggestions: [
@@ -768,6 +768,20 @@ const completionSpec: Fig.Spec = {
             name: "SITE",
           },
         },
+        global_option_help,
+        global_option_quiet,
+        global_option_version,
+        global_option_ansi,
+        global_option_noansi,
+        global_option_nointeraction,
+        global_option_verbose,
+      ],
+    },
+    {
+      name: "isolated",
+      description:
+          "List all sites using isolated versions of PHP.",
+      options: [
         global_option_help,
         global_option_quiet,
         global_option_version,

--- a/src/valet.ts
+++ b/src/valet.ts
@@ -747,7 +747,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "isolate",
       description:
-          "Change the version of PHP used by Valet to serve the current working directory",
+        "Change the version of PHP used by Valet to serve the current working directory",
       args: {
         name: "phpVersion",
         suggestions: [
@@ -762,8 +762,7 @@ const completionSpec: Fig.Spec = {
           name: "--site",
           insertValue: "--site={cursor}",
           requiresEquals: true,
-          description:
-              "Name of the website you want to isolate",
+          description: "Name of the website you want to isolate",
           args: {
             name: "SITE",
           },
@@ -779,8 +778,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "isolated",
-      description:
-          "List all sites using isolated versions of PHP",
+      description: "List all sites using isolated versions of PHP",
       options: [
         global_option_help,
         global_option_quiet,
@@ -794,7 +792,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "php",
       description:
-          "Proxy PHP commands to the \"php\" executable on the isolated site",
+        'Proxy PHP commands to the "php" executable on the isolated site',
       options: [
         global_option_help,
         global_option_quiet,
@@ -808,7 +806,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "composer",
       description:
-          "Proxy Composer commands with the \"php\" executable on the isolated site",
+        'Proxy Composer commands with the "php" executable on the isolated site',
       options: [
         global_option_help,
         global_option_quiet,
@@ -821,8 +819,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "which-php",
-      description:
-          "Get the PHP executable path for a site",
+      description: "Get the PHP executable path for a site",
       options: [
         global_option_help,
         global_option_quiet,

--- a/src/valet.ts
+++ b/src/valet.ts
@@ -779,6 +779,29 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
+      name: "unisolate",
+      description:
+        "Stop customizing the version of PHP used by Valet to serve the current working directory",
+      options: [
+        {
+          name: "--site",
+          insertValue: "--site={cursor}",
+          requiresEquals: true,
+          description: "Name of the website you want to unisolate",
+          args: {
+            name: "SITE",
+          },
+        },
+        global_option_help,
+        global_option_quiet,
+        global_option_version,
+        global_option_ansi,
+        global_option_noansi,
+        global_option_nointeraction,
+        global_option_verbose,
+      ],
+    },
+    {
       name: "isolated",
       description: "List all sites using isolated versions of PHP",
       options: [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This PR adds 6 new commands for the new Laravel Valet https://laravel.com/docs/9.x/valet isolation feature.
You can see these new commands on this PR: https://github.com/laravel/valet/pull/1216 and in this tweet from Matt Stauffer https://twitter.com/stauffermatt/status/1510634227360210950

New commands list:
- valet isolate php@XX
- valet unisolate
- valet isolated
- valet php
- valet composer
- valet which-php

**What is the current behavior? (You can also link to an open issue here)**
Commands missing.

**What is the new behavior (if this is a feature change)?**
New isolation commands available.

**Additional info:**
<img width="759" alt="Capture d’écran 2022-04-04 à 09 59 20" src="https://user-images.githubusercontent.com/1562662/161499927-1375dea4-209f-4bad-9be1-854c4f7d3e2b.png">
