### PR TITLE
feat(git): add config key suggestions

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -497,7 +497,7 @@ const configSuggestions: Fig.Suggestion[] = [
   {
     name: "core.quotePath",
     description:
-      'The commands that output paths (e.g.  ls-files, diff), when not given the -z option, will quote "unusual" characters in the pathname by enclosing the pathname in a double-quote pair and with backslashes the same way strings in C source code are quoted. If this variable is set to false, the bytes higher than 0x80 are not quoted but output as verbatim. Note that double quote, backslash and control characters are always quoted without -z regardless of the setting of this variable',
+      'The commands that output paths (e.g.  ls-files, diff), when not given the -z option, will quote "unusual" characters in the pathname by enclosing the pathname in a double-quote pair and with backslashes the same way strings in C source code are quoted. If this variable is set to false, the bytes higher than 0x80 are not quoted but output as verbatim',
   },
   {
     name: "core.eol",
@@ -712,7 +712,7 @@ const configSuggestions: Fig.Suggestion[] = [
     name: "branch.&lt;name&gt;.remote",
     insertValue: "branch.{cursor}.remote",
     description:
-      "When on branch <name>, it tells git fetch and git push which remote to fetch from/push to. The remote to push to may be overridden with remote.pushDefault (for all branches). The remote to push to, for the current branch, may be further overridden by branch.<name>.pushRemote. If no remote is configured, or if you are not on any branch, it defaults to origin for fetching and remote.pushDefault for pushing. Additionally, . (a period) is the current local repository (a dot-repository), see branch.<name>.merge's final note below",
+      "When on branch <name>, it tells git fetch and git push which remote to fetch from/push to. The remote to push to may be overridden with remote.pushDefault (for all branches). The remote to push to, for the current branch, may be further overridden by branch.<name>.pushRemote. If no remote is configured, or if you are not on any branch, it defaults to origin for fetching and remote.pushDefault for pushing",
   },
   {
     name: "branch.&lt;name&gt;.pushRemote",
@@ -895,7 +895,7 @@ const configSuggestions: Fig.Suggestion[] = [
   {
     name: "credential.username",
     description:
-      "If no username is set for a network authentication, use this username by default. See credential.<context>.* below, and gitcredentials(7)",
+      "If no username is set for a network authentication, use this username by default",
   },
   {
     name: "credential.&lt;url&gt;.*",
@@ -1017,7 +1017,7 @@ const configSuggestions: Fig.Suggestion[] = [
   {
     name: "diff.tool",
     description:
-      "Controls which diff tool is used by git-difftool. This variable overrides the value configured in merge.tool. The list below shows the valid built-in values. Any other value is treated as a custom diff tool and requires that a corresponding difftool.<tool>.cmd variable is defined",
+      "Controls which diff tool is used by git-difftool. This variable overrides the value configured in merge.tool",
   },
   { name: "diff.algorithm", description: "Choose a diff algorithm" },
   {
@@ -1704,7 +1704,7 @@ const configSuggestions: Fig.Suggestion[] = [
   {
     name: "merge.tool",
     description:
-      "Controls which merge tool is used by git-mergetool. The list below shows the valid built-in values. Any other value is treated as a custom merge tool and requires that a corresponding mergetool.<tool>.cmd variable is defined",
+      "Controls which merge tool is used by git-mergetool. Any other value is treated as a custom merge tool and requires that a corresponding mergetool.<tool>.cmd variable is defined",
   },
   {
     name: "merge.verbosity",
@@ -1792,7 +1792,7 @@ const configSuggestions: Fig.Suggestion[] = [
     name: "notes.rewrite.&lt;command&gt;",
     insertValue: "notes.rewrite.{cursor}",
     description:
-      'When rewriting commits with <command> (currently amend or rebase) and this variable is set to true, Git automatically copies your notes from the original to the rewritten commit. Defaults to true, but see "notes.rewriteRef" below',
+      "When rewriting commits with <command> (currently amend or rebase) and this variable is set to true, Git automatically copies your notes from the original to the rewritten commit",
   },
   {
     name: "notes.rewriteMode",
@@ -2143,7 +2143,7 @@ const configSuggestions: Fig.Suggestion[] = [
     name: "sendemail.&lt;identity&gt;.*",
     insertValue: "sendemail.{cursor}.",
     description:
-      "Identity-specific versions of the sendemail.*  parameters found below, taking precedence over those when the this identity is selected, through command-line or sendemail.identity",
+      "Identity-specific versions of the sendemail.*  parameters, taking precedence over those when the this identity is selected, through command-line or sendemail.identity",
   },
   {
     name: "sendemail.aliasesFile",
@@ -2157,8 +2157,14 @@ const configSuggestions: Fig.Suggestion[] = [
     name: "sendemail.annotate",
     description: "See git-send-email for description",
   },
-  { name: "sendemail.bcc", description: "See git-send-email for description" },
-  { name: "sendemail.cc", description: "See git-send-email for description" },
+  {
+    name: "sendemail.bcc",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.cc",
+    description: "See git-send-email for description",
+  },
   {
     name: "sendemail.ccCmd",
     description: "See git-send-email for description",

--- a/src/git.ts
+++ b/src/git.ts
@@ -388,6 +388,2027 @@ export const gitGenerators: Record<string, Fig.Generator> = {
   },
 };
 
+const configSuggestions: Fig.Suggestion[] = [
+  {
+    name: "advice.pushUpdateRejected",
+    description:
+      "Set this variable to false if you want to disable pushNonFFCurrent, pushNonFFMatching, pushAlreadyExists, pushFetchFirst, and pushNeedsForce simultaneously",
+  },
+  {
+    name: "advice.pushNonFFCurrent",
+    description:
+      "Advice shown when git-push fails due to a non-fast-forward update to the current branch",
+  },
+  {
+    name: "advice.pushNonFFMatching",
+    description:
+      "Advice shown when you ran git-push and pushed matching refs explicitly (i.e. you used :, or specified a refspec that isn’t your current branch) and it resulted in a non-fast-forward error",
+  },
+  {
+    name: "advice.pushAlreadyExists",
+    description:
+      "Shown when git-push rejects an update that does not qualify for fast-forwarding (e.g., a tag.)",
+  },
+  {
+    name: "advice.pushFetchFirst",
+    description:
+      "Shown when git-push rejects an update that tries to overwrite a remote ref that points at an object we do not have",
+  },
+  {
+    name: "advice.pushNeedsForce",
+    description:
+      "Shown when git-push rejects an update that tries to overwrite a remote ref that points at an object that is not a commit-ish, or make the remote ref point at an object that is not a commit-ish",
+  },
+  {
+    name: "advice.statusHints",
+    description:
+      "Show directions on how to proceed from the current state in the output of git- status(1), in the template shown when writing commit messages in git-commit, and in the help message shown by git-checkout when switching branch",
+  },
+  {
+    name: "advice.statusUoption",
+    description:
+      "Advise to consider using the -u option to git-status when the command takes more than 2 seconds to enumerate untracked files",
+  },
+  {
+    name: "advice.commitBeforeMerge",
+    description:
+      "Advice shown when git-merge refuses to merge to avoid overwriting local changes",
+  },
+  {
+    name: "advice.resolveConflict",
+    description:
+      "Advice shown by various commands when conflicts prevent the operation from being performed",
+  },
+  {
+    name: "advice.implicitIdentity",
+    description:
+      "Advice on how to set your identity configuration when your information is guessed from the system username and domain name",
+  },
+  {
+    name: "advice.detachedHead",
+    description:
+      "Advice shown when you used git-checkout to move to the detach HEAD state, to instruct how to create a local branch after the fact",
+  },
+  {
+    name: "advice.amWorkDir",
+    description:
+      "Advice that shows the location of the patch file when git-am fails to apply it",
+  },
+  {
+    name: "advice.rmHints",
+    description:
+      "In case of failure in the output of git-rm, show directions on how to proceed from the current state",
+  },
+  {
+    name: "core.fileMode",
+    description:
+      "Tells Git if the executable bit of files in the working tree is to be honored",
+  },
+  {
+    name: "core.ignoreCase",
+    description:
+      'If true, this option enables various workarounds to enable Git to work better on filesystems that are not case sensitive, like FAT. For example, if a directory listing finds "makefile" when Git expects "Makefile", Git will assume it is really the same file, and continue to remember it as "Makefile"',
+  },
+  {
+    name: "core.precomposeUnicode",
+    description:
+      "This option is only used by Mac OS implementation of Git. When core.precomposeUnicode=true, Git reverts the unicode decomposition of filenames done by Mac OS. This is useful when sharing a repository between Mac OS and Linux or Windows. (Git for Windows 1.7.10 or higher is needed, or Git under cygwin 1.7). When false, file names are handled fully transparent by Git, which is backward compatible with older versions of Git",
+  },
+  {
+    name: "core.protectHFS",
+    description:
+      "If set to true, do not allow checkout of paths that would be considered equivalent to .git on an HFS+ filesystem. Defaults to true on Mac OS, and false elsewhere",
+  },
+  {
+    name: "core.protectNTFS",
+    description:
+      'If set to true, do not allow checkout of paths that would cause problems with the NTFS filesystem, e.g. conflict with 8.3 "short" names. Defaults to true on Windows, and false elsewhere',
+  },
+  {
+    name: "core.trustctime",
+    description:
+      "If false, the ctime differences between the index and the working tree are ignored; useful when the inode change time is regularly modified by something outside Git (file system crawlers and some backup systems). See git-update-index. True by default",
+  },
+  {
+    name: "core.checkStat",
+    description:
+      "Determines which stat fields to match between the index and work tree. The user can set this to default or minimal. Default (or explicitly default), is to check all fields, including the sub-second part of mtime and ctime",
+  },
+  {
+    name: "core.quotePath",
+    description:
+      'The commands that output paths (e.g.  ls-files, diff), when not given the -z option, will quote "unusual" characters in the pathname by enclosing the pathname in a double-quote pair and with backslashes the same way strings in C source code are quoted. If this variable is set to false, the bytes higher than 0x80 are not quoted but output as verbatim. Note that double quote, backslash and control characters are always quoted without -z regardless of the setting of this variable',
+  },
+  {
+    name: "core.eol",
+    description:
+      "Sets the line ending type to use in the working directory for files that have the text property set. Alternatives are lf, crlf and native, which uses the platform’s native line ending. The default value is native. See gitattributes(5) for more information on end-of-line conversion",
+  },
+  {
+    name: "core.safecrlf",
+    description:
+      'If true, makes Git check if converting CRLF is reversible when end-of-line conversion is active. Git will verify if a command modifies a file in the work tree either directly or indirectly. For example, committing a file followed by checking out the same file should yield the original file in the work tree. If this is not the case for the current setting of core.autocrlf, Git will reject the file. The variable can be set to "warn", in which case Git will only warn about an irreversible conversion but continue the operation',
+  },
+  {
+    name: "core.autocrlf",
+    description:
+      'Setting this variable to "true" is almost the same as setting the text attribute to "auto" on all files except that text files are not guaranteed to be normalized: files that contain CRLF in the repository will not be touched. Use this setting if you want to have CRLF line endings in your working directory even though the repository does not have normalized line endings. This variable can be set to input, in which case no output conversion is performed',
+  },
+  {
+    name: "core.symlinks",
+    description:
+      "If false, symbolic links are checked out as small plain files that contain the link text.  git-update-index(1) and git-add will not change the recorded type to regular file. Useful on filesystems like FAT that do not support symbolic links",
+  },
+  {
+    name: "core.gitProxy",
+    description:
+      'A "proxy command" to execute (as command host port) instead of establishing direct connection to the remote server when using the Git protocol for fetching. If the variable value is in the "COMMAND for DOMAIN" format, the command is applied only on hostnames ending with the specified domain string. This variable may be set multiple times and is matched in the given order; the first match wins',
+  },
+  {
+    name: "core.ignoreStat",
+    description:
+      'If true, Git will avoid using lstat() calls to detect if files have changed by setting the "assume-unchanged" bit for those tracked files which it has updated identically in both the index and working tree',
+  },
+  {
+    name: "core.preferSymlinkRefs",
+    description:
+      'Instead of the default "symref" format for HEAD and other symbolic reference files, use symbolic links. This is sometimes needed to work with old scripts that expect HEAD to be a symbolic link',
+  },
+  {
+    name: "core.bare",
+    description:
+      "If true this repository is assumed to be bare and has no working directory associated with it. If this is the case a number of commands that require a working directory will be disabled, such as git-add(1) or git-merge",
+  },
+  {
+    name: "core.worktree",
+    description:
+      "Set the path to the root of the working tree. If GIT_COMMON_DIR environment variable is set, core.worktree is ignored and not used for determining the root of working tree. This can be overridden by the GIT_WORK_TREE environment variable and the --work-tree command-line option. The value can be an absolute path or relative to the path to the .git directory, which is either specified by --git-dir or GIT_DIR, or automatically discovered. If --git-dir or GIT_DIR is specified but none of --work-tree, GIT_WORK_TREE and core.worktree is specified, the current working directory is regarded as the top level of your working tree",
+  },
+  {
+    name: "core.logAllRefUpdates",
+    description:
+      'Enable the reflog. Updates to a ref <ref> is logged to the file "$GIT_DIR/logs/<ref>", by appending the new and old SHA-1, the date/time and the reason of the update, but only when the file exists. If this configuration variable is set to true, missing "$GIT_DIR/logs/<ref>" file is automatically created for branch heads (i.e. under refs/heads/), remote refs (i.e. under refs/remotes/), note refs (i.e. under refs/notes/), and the symbolic ref HEAD',
+  },
+  {
+    name: "core.repositoryFormatVersion",
+    description:
+      "Internal variable identifying the repository format and layout version",
+  },
+  {
+    name: "core.sharedRepository",
+    description:
+      "When group (or true), the repository is made shareable between several users in a group (making sure all the files and objects are group-writable). When all (or world or everybody), the repository will be readable by all users, additionally to being group-shareable. When umask (or false), Git will use permissions reported by umask(2). When 0xxx, where 0xxx is an octal number, files in the repository will have this mode value.  0xxx will override user’s umask value (whereas the other options will only override requested parts of the user’s umask value). Examples: 0660 will make the repo read/write-able for the owner and group, but inaccessible to others (equivalent to group unless umask is e.g.  0022).  0640 is a repository that is group-readable but not group-writable. See git-init. False by default",
+  },
+  {
+    name: "core.warnAmbiguousRefs",
+    description:
+      "If true, Git will warn you if the ref name you passed it is ambiguous and might match multiple refs in the repository. True by default",
+  },
+  {
+    name: "core.compression",
+    description:
+      "An integer -1..9, indicating a default compression level. -1 is the zlib default. 0 means no compression, and 1..9 are various speed/size tradeoffs, 9 being slowest. If set, this provides a default to other compression variables, such as core.looseCompression and pack.compression",
+  },
+  {
+    name: "core.looseCompression",
+    description:
+      "An integer -1..9, indicating the compression level for objects that are not in a pack file. -1 is the zlib default. 0 means no compression, and 1..9 are various speed/size tradeoffs, 9 being slowest. If not set, defaults to core.compression. If that is not set, defaults to 1 (best speed)",
+  },
+  {
+    name: "core.packedGitWindowSize",
+    description:
+      "Number of bytes of a pack file to map into memory in a single mapping operation. Larger window sizes may allow your system to process a smaller number of large pack files more quickly. Smaller window sizes will negatively affect performance due to increased calls to the operating system’s memory manager, but may improve performance when accessing a large number of large pack files",
+  },
+  {
+    name: "core.packedGitLimit",
+    description:
+      "Maximum number of bytes to map simultaneously into memory from pack files. If Git needs to access more than this many bytes at once to complete an operation it will unmap existing regions to reclaim virtual address space within the process",
+  },
+  {
+    name: "core.deltaBaseCacheLimit",
+    description:
+      "Maximum number of bytes to reserve for caching base objects that may be referenced by multiple deltified objects. By storing the entire decompressed base objects in a cache Git is able to avoid unpacking and decompressing frequently used base objects multiple times",
+  },
+  {
+    name: "core.bigFileThreshold",
+    description:
+      "Files larger than this size are stored deflated, without attempting delta compression. Storing large files without delta compression avoids excessive memory usage, at the slight expense of increased disk usage. Additionally files larger than this size are always treated as binary",
+  },
+  {
+    name: "core.excludesFile",
+    description:
+      'In addition to .gitignore (per-directory) and .git/info/exclude, Git looks into this file for patterns of files which are not meant to be tracked"~/" is expanded to the value of $HOME and "~user/" to the specified user’s home directory. Its default value is $XDG_CONFIG_HOME/git/ignore. If $XDG_CONFIG_HOME is either not set or empty, $HOME/.config/git/ignore is used instead. See gitignore(5)',
+  },
+  {
+    name: "core.askPass",
+    description:
+      "Some commands (e.g. svn and http interfaces) that interactively ask for a password can be told to use an external program given via the value of this variable. Can be overridden by the GIT_ASKPASS environment variable. If not set, fall back to the value of the SSH_ASKPASS environment variable or, failing that, a simple password prompt. The external program shall be given a suitable prompt as command-line argument and write the password on its STDOUT",
+  },
+  {
+    name: "core.attributesFile",
+    description:
+      "In addition to .gitattributes (per-directory) and .git/info/attributes, Git looks into this file for attributes (see gitattributes(5)). Path expansions are made the same way as for core.excludesFile. Its default value is $XDG_CONFIG_HOME/git/attributes. If $XDG_CONFIG_HOME is either not set or empty, $HOME/.config/git/attributes is used instead",
+  },
+  {
+    name: "core.editor",
+    description:
+      "Commands such as commit and tag that lets you edit messages by launching an editor uses the value of this variable when it is set, and the environment variable GIT_EDITOR is not set. See git-var",
+  },
+  {
+    name: "core.commentChar",
+    description:
+      "Commands such as commit and tag that lets you edit messages consider a line that begins with this character commented, and removes them after the editor returns (default #)",
+  },
+  {
+    name: "core.packedRefsTimeout",
+    description:
+      "The length of time, in milliseconds, to retry when trying to lock the packed-refs file. Value 0 means not to retry at all; -1 means to try indefinitely. Default is 1000 (i.e., retry for 1 second)",
+  },
+  {
+    name: "sequence.editor",
+    description:
+      "Text editor used by git rebase -i for editing the rebase instruction file. The value is meant to be interpreted by the shell when it is used. It can be overridden by the GIT_SEQUENCE_EDITOR environment variable. When not configured the default commit message editor is used instead",
+  },
+  {
+    name: "core.pager",
+    description:
+      "Text viewer for use by Git commands (e.g., less). The value is meant to be interpreted by the shell. The order of preference is the $GIT_PAGER environment variable, then core.pager configuration, then $PAGER, and then the default chosen at compile time (usually less)",
+  },
+  {
+    name: "core.whitespace",
+    description:
+      "A comma separated list of common whitespace problems to notice.  git diff will use color.diff.whitespace to highlight them, and git apply --whitespace=error will consider them as errors",
+  },
+  {
+    name: "core.fsyncObjectFiles",
+    description: "This boolean will enable fsync() when writing object files",
+  },
+  {
+    name: "core.preloadIndex",
+    description: "Enable parallel index preload for operations like git diff",
+  },
+  {
+    name: "core.createObject",
+    description:
+      "You can set this to link, in which case a hardlink followed by a delete of the source are used to make sure that object creation will not overwrite existing objects",
+  },
+  {
+    name: "core.notesRef",
+    description:
+      "When showing commit messages, also show notes which are stored in the given ref. The ref must be fully qualified. If the given ref does not exist, it is not an error but means that no notes should be printed",
+  },
+  {
+    name: "core.sparseCheckout",
+    description:
+      'Enable "sparse checkout" feature. See section "Sparse checkout" in git-read-tree for more information',
+  },
+  {
+    name: "core.abbrev",
+    description:
+      "Set the length object names are abbreviated to. If unspecified, many commands abbreviate to 7 hexdigits, which may not be enough for abbreviated object names to stay unique for sufficiently long time",
+  },
+  {
+    name: "add.ignoreErrors",
+    description:
+      "Tells git add to continue adding files when some files cannot be added due to indexing errors. Equivalent to the --ignore-errors option of git-add.  add.ignore-errors is deprecated, as it does not follow the usual naming convention for configuration variables",
+  },
+  {
+    name: "alias.*",
+    insertValue: "alias.{cursor}",
+    description:
+      'Command aliases for the git(1) command wrapper - e.g. after defining "alias.last = cat-file commit HEAD", the invocation "git last" is equivalent to "git cat-file commit HEAD". To avoid confusion and troubles with script usage, aliases that hide existing Git commands are ignored. Arguments are split by spaces, the usual shell quoting and escaping is supported. A quote pair or a backslash can be used to quote them',
+  },
+  {
+    name: "am.keepcr",
+    description:
+      "If true, git-am will call git-mailsplit for patches in mbox format with parameter --keep-cr. In this case git-mailsplit will not remove \r from lines ending with \r\n. Can be overridden by giving --no-keep-cr from the command line. See git-am, git- mailsplit(1)",
+  },
+  {
+    name: "am.threeWay",
+    description:
+      "By default, git am will fail if the patch does not apply cleanly. When set to true, this setting tells git am to fall back on 3-way merge if the patch records the identity of blobs it is supposed to apply to and we have those blobs available locally (equivalent to giving the --3way option from the command line). Defaults to false. See git-am",
+  },
+  {
+    name: "apply.ignoreWhitespace",
+    description:
+      "When set to change, tells git apply to ignore changes in whitespace, in the same way as the --ignore-space-change option. When set to one of: no, none, never, false tells git apply to respect all whitespace differences. See git-apply",
+  },
+  {
+    name: "apply.whitespace",
+    description:
+      "Tells git apply how to handle whitespaces, in the same way as the --whitespace option. See git-apply",
+  },
+  {
+    name: "branch.autoSetupMerge",
+    description:
+      "Tells git branch and git checkout to set up new branches so that git-pull will appropriately merge from the starting point branch. Note that even if this option is not set, this behavior can be chosen per-branch using the --track and --no-track options. The valid settings are: false — no automatic setup is done; true — automatic setup is done when the starting point is a remote-tracking branch; always —  automatic setup is done when the starting point is either a local branch or remote-tracking branch. This option defaults to true",
+  },
+  {
+    name: "branch.autoSetupRebase",
+    description:
+      'When a new branch is created with git branch or git checkout that tracks another branch, this variable tells Git to set up pull to rebase instead of merge (see "branch.<name>.rebase"). When never, rebase is never automatically set to true. When local, rebase is set to true for tracked branches of other local branches. When remote, rebase is set to true for tracked branches of remote-tracking branches. When always, rebase will be set to true for all tracking branches. See "branch.autoSetupMerge" for details on how to set up a branch to track another branch. This option defaults to never',
+  },
+  {
+    name: "branch.&lt;name&gt;.remote",
+    insertValue: "branch.{cursor}.remote",
+    description:
+      "When on branch <name>, it tells git fetch and git push which remote to fetch from/push to. The remote to push to may be overridden with remote.pushDefault (for all branches). The remote to push to, for the current branch, may be further overridden by branch.<name>.pushRemote. If no remote is configured, or if you are not on any branch, it defaults to origin for fetching and remote.pushDefault for pushing. Additionally, . (a period) is the current local repository (a dot-repository), see branch.<name>.merge's final note below",
+  },
+  {
+    name: "branch.&lt;name&gt;.pushRemote",
+    insertValue: "branch.{cursor}.pushRemote",
+    description:
+      "When on branch <name>, it overrides branch.<name>.remote for pushing. It also overrides remote.pushDefault for pushing from branch <name>. When you pull from one place (e.g. your upstream) and push to another place (e.g. your own publishing repository), you would want to set remote.pushDefault to specify the remote to push to for all branches, and use this option to override it for a specific branch",
+  },
+  {
+    name: "branch.&lt;name&gt;.merge",
+    insertValue: "branch.{cursor}.merge",
+    description:
+      'Defines, together with branch.<name>.remote, the upstream branch for the given branch. It tells git fetch/git pull/git rebase which branch to merge and can also affect git push (see push.default). When in branch <name>, it tells git fetch the default refspec to be marked for merging in FETCH_HEAD. The value is handled like the remote part of a refspec, and must match a ref which is fetched from the remote given by "branch.<name>.remote". The merge information is used by git pull (which at first calls git fetch) to lookup the default branch for merging. Without this option, git pull defaults to merge the first refspec fetched. Specify multiple values to get an octopus merge. If you wish to setup git pull so that it merges into <name> from another branch in the local repository, you can point branch.<name>.merge to the desired branch, and use the relative path setting .  (a period) for branch.<name>.remote',
+  },
+  {
+    name: "branch.&lt;name&gt;.mergeOptions",
+    insertValue: "branch.{cursor}.mergeOptions",
+    description:
+      "Sets default options for merging into branch <name>. The syntax and supported options are the same as those of git-merge, but option values containing whitespace characters are currently not supported",
+  },
+  {
+    name: "branch.&lt;name&gt;.rebase",
+    insertValue: "branch.{cursor}.rebase",
+    description:
+      'When true, rebase the branch <name> on top of the fetched branch, instead of merging the default branch from the default remote when "git pull" is run. See "pull.rebase" for doing this in a non branch-specific manner',
+  },
+  {
+    name: "branch.&lt;name&gt;.description",
+    insertValue: "branch.{cursor}.description",
+    description:
+      "Branch description, can be edited with git branch --edit-description. Branch description is automatically added in the format-patch cover letter or request-pull summary",
+  },
+  {
+    name: "browser.&lt;tool&gt;.cmd",
+    insertValue: "browser.{cursor}.cmd",
+    description:
+      "Specify the command to invoke the specified browser. The specified command is evaluated in shell with the URLs passed as arguments. (See git-web--browse.)",
+  },
+  {
+    name: "browser.&lt;tool&gt;.path",
+    insertValue: "browser.{cursor}.path",
+    description:
+      "Override the path for the given tool that may be used to browse HTML help (see -w option in git-help(1)) or a working repository in gitweb (see git-instaweb)",
+  },
+  {
+    name: "clean.requireForce",
+    description:
+      "A boolean to make git-clean do nothing unless given -f, -i or -n. Defaults to true",
+  },
+  {
+    name: "color.branch",
+    description:
+      "A boolean to enable/disable color in the output of git-branch. May be set to always, false (or never) or auto (or true), in which case colors are used only when the output is to a terminal. Defaults to false",
+  },
+  {
+    name: "color.branch.&lt;slot&gt;",
+    insertValue: "color.branch.{cursor}",
+    description:
+      "Use customized color for branch coloration.  <slot> is one of current (the current branch), local (a local branch), remote (a remote-tracking branch in refs/remotes/), upstream (upstream tracking branch), plain (other refs)",
+  },
+  {
+    name: "color.diff",
+    description:
+      "Whether to use ANSI escape sequences to add color to patches. If this is set to always, git-diff(1), git-log(1), and git-show will use color for all patches. If it is set to true or auto, those commands will only use color when output is to the terminal. Defaults to false",
+  },
+  {
+    name: "color.diff.&lt;slot&gt;",
+    insertValue: "color.diff.{cursor}",
+    description:
+      "Use customized color for diff colorization.  <slot> specifies which part of the patch to use the specified color, and is one of context (context text - plain is a historical synonym), meta (metainformation), frag (hunk header), func (function in hunk header), old (removed lines), new (added lines), commit (commit headers), or whitespace (highlighting whitespace errors)",
+  },
+  {
+    name: "color.decorate.&lt;slot&gt;",
+    insertValue: "color.decorate.{cursor}",
+    description:
+      "Use customized color for git log --decorate output.  <slot> is one of branch, remoteBranch, tag, stash or HEAD for local branches, remote-tracking branches, tags, stash and HEAD, respectively",
+  },
+  {
+    name: "color.grep",
+    description:
+      "When set to always, always highlight matches. When false (or never), never. When set to true or auto, use color only when the output is written to the terminal. Defaults to false",
+  },
+  {
+    name: "color.grep.&lt;slot&gt;",
+    insertValue: "color.grep.{cursor}",
+    description:
+      "Use customized color for grep colorization.  <slot> specifies which part of the line to use the specified color",
+  },
+  {
+    name: "color.interactive",
+    description:
+      'When set to always, always use colors for interactive prompts and displays (such as those used by "git-add --interactive" and "git-clean --interactive"). When false (or never), never. When set to true or auto, use colors only when the output is to the terminal. Defaults to false',
+  },
+  {
+    name: "color.interactive.&lt;slot&gt;",
+    insertValue: "color.interactive.{cursor}",
+    description:
+      "Use customized color for git add --interactive and git clean --interactive output. <slot> may be prompt, header, help or error, for four distinct types of normal output from interactive commands",
+  },
+  {
+    name: "color.pager",
+    description:
+      "A boolean to enable/disable colored output when the pager is in use (default is true)",
+  },
+  {
+    name: "color.showBranch",
+    description:
+      "A boolean to enable/disable color in the output of git-show-branch. May be set to always, false (or never) or auto (or true), in which case colors are used only when the output is to a terminal. Defaults to false",
+  },
+  {
+    name: "color.status",
+    description:
+      "A boolean to enable/disable color in the output of git-status. May be set to always, false (or never) or auto (or true), in which case colors are used only when the output is to a terminal. Defaults to false",
+  },
+  {
+    name: "color.status.&lt;slot&gt;",
+    insertValue: "color.status.{cursor}",
+    description:
+      "Use customized color for status colorization.  <slot> is one of header (the header text of the status message), added or updated (files which are added but not committed), changed (files which are changed but not added in the index), untracked (files which are not tracked by Git), branch (the current branch), nobranch (the color the no branch warning is shown in, defaulting to red), or unmerged (files which have unmerged changes)",
+  },
+  {
+    name: "color.ui",
+    description:
+      "This variable determines the default value for variables such as color.diff and color.grep that control the use of color per command family. Its scope will expand as more commands learn configuration to set a default for the --color option. Set it to false or never if you prefer Git commands not to use color unless enabled explicitly with some other configuration or the --color option. Set it to always if you want all output not intended for machine consumption to use color, to true or auto (this is the default since Git 1.8.4) if you want such output to use color when written to the terminal",
+  },
+  {
+    name: "column.ui",
+    description:
+      "Specify whether supported commands should output in columns. This variable consists of a list of tokens separated by spaces or commas",
+  },
+  {
+    name: "column.branch",
+    description:
+      "Specify whether to output branch listing in git branch in columns. See column.ui for details",
+  },
+  {
+    name: "column.clean",
+    description:
+      "Specify the layout when list items in git clean -i, which always shows files and directories in columns. See column.ui for details",
+  },
+  {
+    name: "column.status",
+    description:
+      "Specify whether to output untracked files in git status in columns. See column.ui for details",
+  },
+  {
+    name: "column.tag",
+    description:
+      "Specify whether to output tag listing in git tag in columns. See column.ui for details",
+  },
+  {
+    name: "commit.cleanup",
+    description:
+      "This setting overrides the default of the --cleanup option in git commit. See git- commit(1) for details. Changing the default can be useful when you always want to keep lines that begin with comment character # in your log message, in which case you would do git config commit.cleanup whitespace (note that you will have to remove the help lines that begin with # in the commit log template yourself, if you do this)",
+  },
+  {
+    name: "commit.gpgSign",
+    description:
+      "A boolean to specify whether all commits should be GPG signed. Use of this option when doing operations such as rebase can result in a large number of commits being signed. It may be convenient to use an agent to avoid typing your GPG passphrase several times",
+  },
+  {
+    name: "commit.status",
+    description:
+      "A boolean to enable/disable inclusion of status information in the commit message template when using an editor to prepare the commit message. Defaults to true",
+  },
+  {
+    name: "commit.template",
+    description:
+      'Specify a file to use as the template for new commit messages"~/" is expanded to the value of $HOME and "~user/" to the specified user’s home directory',
+  },
+  {
+    name: "credential.helper",
+    description:
+      "Specify an external helper to be called when a username or password credential is needed; the helper may consult external storage to avoid prompting the user for the credentials. See gitcredentials(7) for details",
+  },
+  {
+    name: "credential.useHttpPath",
+    description:
+      'When acquiring credentials, consider the "path" component of an http or https URL to be important. Defaults to false. See gitcredentials(7) for more information',
+  },
+  {
+    name: "credential.username",
+    description:
+      "If no username is set for a network authentication, use this username by default. See credential.<context>.* below, and gitcredentials(7)",
+  },
+  {
+    name: "credential.&lt;url&gt;.*",
+    insertValue: "credential.{cursor}.",
+    description:
+      'Any of the credential.* options above can be applied selectively to some credentials. For example "credential.https://example.com.username" would set the default username only for https connections to example.com. See gitcredentials(7) for details on how URLs are matched',
+  },
+  {
+    name: "credentialCache.ignoreSIGHUP",
+    description:
+      "Tell git-credential-cache—daemon to ignore SIGHUP, instead of quitting",
+  },
+  {
+    name: "diff.autoRefreshIndex",
+    description:
+      "When using git diff to compare with work tree files, do not consider stat-only change as changed. Instead, silently run git update-index --refresh to update the cached stat information for paths whose contents in the work tree match the contents in the index. This option defaults to true. Note that this affects only git diff Porcelain, and not lower level diff commands such as git diff-files",
+  },
+  {
+    name: "diff.dirstat",
+    description:
+      "A comma separated list of --dirstat parameters specifying the default behavior of the --dirstat option to git-diff` and friends. The defaults can be overridden on the command line (using --dirstat=<param1,param2,...>). The fallback defaults (when not changed by diff.dirstat) are changes,noncumulative,3",
+  },
+  {
+    name: "diff.statGraphWidth",
+    description:
+      "Limit the width of the graph part in --stat output. If set, applies to all commands generating --stat output except format-patch",
+  },
+  {
+    name: "diff.context",
+    description:
+      "Generate diffs with <n> lines of context instead of the default of 3. This value is overridden by the -U option",
+  },
+  {
+    name: "diff.external",
+    description:
+      'If this config variable is set, diff generation is not performed using the internal diff machinery, but using the given command. Can be overridden with the ‘GIT_EXTERNAL_DIFF’ environment variable. The command is called with parameters as described under "git Diffs" in git(1). Note: if you want to use an external diff program only on a subset of your files, you might want to use gitattributes(5) instead',
+  },
+  {
+    name: "diff.ignoreSubmodules",
+    description:
+      "Sets the default value of --ignore-submodules. Note that this affects only git diff Porcelain, and not lower level diff commands such as git diff-files.  git checkout also honors this setting when reporting uncommitted changes. Setting it to all disables the submodule summary normally shown by git commit and git status when status.submoduleSummary is set unless it is overridden by using the --ignore-submodules command-line option. The git submodule commands are not affected by this setting",
+  },
+  {
+    name: "diff.mnemonicPrefix",
+    description:
+      'If set, git diff uses a prefix pair that is different from the standard "a/" and "b/" depending on what is being compared. When this configuration is in effect, reverse diff output also swaps the order of the prefixes:',
+  },
+  {
+    name: "diff.noprefix",
+    description:
+      "If set, git diff does not show any source or destination prefix",
+  },
+  {
+    name: "diff.orderFile",
+    description:
+      "File indicating how to order files within a diff, using one shell glob pattern per line. Can be overridden by the -O option to git-diff",
+  },
+  {
+    name: "diff.renameLimit",
+    description:
+      "The number of files to consider when performing the copy/rename detection; equivalent to the git diff option -l",
+  },
+  {
+    name: "diff.renames",
+    description:
+      'Tells Git to detect renames. If set to any boolean value, it will enable basic rename detection. If set to "copies" or "copy", it will detect copies, as well',
+  },
+  {
+    name: "diff.suppressBlankEmpty",
+    description:
+      "A boolean to inhibit the standard behavior of printing a space before each empty output line. Defaults to false",
+  },
+  {
+    name: "diff.submodule",
+    description:
+      'Specify the format in which differences in submodules are shown. The "log" format lists the commits in the range like git-submodule summary does. The "short" format format just shows the names of the commits at the beginning and end of the range. Defaults to short',
+  },
+  {
+    name: "diff.wordRegex",
+    description:
+      'A POSIX Extended Regular Expression used to determine what is a "word" when performing word-by-word difference calculations. Character sequences that match the regular expression are "words", all other characters are ignorable whitespace',
+  },
+  {
+    name: "diff.&lt;driver&gt;.command",
+    insertValue: "diff.{cursor}.command",
+    description:
+      "The custom diff driver command. See gitattributes(5) for details",
+  },
+  {
+    name: "diff.&lt;driver&gt;.xfuncname",
+    insertValue: "diff.{cursor}.xfuncname",
+    description:
+      "The regular expression that the diff driver should use to recognize the hunk header. A built-in pattern may also be used. See gitattributes(5) for details",
+  },
+  {
+    name: "diff.&lt;driver&gt;.binary",
+    insertValue: "diff.{cursor}.binary",
+    description:
+      "Set this option to true to make the diff driver treat files as binary. See gitattributes(5) for details",
+  },
+  {
+    name: "diff.&lt;driver&gt;.textconv",
+    insertValue: "diff.{cursor}.textconv",
+    description:
+      "The command that the diff driver should call to generate the text-converted version of a file. The result of the conversion is used to generate a human-readable diff. See gitattributes(5) for details",
+  },
+  {
+    name: "diff.&lt;driver&gt;.wordRegex",
+    insertValue: "diff.{cursor}.wordRegex",
+    description:
+      "The regular expression that the diff driver should use to split words in a line. See gitattributes(5) for details",
+  },
+  {
+    name: "diff.&lt;driver&gt;.cachetextconv",
+    insertValue: "diff.{cursor}.cachetextconv",
+    description:
+      "Set this option to true to make the diff driver cache the text conversion outputs. See gitattributes(5) for details",
+  },
+  {
+    name: "diff.tool",
+    description:
+      "Controls which diff tool is used by git-difftool. This variable overrides the value configured in merge.tool. The list below shows the valid built-in values. Any other value is treated as a custom diff tool and requires that a corresponding difftool.<tool>.cmd variable is defined",
+  },
+  { name: "diff.algorithm", description: "Choose a diff algorithm" },
+  {
+    name: "difftool.&lt;tool&gt;.path",
+    insertValue: "difftool.{cursor}.path",
+    description:
+      "Override the path for the given tool. This is useful in case your tool is not in the PATH",
+  },
+  {
+    name: "difftool.&lt;tool&gt;.cmd",
+    insertValue: "difftool.{cursor}.cmd",
+    description:
+      "Specify the command to invoke the specified diff tool. The specified command is evaluated in shell with the following variables available: LOCAL is set to the name of the temporary file containing the contents of the diff pre-image and REMOTE is set to the name of the temporary file containing the contents of the diff post-image",
+  },
+  {
+    name: "difftool.prompt",
+    description: "Prompt before each invocation of the diff tool",
+  },
+  {
+    name: "fetch.recurseSubmodules",
+    description:
+      "This option can be either set to a boolean value or to on-demand. Setting it to a boolean changes the behavior of fetch and pull to unconditionally recurse into submodules when set to true or to not recurse at all when set to false. When set to on-demand (the default value), fetch and pull will only recurse into a populated submodule when its superproject retrieves a commit that updates the submodule’s reference",
+  },
+  {
+    name: "fetch.fsckObjects",
+    description:
+      "If it is set to true, git-fetch-pack will check all fetched objects. It will abort in the case of a malformed object or a broken link. The result of an abort are only dangling objects. Defaults to false. If not set, the value of transfer.fsckObjects is used instead",
+  },
+  {
+    name: "fetch.unpackLimit",
+    description:
+      "If the number of objects fetched over the Git native transfer is below this limit, then the objects will be unpacked into loose object files. However if the number of received objects equals or exceeds this limit then the received pack will be stored as a pack, after adding any missing delta bases. Storing the pack from a push can make the push operation complete faster, especially on slow filesystems. If not set, the value of transfer.unpackLimit is used instead",
+  },
+  {
+    name: "fetch.prune",
+    description:
+      "If true, fetch will automatically behave as if the --prune option was given on the command line. See also remote.<name>.prune",
+  },
+  {
+    name: "format.attach",
+    description:
+      "Enable multipart/mixed attachments as the default for format-patch. The value can also be a double quoted string which will enable attachments as the default and set the value as the boundary. See the --attach option in git-format-patch",
+  },
+  {
+    name: "format.numbered",
+    description:
+      'A boolean which can enable or disable sequence numbers in patch subjects. It defaults to "auto" which enables it only if there is more than one patch. It can be enabled or disabled for all messages by setting it to "true" or "false". See --numbered option in git-format-patch',
+  },
+  {
+    name: "format.headers",
+    description:
+      "Additional email headers to include in a patch to be submitted by mail. See git- format-patch(1)",
+  },
+  {
+    name: "format.to",
+    description:
+      "Additional recipients to include in a patch to be submitted by mail. See the --to and --cc options in git-format-patch",
+  },
+  {
+    name: "format.cc",
+    description:
+      "Additional recipients to include in a patch to be submitted by mail. See the --to and --cc options in git-format-patch",
+  },
+  {
+    name: "format.subjectPrefix",
+    description:
+      "The default for format-patch is to output files with the [PATCH] subject prefix. Use this variable to change that prefix",
+  },
+  {
+    name: "format.signature",
+    description:
+      'The default for format-patch is to output a signature containing the Git version number. Use this variable to change that default. Set this variable to the empty string ("")',
+  },
+  {
+    name: "format.signatureFile",
+    description:
+      "Works just like format.signature except the contents of the file specified by this variable will be used as the signature",
+  },
+  {
+    name: "format.suffix",
+    description:
+      "The default for format-patch is to output files with the suffix .patch. Use this variable to change that suffix (make sure to include the dot if you want it)",
+  },
+  {
+    name: "format.pretty",
+    description:
+      "The default pretty format for log/show/whatchanged command, See git-log, git- show(1), git-whatchanged",
+  },
+  {
+    name: "format.thread",
+    description:
+      "The default threading style for git format-patch. Can be a boolean value, or shallow or deep.  shallow threading makes every mail a reply to the head of the series, where the head is chosen from the cover letter, the --in-reply-to, and the first patch mail, in this order.  deep threading makes every mail a reply to the previous one. A true boolean value is the same as shallow, and a false value disables threading",
+  },
+  {
+    name: "format.signOff",
+    description:
+      "A boolean value which lets you enable the -s/--signoff option of format-patch by default.  Note: Adding the Signed-off-by: line to a patch should be a conscious act and means that you certify you have the rights to submit this work under the same open source license. Please see the SubmittingPatches document for further discussion",
+  },
+  {
+    name: "format.coverLetter",
+    description:
+      'A boolean that controls whether to generate a cover-letter when format-patch is invoked, but in addition can be set to "auto", to generate a cover-letter only when there’s more than one patch',
+  },
+  {
+    name: "filter.&lt;driver&gt;.clean",
+    insertValue: "filter.{cursor}.clean",
+    description:
+      "The command which is used to convert the content of a worktree file to a blob upon checkin. See gitattributes(5) for details",
+  },
+  {
+    name: "filter.&lt;driver&gt;.smudge",
+    insertValue: "filter.{cursor}.smudge",
+    description:
+      "The command which is used to convert the content of a blob object to a worktree file upon checkout. See gitattributes(5) for details",
+  },
+  {
+    name: "fsck.&lt;msg-id&gt;",
+    insertValue: "fsck.{cursor}",
+    description:
+      "Allows overriding the message type (error, warn or ignore) of a specific message ID such as missingEmail",
+  },
+  {
+    name: "fsck.skipList",
+    description:
+      "The path to a sorted list of object names (i.e. one SHA-1 per line) that are known to be broken in a non-fatal way and should be ignored. This feature is useful when an established project should be accepted despite early commits containing errors that can be safely ignored such as invalid committer email addresses. Note: corrupt objects cannot be skipped with this setting",
+  },
+  {
+    name: "gc.aggressiveDepth",
+    description:
+      "The depth parameter used in the delta compression algorithm used by git gc --aggressive. This defaults to 250",
+  },
+  {
+    name: "gc.aggressiveWindow",
+    description:
+      "The window size parameter used in the delta compression algorithm used by git gc --aggressive. This defaults to 250",
+  },
+  {
+    name: "gc.auto",
+    description:
+      "When there are approximately more than this many loose objects in the repository, git gc --auto will pack them. Some Porcelain commands use this command to perform a light-weight garbage collection from time to time. The default value is 6700. Setting this to 0 disables it",
+  },
+  {
+    name: "gc.autoPackLimit",
+    description:
+      "When there are more than this many packs that are not marked with *.keep file in the repository, git gc --auto consolidates them into one larger pack. The default value is 50. Setting this to 0 disables it",
+  },
+  {
+    name: "gc.autoDetach",
+    description:
+      "Make git gc --auto return immediately and run in background if the system supports it. Default is true",
+  },
+  {
+    name: "gc.packRefs",
+    description:
+      "Running git pack-refs in a repository renders it unclonable by Git versions prior to 1.5.1.2 over dumb transports such as HTTP. This variable determines whether git gc runs git pack-refs. This can be set to notbare to enable it within all non-bare repos or it can be set to a boolean value. The default is true",
+  },
+  {
+    name: "gc.pruneExpire",
+    description:
+      'When git gc is run, it will call prune --expire 2.weeks.ago. Override the grace period with this config variable. The value "now" may be used to disable this grace period and always prune unreachable objects immediately, or "never" may be used to suppress pruning',
+  },
+  {
+    name: "gc.worktreePruneExpire",
+    description:
+      'When git gc is run, it calls git worktree prune --expire 3.months.ago. This config variable can be used to set a different grace period. The value "now" may be used to disable the grace period and prune $GIT_DIR/worktrees immediately, or "never" may be used to suppress pruning',
+  },
+  {
+    name: "gc.reflogExpire",
+    description:
+      'Git reflog expire removes reflog entries older than this time; defaults to 90 days. The value "now" expires all entries immediately, and "never" suppresses expiration altogether. With "<pattern>" (e.g"refs/stash") in the middle the setting applies only to the refs that match the <pattern>',
+  },
+  {
+    name: "gc.&lt;pattern&gt;.reflogExpire",
+    insertValue: "gc.{cursor}.reflogExpire",
+    description:
+      'Git reflog expire removes reflog entries older than this time; defaults to 90 days. The value "now" expires all entries immediately, and "never" suppresses expiration altogether. With "<pattern>" (e.g"refs/stash") in the middle the setting applies only to the refs that match the <pattern>',
+  },
+  {
+    name: "gc.reflogExpireUnreachable",
+    description:
+      'Git reflog expire removes reflog entries older than this time and are not reachable from the current tip; defaults to 30 days. The value "now" expires all entries immediately, and "never" suppresses expiration altogether. With "<pattern>" (e.g"refs/stash") in the middle, the setting applies only to the refs that match the <pattern>',
+  },
+  {
+    name: "gc.&lt;pattern&gt;.reflogExpireUnreachable",
+    insertValue: "gc.{cursor}.reflogExpireUnreachable",
+    description:
+      'Git reflog expire removes reflog entries older than this time and are not reachable from the current tip; defaults to 30 days. The value "now" expires all entries immediately, and "never" suppresses expiration altogether. With "<pattern>" (e.g"refs/stash") in the middle, the setting applies only to the refs that match the <pattern>',
+  },
+  {
+    name: "gc.rerereResolved",
+    description:
+      "Records of conflicted merge you resolved earlier are kept for this many days when git rerere gc is run. The default is 60 days. See git-rerere",
+  },
+  {
+    name: "gc.rerereUnresolved",
+    description:
+      "Records of conflicted merge you have not resolved are kept for this many days when git rerere gc is run. The default is 15 days. See git-rerere",
+  },
+  {
+    name: "gitcvs.commitMsgAnnotation",
+    description:
+      'Append this string to each commit message. Set to empty string to disable this feature. Defaults to "via git-CVS emulator"',
+  },
+  {
+    name: "gitcvs.enabled",
+    description:
+      "Whether the CVS server interface is enabled for this repository. See git-cvsserver",
+  },
+  {
+    name: "gitcvs.logFile",
+    description:
+      "Path to a log file where the CVS server interface well... logs various stuff. See git- cvsserver(1)",
+  },
+  {
+    name: "gitcvs.usecrlfattr",
+    description:
+      "If true, the server will look up the end-of-line conversion attributes for files to determine the -k modes to use. If the attributes force Git to treat a file as text, the -k mode will be left blank so CVS clients will treat it as text. If they suppress text conversion, the file will be set with -kb mode, which suppresses any newline munging the client might otherwise do. If the attributes do not allow the file type to be determined, then gitcvs.allBinary is used. See gitattributes(5)",
+  },
+  {
+    name: "gitcvs.allBinary",
+    description:
+      'This is used if gitcvs.usecrlfattr does not resolve the correct -kb mode to use. If true, all unresolved files are sent to the client in mode -kb. This causes the client to treat them as binary files, which suppresses any newline munging it otherwise might do. Alternatively, if it is set to "guess", then the contents of the file are examined to decide if it is binary, similar to core.autocrlf',
+  },
+  {
+    name: "gitcvs.dbName",
+    description:
+      "Database used by git-cvsserver to cache revision information derived from the Git repository. The exact meaning depends on the used database driver, for SQLite (which is the default driver) this is a filename. Supports variable substitution (see git- cvsserver(1) for details). May not contain semicolons (;). Default: %Ggitcvs.%m.sqlite",
+  },
+  {
+    name: "gitcvs.dbDriver",
+    description:
+      "Used Perl DBI driver. You can specify any available driver for this here, but it might not work. git-cvsserver is tested with DBD::SQLite, reported to work with DBD::Pg, and reported not to work with DBD::mysql. Experimental feature. May not contain double colons (:). Default: SQLite. See git-cvsserver",
+  },
+  {
+    name: "gitcvs.dbUser",
+    description:
+      "Database user and password. Only useful if setting gitcvs.dbDriver, since SQLite has no concept of database users and/or passwords.  gitcvs.dbUser supports variable substitution (see git-cvsserver for details)",
+  },
+  {
+    name: "gitcvs.dbPass",
+    description:
+      "Database user and password. Only useful if setting gitcvs.dbDriver, since SQLite has no concept of database users and/or passwords.  gitcvs.dbUser supports variable substitution (see git-cvsserver for details)",
+  },
+  {
+    name: "gitcvs.dbTableNamePrefix",
+    description:
+      "Database table name prefix. Prepended to the names of any database tables used, allowing a single database to be used for several repositories. Supports variable substitution (see git-cvsserver for details). Any non-alphabetic characters will be replaced with underscores",
+  },
+  { name: "gitweb.category", description: "See gitweb(1) for description" },
+  { name: "gitweb.description", description: "See gitweb(1) for description" },
+  { name: "gitweb.owner", description: "See gitweb(1) for description" },
+  { name: "gitweb.url", description: "See gitweb(1) for description" },
+  { name: "gitweb.avatar", description: "See gitweb.conf(5) for description" },
+  { name: "gitweb.blame", description: "See gitweb.conf(5) for description" },
+  { name: "gitweb.grep", description: "See gitweb.conf(5) for description" },
+  {
+    name: "gitweb.highlight",
+    description: "See gitweb.conf(5) for description",
+  },
+  { name: "gitweb.patches", description: "See gitweb.conf(5) for description" },
+  { name: "gitweb.pickaxe", description: "See gitweb.conf(5) for description" },
+  {
+    name: "gitweb.remote_heads",
+    description: "See gitweb.conf(5) for description",
+  },
+  {
+    name: "gitweb.showSizes",
+    description: "See gitweb.conf(5) for description",
+  },
+  {
+    name: "gitweb.snapshot",
+    description: "See gitweb.conf(5) for description",
+  },
+  {
+    name: "grep.lineNumber",
+    description: "If set to true, enable -n option by default",
+  },
+  {
+    name: "grep.patternType",
+    description:
+      "Set the default matching behavior. Using a value of basic, extended, fixed, or perl will enable the --basic-regexp, --extended-regexp, --fixed-strings, or --perl-regexp option accordingly, while the value default will return to the default matching behavior",
+  },
+  {
+    name: "grep.extendedRegexp",
+    description:
+      "If set to true, enable --extended-regexp option by default. This option is ignored when the grep.patternType option is set to a value other than default",
+  },
+  {
+    name: "gpg.program",
+    description:
+      'Use this custom program instead of "gpg" found on $PATH when making or verifying a PGP signature. The program must support the same command-line interface as GPG, namely, to verify a detached signature, "gpg --verify $file - <$signature" is run, and the program is expected to signal a good signature by exiting with code 0, and to generate an ASCII-armored detached signature, the standard input of "gpg -bsau $key" is fed with the contents to be signed, and the program is expected to send the result to its standard output',
+  },
+  {
+    name: "gui.commitMsgWidth",
+    description:
+      'Defines how wide the commit message window is in the git-gui"75" is the default',
+  },
+  {
+    name: "gui.diffContext",
+    description:
+      'Specifies how many context lines should be used in calls to diff made by the git- gui(1). The default is "5"',
+  },
+  {
+    name: "gui.displayUntracked",
+    description:
+      'Determines if :git-gui shows untracked files in the file list. The default is "true"',
+  },
+  {
+    name: "gui.encoding",
+    description:
+      "Specifies the default encoding to use for displaying of file contents in git-gui and gitk(1). It can be overridden by setting the encoding attribute for relevant files (see gitattributes(5)). If this option is not set, the tools default to the locale encoding",
+  },
+  {
+    name: "gui.matchTrackingBranch",
+    description:
+      'Determines if new branches created with git-gui should default to tracking remote branches with matching names or not. Default: "false"',
+  },
+  {
+    name: "gui.newBranchTemplate",
+    description:
+      "Is used as suggested name when creating new branches using the git-gui",
+  },
+  {
+    name: "gui.pruneDuringFetch",
+    description:
+      'True" if git-gui should prune remote-tracking branches when performing a fetch. The default value is "false"',
+  },
+  {
+    name: "gui.trustmtime",
+    description:
+      "Determines if git-gui should trust the file modification timestamp or not. By default the timestamps are not trusted",
+  },
+  {
+    name: "gui.spellingDictionary",
+    description:
+      'Specifies the dictionary used for spell checking commit messages in the git-gui. When set to "none" spell checking is turned off',
+  },
+  {
+    name: "gui.fastCopyBlame",
+    description:
+      "If true, git gui blame uses -C instead of -C -C for original location detection. It makes blame significantly faster on huge repositories at the expense of less thorough copy detection",
+  },
+  {
+    name: "gui.copyBlameThreshold",
+    description:
+      "Specifies the threshold to use in git gui blame original location detection, measured in alphanumeric characters. See the git-blame manual for more information on copy detection",
+  },
+  {
+    name: "gui.blamehistoryctx",
+    description:
+      "Specifies the radius of history context in days to show in gitk(1) for the selected commit, when the Show History Context menu item is invoked from git gui blame. If this variable is set to zero, the whole history is shown",
+  },
+  {
+    name: "guitool.&lt;name&gt;.cmd",
+    insertValue: "guitool.{cursor}.cmd",
+    description:
+      "Specifies the shell command line to execute when the corresponding item of the git- gui(1) Tools menu is invoked. This option is mandatory for every tool. The command is executed from the root of the working directory, and in the environment it receives the name of the tool as GIT_GUITOOL, the name of the currently selected file as FILENAME, and the name of the current branch as CUR_BRANCH (if the head is detached, CUR_BRANCH is empty)",
+  },
+  {
+    name: "guitool.&lt;name&gt;.needsFile",
+    insertValue: "guitool.{cursor}.needsFile",
+    description:
+      "Run the tool only if a diff is selected in the GUI. It guarantees that FILENAME is not empty",
+  },
+  {
+    name: "guitool.&lt;name&gt;.noConsole",
+    insertValue: "guitool.{cursor}.noConsole",
+    description:
+      "Run the command silently, without creating a window to display its output",
+  },
+  {
+    name: "guitool.&lt;name&gt;.noRescan",
+    insertValue: "guitool.{cursor}.noRescan",
+    description:
+      "Don’t rescan the working directory for changes after the tool finishes execution",
+  },
+  {
+    name: "guitool.&lt;name&gt;.confirm",
+    insertValue: "guitool.{cursor}.confirm",
+    description: "Show a confirmation dialog before actually running the tool",
+  },
+  {
+    name: "guitool.&lt;name&gt;.argPrompt",
+    insertValue: "guitool.{cursor}.argPrompt",
+    description:
+      "Request a string argument from the user, and pass it to the tool through the ARGS environment variable. Since requesting an argument implies confirmation, the confirm option has no effect if this is enabled. If the option is set to true, yes, or 1, the dialog uses a built-in generic prompt; otherwise the exact value of the variable is used",
+  },
+  {
+    name: "guitool.&lt;name&gt;.revPrompt",
+    insertValue: "guitool.{cursor}.revPrompt",
+    description:
+      "Request a single valid revision from the user, and set the REVISION environment variable. In other aspects this option is similar to argPrompt, and can be used together with it",
+  },
+  {
+    name: "guitool.&lt;name&gt;.revUnmerged",
+    insertValue: "guitool.{cursor}.revUnmerged",
+    description:
+      "Show only unmerged branches in the revPrompt subdialog. This is useful for tools similar to merge or rebase, but not for things like checkout or reset",
+  },
+  {
+    name: "guitool.&lt;name&gt;.title",
+    insertValue: "guitool.{cursor}.title",
+    description:
+      "Specifies the title to use for the prompt dialog. The default is the tool name",
+  },
+  {
+    name: "guitool.&lt;name&gt;.prompt",
+    insertValue: "guitool.{cursor}.prompt",
+    description:
+      "Specifies the general prompt string to display at the top of the dialog, before subsections for argPrompt and revPrompt. The default value includes the actual command",
+  },
+  {
+    name: "help.browser",
+    description:
+      "Specify the browser that will be used to display help in the web format. See git- help(1)",
+  },
+  {
+    name: "help.format",
+    description:
+      "Override the default help format used by git-help. Values man, info, web and html are supported.  man is the default.  web and html are the same",
+  },
+  {
+    name: "help.autoCorrect",
+    description:
+      "Automatically correct and execute mistyped commands after waiting for the given number of deciseconds (0.1 sec). If more than one command can be deduced from the entered text, nothing will be executed. If the value of this option is negative, the corrected command will be executed immediately. If the value is 0 - the command will be just shown but not executed. This is the default",
+  },
+  {
+    name: "help.htmlPath",
+    description:
+      "Specify the path where the HTML documentation resides. File system paths and URLs are supported. HTML pages will be prefixed with this path when help is displayed in the web format. This defaults to the documentation path of your Git installation",
+  },
+  {
+    name: "http.proxy",
+    description:
+      "Override the HTTP proxy, normally configured using the http_proxy, https_proxy, and all_proxy environment variables (see curl(1)). This can be overridden on a per-remote basis; see remote.<name>.proxy",
+  },
+  {
+    name: "http.cookieFile",
+    description:
+      "File containing previously stored cookie lines which should be used in the Git http session, if they match the server. The file format of the file to read cookies from should be plain HTTP headers or the Netscape/Mozilla cookie file format (see curl(1)). NOTE that the file specified with http.cookieFile is only used as input unless http.saveCookies is set",
+  },
+  {
+    name: "http.saveCookies",
+    description:
+      "If set, store cookies received during requests to the file specified by http.cookieFile. Has no effect if http.cookieFile is unset",
+  },
+  {
+    name: "http.sslVersion",
+    description:
+      "The SSL version to use when negotiating an SSL connection, if you want to force the default. The available and default version depend on whether libcurl was built against NSS or OpenSSL and the particular configuration of the crypto library in use. Internally this sets the CURLOPT_SSL_VERSION option; see the libcurl documentation for more details on the format of this option and for the ssl version supported",
+  },
+  {
+    name: "http.sslCipherList",
+    description:
+      "A list of SSL ciphers to use when negotiating an SSL connection. The available ciphers depend on whether libcurl was built against NSS or OpenSSL and the particular configuration of the crypto library in use. Internally this sets the CURLOPT_SSL_CIPHER_LIST option; see the libcurl documentation for more details on the format of this list",
+  },
+  {
+    name: "http.sslVerify",
+    description:
+      "Whether to verify the SSL certificate when fetching or pushing over HTTPS. Can be overridden by the GIT_SSL_NO_VERIFY environment variable",
+  },
+  {
+    name: "http.sslCert",
+    description:
+      "File containing the SSL certificate when fetching or pushing over HTTPS. Can be overridden by the GIT_SSL_CERT environment variable",
+  },
+  {
+    name: "http.sslKey",
+    description:
+      "File containing the SSL private key when fetching or pushing over HTTPS. Can be overridden by the GIT_SSL_KEY environment variable",
+  },
+  {
+    name: "http.sslCertPasswordProtected",
+    description:
+      "Enable Git’s password prompt for the SSL certificate. Otherwise OpenSSL will prompt the user, possibly many times, if the certificate or private key is encrypted. Can be overridden by the GIT_SSL_CERT_PASSWORD_PROTECTED environment variable",
+  },
+  {
+    name: "http.sslCAInfo",
+    description:
+      "File containing the certificates to verify the peer with when fetching or pushing over HTTPS. Can be overridden by the GIT_SSL_CAINFO environment variable",
+  },
+  {
+    name: "http.sslCAPath",
+    description:
+      "Path containing files with the CA certificates to verify the peer with when fetching or pushing over HTTPS. Can be overridden by the GIT_SSL_CAPATH environment variable",
+  },
+  {
+    name: "http.sslTry",
+    description:
+      "Attempt to use AUTH SSL/TLS and encrypted data transfers when connecting via regular FTP protocol. This might be needed if the FTP server requires it for security reasons or you wish to connect securely whenever remote FTP server supports it. Default is false since it might trigger certificate verification errors on misconfigured servers",
+  },
+  {
+    name: "http.maxRequests",
+    description:
+      "How many HTTP requests to launch in parallel. Can be overridden by the GIT_HTTP_MAX_REQUESTS environment variable. Default is 5",
+  },
+  {
+    name: "http.minSessions",
+    description:
+      "The number of curl sessions (counted across slots) to be kept across requests. They will not be ended with curl_easy_cleanup() until http_cleanup() is invoked. If USE_CURL_MULTI is not defined, this value will be capped at 1. Defaults to 1",
+  },
+  {
+    name: "http.postBuffer",
+    description:
+      "Maximum size in bytes of the buffer used by smart HTTP transports when POSTing data to the remote system. For requests larger than this buffer size, HTTP/1.1 and Transfer-Encoding: chunked is used to avoid creating a massive pack file locally. Default is 1 MiB, which is sufficient for most requests",
+  },
+  {
+    name: "http.lowSpeedLimit",
+    description:
+      "If the HTTP transfer speed is less than http.lowSpeedLimit for longer than http.lowSpeedTime seconds, the transfer is aborted. Can be overridden by the GIT_HTTP_LOW_SPEED_LIMIT and GIT_HTTP_LOW_SPEED_TIME environment variables",
+  },
+  {
+    name: "http.lowSpeedTime",
+    description:
+      "If the HTTP transfer speed is less than http.lowSpeedLimit for longer than http.lowSpeedTime seconds, the transfer is aborted. Can be overridden by the GIT_HTTP_LOW_SPEED_LIMIT and GIT_HTTP_LOW_SPEED_TIME environment variables",
+  },
+  {
+    name: "http.noEPSV",
+    description:
+      'A boolean which disables using of EPSV ftp command by curl. This can helpful with some "poor" ftp servers which don’t support EPSV mode. Can be overridden by the GIT_CURL_FTP_NO_EPSV environment variable. Default is false (curl will use EPSV)',
+  },
+  {
+    name: "http.userAgent",
+    description:
+      "The HTTP USER_AGENT string presented to an HTTP server. The default value represents the version of the client Git such as git/1.7.1. This option allows you to override this value to a more common value such as Mozilla/4.0. This may be necessary, for instance, if connecting through a firewall that restricts HTTP connections to a set of common USER_AGENT strings (but not including those like git/1.7.1). Can be overridden by the GIT_HTTP_USER_AGENT environment variable",
+  },
+  {
+    name: "i18n.commitEncoding",
+    description:
+      "Character encoding the commit messages are stored in; Git itself does not care per se, but this information is necessary e.g. when importing commits from emails or in the gitk graphical history browser (and possibly at other places in the future or in other porcelains). See e.g.  git-mailinfo. Defaults to utf-8",
+  },
+  {
+    name: "i18n.logOutputEncoding",
+    description:
+      "Character encoding the commit messages are converted to when running git log and friends",
+  },
+  {
+    name: "imap",
+    description:
+      "The configuration variables in the imap section are described in git-imap-send",
+  },
+  {
+    name: "index.version",
+    description:
+      "Specify the version with which new index files should be initialized. This does not affect existing repositories",
+  },
+  {
+    name: "init.templateDir",
+    description:
+      'Specify the directory from which templates will be copied. (See the "TEMPLATE DIRECTORY" section of git-init.)',
+  },
+  {
+    name: "instaweb.browser",
+    description:
+      "Specify the program that will be used to browse your working repository in gitweb. See git-instaweb",
+  },
+  {
+    name: "instaweb.httpd",
+    description:
+      "The HTTP daemon command-line to start gitweb on your working repository. See git- instaweb(1)",
+  },
+  {
+    name: "instaweb.local",
+    description:
+      "If true the web server started by git-instaweb will be bound to the local IP (127.0.0.1)",
+  },
+  {
+    name: "instaweb.modulePath",
+    description:
+      "The default module path for git-instaweb to use instead of /usr/lib/apache2/modules. Only used if httpd is Apache",
+  },
+  {
+    name: "instaweb.port",
+    description:
+      "The port number to bind the gitweb httpd to. See git-instaweb",
+  },
+  {
+    name: "interactive.singleKey",
+    description:
+      "In interactive commands, allow the user to provide one-letter input with a single key (i.e., without hitting enter). Currently this is used by the --patch mode of git- add(1), git-checkout(1), git-commit(1), git-reset(1), and git-stash. Note that this setting is silently ignored if portable keystroke input is not available; requires the Perl module Term::ReadKey",
+  },
+  {
+    name: "log.abbrevCommit",
+    description:
+      "If true, makes git-log(1), git-show(1), and git-whatchanged assume --abbrev-commit. You may override this option with --no-abbrev-commit",
+  },
+  {
+    name: "log.date",
+    description:
+      "Set the default date-time mode for the log command. Setting a value for log.date is similar to using git log's --date option. See git-log for details",
+  },
+  {
+    name: "log.decorate",
+    description:
+      "Print out the ref names of any commits that are shown by the log command. If short is specified, the ref name prefixes refs/heads/, refs/tags/ and refs/remotes/ will not be printed. If full is specified, the full ref name (including prefix) will be printed. This is the same as the log commands --decorate option",
+  },
+  {
+    name: "log.follow",
+    description:
+      "If true, git log will act as if the --follow option was used when a single <path> is given. This has the same limitations as --follow, i.e. it cannot be used to follow multiple files and does not work well on non-linear history",
+  },
+  {
+    name: "log.showRoot",
+    description:
+      "If true, the initial commit will be shown as a big creation event. This is equivalent to a diff against an empty tree. Tools like git-log(1) or git-whatchanged, which normally hide the root commit will now show it. True by default",
+  },
+  {
+    name: "log.mailmap",
+    description:
+      "If true, makes git-log(1), git-show(1), and git-whatchanged assume --use-mailmap",
+  },
+  {
+    name: "mailinfo.scissors",
+    description:
+      'If true, makes git-mailinfo(1) (and therefore git-am) act by default as if the --scissors option was provided on the command-line. When active, this features removes everything from the message body before a scissors line (i.e. consisting mainly of ">8", "8<" and "-")',
+  },
+  {
+    name: "mailmap.file",
+    description:
+      "The location of an augmenting mailmap file. The default mailmap, located in the root of the repository, is loaded first, then the mailmap file pointed to by this variable. The location of the mailmap file may be in a repository subdirectory, or somewhere outside of the repository itself. See git-shortlog(1) and git-blame",
+  },
+  {
+    name: "mailmap.blob",
+    description:
+      "Like mailmap.file, but consider the value as a reference to a blob in the repository. If both mailmap.file and mailmap.blob are given, both are parsed, with entries from mailmap.file taking precedence. In a bare repository, this defaults to HEAD:.mailmap. In a non-bare repository, it defaults to empty",
+  },
+  {
+    name: "man.viewer",
+    description:
+      "Specify the programs that may be used to display help in the man format. See git- help(1)",
+  },
+  {
+    name: "man.&lt;tool&gt;.cmd",
+    insertValue: "man.{cursor}.cmd",
+    description:
+      "Specify the command to invoke the specified man viewer. The specified command is evaluated in shell with the man page passed as argument. (See git-help.)",
+  },
+  {
+    name: "man.&lt;tool&gt;.path",
+    insertValue: "man.{cursor}.path",
+    description:
+      "Override the path for the given tool that may be used to display help in the man format. See git-help",
+  },
+  {
+    name: "merge.conflictStyle",
+    description:
+      'Specify the style in which conflicted hunks are written out to working tree files upon merge. The default is "merge", which shows a <<<<<<< conflict marker, changes made by one side, a ======= marker, changes made by the other side, and then a >>>>>>> marker. An alternate style, "diff3", adds a ||||||| marker and the original text before the ======= marker',
+  },
+  {
+    name: "merge.defaultToUpstream",
+    description:
+      "If merge is called without any commit argument, merge the upstream branches configured for the current branch by using their last observed values stored in their remote-tracking branches. The values of the branch.<current branch>.merge that name the branches at the remote named by branch.<current branch>.remote are consulted, and then they are mapped via remote.<remote>.fetch to their corresponding remote-tracking branches, and the tips of these tracking branches are merged",
+  },
+  {
+    name: "merge.ff",
+    description:
+      "By default, Git does not create an extra merge commit when merging a commit that is a descendant of the current commit. Instead, the tip of the current branch is fast-forwarded. When set to false, this variable tells Git to create an extra merge commit in such a case (equivalent to giving the --no-ff option from the command line). When set to only, only such fast-forward merges are allowed (equivalent to giving the --ff-only option from the command line)",
+  },
+  {
+    name: "merge.branchdesc",
+    description:
+      "In addition to branch names, populate the log message with the branch description text associated with them. Defaults to false",
+  },
+  {
+    name: "merge.log",
+    description:
+      "In addition to branch names, populate the log message with at most the specified number of one-line descriptions from the actual commits that are being merged. Defaults to false, and true is a synonym for 20",
+  },
+  {
+    name: "merge.renameLimit",
+    description:
+      "The number of files to consider when performing rename detection during a merge; if not specified, defaults to the value of diff.renameLimit",
+  },
+  {
+    name: "merge.renormalize",
+    description:
+      'Tell Git that canonical representation of files in the repository has changed over time (e.g. earlier commits record text files with CRLF line endings, but recent ones use LF line endings). In such a repository, Git can convert the data recorded in commits to a canonical form before performing a merge to reduce unnecessary conflicts. For more information, see section "Merging branches with differing checkin/checkout attributes" in gitattributes(5)',
+  },
+  {
+    name: "merge.stat",
+    description:
+      "Whether to print the diffstat between ORIG_HEAD and the merge result at the end of the merge. True by default",
+  },
+  {
+    name: "merge.tool",
+    description:
+      "Controls which merge tool is used by git-mergetool. The list below shows the valid built-in values. Any other value is treated as a custom merge tool and requires that a corresponding mergetool.<tool>.cmd variable is defined",
+  },
+  {
+    name: "merge.verbosity",
+    description:
+      "Controls the amount of output shown by the recursive merge strategy. Level 0 outputs nothing except a final error message if conflicts were detected. Level 1 outputs only conflicts, 2 outputs conflicts and file changes. Level 5 and above outputs debugging information. The default is level 2. Can be overridden by the GIT_MERGE_VERBOSITY environment variable",
+  },
+  {
+    name: "merge.&lt;driver&gt;.name",
+    insertValue: "merge.{cursor}.name",
+    description:
+      "Defines a human-readable name for a custom low-level merge driver. See gitattributes(5) for details",
+  },
+  {
+    name: "merge.&lt;driver&gt;.driver",
+    insertValue: "merge.{cursor}.driver",
+    description:
+      "Defines the command that implements a custom low-level merge driver. See gitattributes(5) for details",
+  },
+  {
+    name: "merge.&lt;driver&gt;.recursive",
+    insertValue: "merge.{cursor}.recursive",
+    description:
+      "Names a low-level merge driver to be used when performing an internal merge between common ancestors. See gitattributes(5) for details",
+  },
+  {
+    name: "mergetool.&lt;tool&gt;.path",
+    insertValue: "mergetool.{cursor}.path",
+    description:
+      "Override the path for the given tool. This is useful in case your tool is not in the PATH",
+  },
+  {
+    name: "mergetool.&lt;tool&gt;.cmd",
+    insertValue: "mergetool.{cursor}.cmd",
+    description:
+      "Specify the command to invoke the specified merge tool. The specified command is evaluated in shell with the following variables available: BASE is the name of a temporary file containing the common base of the files to be merged, if available; LOCAL is the name of a temporary file containing the contents of the file on the current branch; REMOTE is the name of a temporary file containing the contents of the file from the branch being merged; MERGED contains the name of the file to which the merge tool should write the results of a successful merge",
+  },
+  {
+    name: "mergetool.&lt;tool&gt;.trustExitCode",
+    insertValue: "mergetool.{cursor}.trustExitCode",
+    description:
+      "For a custom merge command, specify whether the exit code of the merge command can be used to determine whether the merge was successful. If this is not set to true then the merge target file timestamp is checked and the merge assumed to have been successful if the file has been updated, otherwise the user is prompted to indicate the success of the merge",
+  },
+  {
+    name: "mergetool.meld.hasOutput",
+    description:
+      "Older versions of meld do not support the --output option. Git will attempt to detect whether meld supports --output by inspecting the output of meld --help. Configuring mergetool.meld.hasOutput will make Git skip these checks and use the configured value instead. Setting mergetool.meld.hasOutput to true tells Git to unconditionally use the --output option, and false avoids using --output",
+  },
+  {
+    name: "mergetool.keepBackup",
+    description:
+      "After performing a merge, the original file with conflict markers can be saved as a file with a .orig extension. If this variable is set to false then this file is not preserved. Defaults to true (i.e. keep the backup files)",
+  },
+  {
+    name: "mergetool.keepTemporaries",
+    description:
+      "When invoking a custom merge tool, Git uses a set of temporary files to pass to the tool. If the tool returns an error and this variable is set to true, then these temporary files will be preserved, otherwise they will be removed after the tool has exited. Defaults to false",
+  },
+  {
+    name: "mergetool.writeToTemp",
+    description:
+      "Git writes temporary BASE, LOCAL, and REMOTE versions of conflicting files in the worktree by default. Git will attempt to use a temporary directory for these files when set true. Defaults to false",
+  },
+  {
+    name: "mergetool.prompt",
+    description:
+      "Prompt before each invocation of the merge resolution program",
+  },
+  {
+    name: "notes.mergeStrategy",
+    description:
+      'Which merge strategy to choose by default when resolving notes conflicts. Must be one of manual, ours, theirs, union, or cat_sort_uniq. Defaults to manual. See "NOTES MERGE STRATEGIES" section of git-notes for more information on each strategy',
+  },
+  {
+    name: "notes.&lt;name&gt;.mergeStrategy",
+    insertValue: "notes.{cursor}.mergeStrategy",
+    description:
+      'Which merge strategy to choose when doing a notes merge into refs/notes/<name>. This overrides the more general "notes.mergeStrategy". See the "NOTES MERGE STRATEGIES" section in git-notes for more information on the available strategies',
+  },
+  {
+    name: "notes.displayRef",
+    description:
+      "The (fully qualified) refname from which to show notes when showing commit messages. The value of this variable can be set to a glob, in which case notes from all matching refs will be shown. You may also specify this configuration variable several times. A warning will be issued for refs that do not exist, but a glob that does not match any refs is silently ignored",
+  },
+  {
+    name: "notes.rewrite.&lt;command&gt;",
+    insertValue: "notes.rewrite.{cursor}",
+    description:
+      'When rewriting commits with <command> (currently amend or rebase) and this variable is set to true, Git automatically copies your notes from the original to the rewritten commit. Defaults to true, but see "notes.rewriteRef" below',
+  },
+  {
+    name: "notes.rewriteMode",
+    description:
+      'When copying notes during a rewrite (see the "notes.rewrite.<command>" option), determines what to do if the target commit already has a note. Must be one of overwrite, concatenate, cat_sort_uniq, or ignore. Defaults to concatenate',
+  },
+  {
+    name: "notes.rewriteRef",
+    description:
+      "When copying notes during a rewrite, specifies the (fully qualified) ref whose notes should be copied. The ref may be a glob, in which case notes in all matching refs will be copied. You may also specify this configuration several times",
+  },
+  {
+    name: "pack.window",
+    description:
+      "The size of the window used by git-pack-objects when no window size is given on the command line. Defaults to 10",
+  },
+  {
+    name: "pack.depth",
+    description:
+      "The maximum delta depth used by git-pack-objects when no maximum depth is given on the command line. Defaults to 50",
+  },
+  {
+    name: "pack.windowMemory",
+    description:
+      'The maximum size of memory that is consumed by each thread in git-pack-objects for pack window memory when no limit is given on the command line. The value can be suffixed with "k", "m", or "g". When left unconfigured (or set explicitly to 0), there will be no limit',
+  },
+  {
+    name: "pack.compression",
+    description:
+      'An integer -1..9, indicating the compression level for objects in a pack file. -1 is the zlib default. 0 means no compression, and 1..9 are various speed/size tradeoffs, 9 being slowest. If not set, defaults to core.compression. If that is not set, defaults to -1, the zlib default, which is "a default compromise between speed and compression (currently equivalent to level 6)."',
+  },
+  {
+    name: "pack.deltaCacheSize",
+    description:
+      "The maximum memory in bytes used for caching deltas in git-pack-objects before writing them out to a pack. This cache is used to speed up the writing object phase by not having to recompute the final delta result once the best match for all objects is found. Repacking large repositories on machines which are tight with memory might be badly impacted by this though, especially if this cache pushes the system into swapping. A value of 0 means no limit. The smallest size of 1 byte may be used to virtually disable this cache. Defaults to 256 MiB",
+  },
+  {
+    name: "pack.deltaCacheLimit",
+    description:
+      "The maximum size of a delta, that is cached in git-pack-objects. This cache is used to speed up the writing object phase by not having to recompute the final delta result once the best match for all objects is found. Defaults to 1000",
+  },
+  {
+    name: "pack.threads",
+    description:
+      "Specifies the number of threads to spawn when searching for best delta matches. This requires that git-pack-objects be compiled with pthreads otherwise this option is ignored with a warning. This is meant to reduce packing time on multiprocessor machines. The required amount of memory for the delta search window is however multiplied by the number of threads. Specifying 0 will cause Git to auto-detect the number of CPU’s and set the number of threads accordingly",
+  },
+  {
+    name: "pack.indexVersion",
+    description:
+      "Specify the default pack index version. Valid values are 1 for legacy pack index used by Git versions prior to 1.5.2, and 2 for the new pack index with capabilities for packs larger than 4 GB as well as proper protection against the repacking of corrupted packs. Version 2 is the default. Note that version 2 is enforced and this config option ignored whenever the corresponding pack is larger than 2 GB",
+  },
+  {
+    name: "pack.packSizeLimit",
+    description:
+      "The maximum size of a pack. This setting only affects packing to a file when repacking, i.e. the git:// protocol is unaffected. It can be overridden by the --max-pack-size option of git-repack. The minimum size allowed is limited to 1 MiB. The default is unlimited. Common unit suffixes of k, m, or g are supported",
+  },
+  {
+    name: "pack.useBitmaps",
+    description:
+      "When true, git will use pack bitmaps (if available) when packing to stdout (e.g., during the server side of a fetch). Defaults to true. You should not generally need to turn this off unless you are debugging pack bitmaps",
+  },
+  {
+    name: "pack.writeBitmaps (deprecated)",
+    description: "This is a deprecated synonym for repack.writeBitmaps",
+  },
+  {
+    name: "pack.writeBitmapHashCache",
+    description:
+      'When true, git will include a "hash cache" section in the bitmap index (if one is written). This cache can be used to feed git’s delta heuristics, potentially leading to better deltas between bitmapped and non-bitmapped objects (e.g., when serving a fetch between an older, bitmapped pack and objects that have been pushed since the last gc). The downside is that it consumes 4 bytes per object of disk space, and that JGit’s bitmap implementation does not understand it, causing it to complain if Git and JGit are used on the same repository. Defaults to false',
+  },
+  {
+    name: "pager.&lt;cmd&gt;",
+    insertValue: "pager.{cursor}",
+    description:
+      "If the value is boolean, turns on or off pagination of the output of a particular Git subcommand when writing to a tty. Otherwise, turns on pagination for the subcommand using the pager specified by the value of pager.<cmd>. If --paginate or --no-pager is specified on the command line, it takes precedence over this option. To disable pagination for all commands, set core.pager or GIT_PAGER to cat",
+  },
+  {
+    name: "pretty.&lt;name&gt;",
+    insertValue: "pretty.{cursor}",
+    description:
+      'Alias for a --pretty= format string, as specified in git-log. Any aliases defined here can be used just as the built-in pretty formats could. For example, running git config pretty.changelog "format:* %H %s" would cause the invocation git log --pretty=changelog to be equivalent to running git log "--pretty=format:* %H %s". Note that an alias with the same name as a built-in format will be silently ignored',
+  },
+  {
+    name: "pull.ff",
+    description:
+      "By default, Git does not create an extra merge commit when merging a commit that is a descendant of the current commit. Instead, the tip of the current branch is fast-forwarded. When set to false, this variable tells Git to create an extra merge commit in such a case (equivalent to giving the --no-ff option from the command line). When set to only, only such fast-forward merges are allowed (equivalent to giving the --ff-only option from the command line). This setting overrides merge.ff when pulling",
+  },
+  {
+    name: "pull.rebase",
+    description:
+      'When true, rebase branches on top of the fetched branch, instead of merging the default branch from the default remote when "git pull" is run. See "branch.<name>.rebase" for setting this on a per-branch basis',
+  },
+  {
+    name: "pull.octopus",
+    description:
+      "The default merge strategy to use when pulling multiple branches at once",
+  },
+  {
+    name: "pull.twohead",
+    description:
+      "The default merge strategy to use when pulling a single branch",
+  },
+  {
+    name: "push.default",
+    description:
+      "Defines the action git push should take if no refspec is explicitly given. Different values are well-suited for specific workflows; for instance, in a purely central workflow (i.e. the fetch source is equal to the push destination), upstream is probably what you want",
+  },
+  {
+    name: "push.followTags",
+    description:
+      "If set to true enable --follow-tags option by default. You may override this configuration at time of push by specifying --no-follow-tags",
+  },
+  {
+    name: "push.gpgSign",
+    description:
+      "May be set to a boolean value, or the string if-asked. A true value causes all pushes to be GPG signed, as if --signed is passed to git-push. The string if-asked causes pushes to be signed if the server supports it, as if --signed=if-asked is passed to git push. A false value may override a value from a lower-priority config file. An explicit command-line flag always overrides this config option",
+  },
+  {
+    name: "push.recurseSubmodules",
+    description:
+      "Make sure all submodule commits used by the revisions to be pushed are available on a remote-tracking branch. If the value is check then Git will verify that all submodule commits that changed in the revisions to be pushed are available on at least one remote of the submodule. If any commits are missing, the push will be aborted and exit with non-zero status. If the value is on-demand then all submodules that changed in the revisions to be pushed will be pushed. If on-demand was not able to push all necessary revisions it will also be aborted and exit with non-zero status. If the value is no then default behavior of ignoring submodules when pushing is retained. You may override this configuration at time of push by specifying --recurse-submodules=check|on-demand|no",
+  },
+  {
+    name: "rebase.stat",
+    description:
+      "Whether to show a diffstat of what changed upstream since the last rebase. False by default",
+  },
+  {
+    name: "rebase.autoSquash",
+    description: "If set to true enable --autosquash option by default",
+  },
+  {
+    name: "rebase.autoStash",
+    description:
+      "When set to true, automatically create a temporary stash before the operation begins, and apply it after the operation ends. This means that you can run rebase on a dirty worktree. However, use with care: the final stash application after a successful rebase might result in non-trivial conflicts. Defaults to false",
+  },
+  {
+    name: "rebase.missingCommitsCheck",
+    description:
+      'If set to "warn", git rebase -i will print a warning if some commits are removed (e.g. a line was deleted), however the rebase will still proceed. If set to "error", it will print the previous warning and stop the rebase, git rebase --edit-todo can then be used to correct the error. If set to "ignore", no checking is done. To drop a commit without warning or error, use the drop command in the todo-list. Defaults to "ignore"',
+  },
+  {
+    name: "receive.advertiseAtomic",
+    description:
+      "By default, git-receive-pack will advertise the atomic push capability to its clients. If you don’t want to this capability to be advertised, set this variable to false",
+  },
+  {
+    name: "receive.autogc",
+    description:
+      'By default, git-receive-pack will run "git-gc --auto" after receiving data from git-push and updating refs. You can stop it by setting this variable to false',
+  },
+  {
+    name: "receive.certNonceSeed",
+    description:
+      'By setting this variable to a string, git receive-pack will accept a git push --signed and verifies it by using a "nonce" protected by HMAC using this string as a secret key',
+  },
+  {
+    name: "receive.certNonceSlop",
+    description:
+      'When a git push --signed sent a push certificate with a "nonce" that was issued by a receive-pack serving the same repository within this many seconds, export the "nonce" found in the certificate to GIT_PUSH_CERT_NONCE to the hooks (instead of what the receive-pack asked the sending side to include). This may allow writing checks in pre-receive and post-receive a bit easier. Instead of checking GIT_PUSH_CERT_NONCE_SLOP environment variable that records by how many seconds the nonce is stale to decide if they want to accept the certificate, they only can check GIT_PUSH_CERT_NONCE_STATUS is OK',
+  },
+  {
+    name: "receive.fsckObjects",
+    description:
+      "If it is set to true, git-receive-pack will check all received objects. It will abort in the case of a malformed object or a broken link. The result of an abort are only dangling objects. Defaults to false. If not set, the value of transfer.fsckObjects is used instead",
+  },
+  {
+    name: "receive.fsck.&lt;msg-id&gt;",
+    insertValue: "receive.fsck.{cursor}",
+    description:
+      'When receive.fsckObjects is set to true, errors can be switched to warnings and vice versa by configuring the receive.fsck.<msg-id> setting where the <msg-id> is the fsck message ID and the value is one of error, warn or ignore. For convenience, fsck prefixes the error/warning with the message ID, e.g"missingEmail: invalid author/committer line - missing email" means that setting receive.fsck.missingEmail = ignore will hide that issue',
+  },
+  {
+    name: "receive.fsck.skipList",
+    description:
+      "The path to a sorted list of object names (i.e. one SHA-1 per line) that are known to be broken in a non-fatal way and should be ignored. This feature is useful when an established project should be accepted despite early commits containing errors that can be safely ignored such as invalid committer email addresses. Note: corrupt objects cannot be skipped with this setting",
+  },
+  {
+    name: "receive.unpackLimit",
+    description:
+      "If the number of objects received in a push is below this limit then the objects will be unpacked into loose object files. However if the number of received objects equals or exceeds this limit then the received pack will be stored as a pack, after adding any missing delta bases. Storing the pack from a push can make the push operation complete faster, especially on slow filesystems. If not set, the value of transfer.unpackLimit is used instead",
+  },
+  {
+    name: "receive.denyDeletes",
+    description:
+      "If set to true, git-receive-pack will deny a ref update that deletes the ref. Use this to prevent such a ref deletion via a push",
+  },
+  {
+    name: "receive.denyDeleteCurrent",
+    description:
+      "If set to true, git-receive-pack will deny a ref update that deletes the currently checked out branch of a non-bare repository",
+  },
+  {
+    name: "receive.denyCurrentBranch",
+    description:
+      'If set to true or "refuse", git-receive-pack will deny a ref update to the currently checked out branch of a non-bare repository. Such a push is potentially dangerous because it brings the HEAD out of sync with the index and working tree. If set to "warn", print a warning of such a push to stderr, but allow the push to proceed. If set to false or "ignore", allow such pushes with no message. Defaults to "refuse"',
+  },
+  {
+    name: "receive.denyNonFastForwards",
+    description:
+      "If set to true, git-receive-pack will deny a ref update which is not a fast-forward. Use this to prevent such an update via a push, even if that push is forced. This configuration variable is set when initializing a shared repository",
+  },
+  {
+    name: "receive.hideRefs",
+    description:
+      "This variable is the same as transfer.hideRefs, but applies only to receive-pack (and so affects pushes, but not fetches). An attempt to update or delete a hidden ref by git push is rejected",
+  },
+  {
+    name: "receive.updateServerInfo",
+    description:
+      "If set to true, git-receive-pack will run git-update-server-info after receiving data from git-push and updating refs",
+  },
+  {
+    name: "receive.shallowUpdate",
+    description:
+      "If set to true, .git/shallow can be updated when new refs require new shallow roots. Otherwise those refs are rejected",
+  },
+  {
+    name: "remote.pushDefault",
+    description:
+      "The remote to push to by default. Overrides branch.<name>.remote for all branches, and is overridden by branch.<name>.pushRemote for specific branches",
+  },
+  {
+    name: "remote.&lt;name&gt;.url",
+    insertValue: "remote.{cursor}.url",
+    description: "The URL of a remote repository. See git-fetch(1) or git-push",
+  },
+  {
+    name: "remote.&lt;name&gt;.pushurl",
+    insertValue: "remote.{cursor}.pushurl",
+    description: "The push URL of a remote repository. See git-push",
+  },
+  {
+    name: "remote.&lt;name&gt;.proxy",
+    insertValue: "remote.{cursor}.proxy",
+    description:
+      "For remotes that require curl (http, https and ftp), the URL to the proxy to use for that remote. Set to the empty string to disable proxying for that remote",
+  },
+  {
+    name: "remote.&lt;name&gt;.fetch",
+    insertValue: "remote.{cursor}.fetch",
+    description: 'The default set of "refspec" for git-fetch(1). See git-fetch',
+  },
+  {
+    name: "remote.&lt;name&gt;.push",
+    insertValue: "remote.{cursor}.push",
+    description: 'The default set of "refspec" for git-push(1). See git-push',
+  },
+  {
+    name: "remote.&lt;name&gt;.mirror",
+    insertValue: "remote.{cursor}.mirror",
+    description:
+      "If true, pushing to this remote will automatically behave as if the --mirror option was given on the command line",
+  },
+  {
+    name: "remote.&lt;name&gt;.skipDefaultUpdate",
+    insertValue: "remote.{cursor}.skipDefaultUpdate",
+    description:
+      "If true, this remote will be skipped by default when updating using git-fetch or the update subcommand of git-remote",
+  },
+  {
+    name: "remote.&lt;name&gt;.skipFetchAll",
+    insertValue: "remote.{cursor}.skipFetchAll",
+    description:
+      "If true, this remote will be skipped by default when updating using git-fetch or the update subcommand of git-remote",
+  },
+  {
+    name: "remote.&lt;name&gt;.receivepack",
+    insertValue: "remote.{cursor}.receivepack",
+    description:
+      "The default program to execute on the remote side when pushing. See option --receive-pack of git-push",
+  },
+  {
+    name: "remote.&lt;name&gt;.uploadpack",
+    insertValue: "remote.{cursor}.uploadpack",
+    description:
+      "The default program to execute on the remote side when fetching. See option --upload-pack of git-fetch-pack",
+  },
+  {
+    name: "remote.&lt;name&gt;.tagOpt",
+    insertValue: "remote.{cursor}.tagOpt",
+    description:
+      "Setting this value to --no-tags disables automatic tag following when fetching from remote <name>. Setting it to --tags will fetch every tag from remote <name>, even if they are not reachable from remote branch heads. Passing these flags directly to git- fetch(1) can override this setting. See options --tags and --no-tags of git-fetch",
+  },
+  {
+    name: "remote.&lt;name&gt;.vcs",
+    insertValue: "remote.{cursor}.vcs",
+    description:
+      "Setting this to a value <vcs> will cause Git to interact with the remote with the git-remote-<vcs> helper",
+  },
+  {
+    name: "remote.&lt;name&gt;.prune",
+    insertValue: "remote.{cursor}.prune",
+    description:
+      "When set to true, fetching from this remote by default will also remove any remote-tracking references that no longer exist on the remote (as if the --prune option was given on the command line). Overrides fetch.prune settings, if any",
+  },
+  {
+    name: "remotes.&lt;group&gt;",
+    insertValue: "remotes.{cursor}",
+    description:
+      'The list of remotes which are fetched by "git remote update <group>". See git- remote(1)',
+  },
+  {
+    name: "repack.useDeltaBaseOffset",
+    description:
+      'By default, git-repack creates packs that use delta-base offset. If you need to share your repository with Git older than version 1.4.4, either directly or via a dumb protocol such as http, then you need to set this option to "false" and repack. Access from old Git versions over the native protocol are unaffected by this option',
+  },
+  {
+    name: "repack.packKeptObjects",
+    description:
+      "If set to true, makes git repack act as if --pack-kept-objects was passed. See git- repack(1) for details. Defaults to false normally, but true if a bitmap index is being written (either via --write-bitmap-index or repack.writeBitmaps)",
+  },
+  {
+    name: "repack.writeBitmaps",
+    description:
+      'When true, git will write a bitmap index when packing all objects to disk (e.g., when git repack -a is run). This index can speed up the "counting objects" phase of subsequent packs created for clones and fetches, at the cost of some disk space and extra time spent on the initial repack. Defaults to false',
+  },
+  {
+    name: "rerere.autoUpdate",
+    description:
+      "When set to true, git-rerere updates the index with the resulting contents after it cleanly resolves conflicts using previously recorded resolution. Defaults to false",
+  },
+  {
+    name: "rerere.enabled",
+    description:
+      'Activate recording of resolved conflicts, so that identical conflict hunks can be resolved automatically, should they be encountered again. By default, git-rerere is enabled if there is an rr-cache directory under the $GIT_DIR, e.g. if "rerere" was previously used in the repository',
+  },
+  {
+    name: "sendemail.identity",
+    description:
+      "A configuration identity. When given, causes values in the sendemail.<identity> subsection to take precedence over values in the sendemail section. The default identity is the value of sendemail.identity",
+  },
+  {
+    name: "sendemail.smtpEncryption",
+    description:
+      "See git-send-email for description. Note that this setting is not subject to the identity mechanism",
+  },
+  {
+    name: "sendemail.smtpssl (deprecated)",
+    description: "Deprecated alias for sendemail.smtpEncryption = ssl",
+  },
+  {
+    name: "sendemail.smtpsslcertpath",
+    description:
+      "Path to ca-certificates (either a directory or a single file). Set it to an empty string to disable certificate verification",
+  },
+  {
+    name: "sendemail.&lt;identity&gt;.*",
+    insertValue: "sendemail.{cursor}.",
+    description:
+      "Identity-specific versions of the sendemail.*  parameters found below, taking precedence over those when the this identity is selected, through command-line or sendemail.identity",
+  },
+  {
+    name: "sendemail.aliasesFile",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.aliasFileType",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.annotate",
+    description: "See git-send-email for description",
+  },
+  { name: "sendemail.bcc", description: "See git-send-email for description" },
+  { name: "sendemail.cc", description: "See git-send-email for description" },
+  {
+    name: "sendemail.ccCmd",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.chainReplyTo",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.confirm",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.envelopeSender",
+    description: "See git-send-email for description",
+  },
+  { name: "sendemail.from", description: "See git-send-email for description" },
+  {
+    name: "sendemail.multiEdit",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.signedoffbycc",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.smtpPass",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.suppresscc",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.suppressFrom",
+    description: "See git-send-email for description",
+  },
+  { name: "sendemail.to", description: "See git-send-email for description" },
+  {
+    name: "sendemail.smtpDomain",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.smtpServer",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.smtpServerPort",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.smtpServerOption",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.smtpUser",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.thread",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.transferEncoding",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.validate",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.xmailer",
+    description: "See git-send-email for description",
+  },
+  {
+    name: "sendemail.signedoffcc (deprecated)",
+    description: "Deprecated alias for sendemail.signedoffbycc",
+  },
+  {
+    name: "showbranch.default",
+    description:
+      "The default set of branches for git-show-branch(1). See git-show-branch",
+  },
+  {
+    name: "status.relativePaths",
+    description:
+      "By default, git-status shows paths relative to the current directory. Setting this variable to false shows paths relative to the repository root (this was the default for Git prior to v1.5.4)",
+  },
+  {
+    name: "status.short",
+    description:
+      "Set to true to enable --short by default in git-status. The option --no-short takes precedence over this variable",
+  },
+  {
+    name: "status.branch",
+    description:
+      "Set to true to enable --branch by default in git-status. The option --no-branch takes precedence over this variable",
+  },
+  {
+    name: "status.displayCommentPrefix",
+    description:
+      "If set to true, git-status will insert a comment prefix before each output line (starting with core.commentChar, i.e.  # by default). This was the behavior of git- status(1) in Git 1.8.4 and previous. Defaults to false",
+  },
+  {
+    name: "status.showUntrackedFiles",
+    description:
+      "By default, git-status(1) and git-commit show files which are not currently tracked by Git. Directories which contain only untracked files, are shown with the directory name only. Showing untracked files means that Git needs to lstat() all the files in the whole repository, which might be slow on some systems. So, this variable controls how the commands displays the untracked files",
+  },
+  {
+    name: "status.submoduleSummary",
+    description:
+      "Defaults to false. If this is set to a non zero number or true (identical to -1 or an unlimited number), the submodule summary will be enabled and a summary of commits for modified submodules will be shown (see --summary-limit option of git-submodule). Please note that the summary output command will be suppressed for all submodules when diff.ignoreSubmodules is set to all or only for those submodules where submodule.<name>.ignore=all. The only exception to that rule is that status and commit will show staged submodule changes. To also view the summary for ignored submodules you can either use the --ignore-submodules=dirty command-line option or the git submodule summary command, which shows a similar output but does not honor these settings",
+  },
+  {
+    name: "stash.showPatch",
+    description:
+      "If this is set to true, the git stash show command without an option will show the stash in patch form. Defaults to false. See description of show command in git- stash(1)",
+  },
+  {
+    name: "stash.showStat",
+    description:
+      "If this is set to true, the git stash show command without an option will show diffstat of the stash. Defaults to true. See description of show command in git- stash(1)",
+  },
+  {
+    name: "submodule.&lt;name&gt;.path",
+    insertValue: "submodule.{cursor}.path",
+    description:
+      "The path within this project and URL for a submodule. These variables are initially populated by git submodule init. See git-submodule and gitmodules(5) for details",
+  },
+  {
+    name: "submodule.&lt;name&gt;.url",
+    insertValue: "submodule.{cursor}.url",
+    description:
+      "The path within this project and URL for a submodule. These variables are initially populated by git submodule init. See git-submodule and gitmodules(5) for details",
+  },
+  {
+    name: "submodule.&lt;name&gt;.update",
+    insertValue: "submodule.{cursor}.update",
+    description:
+      "The default update procedure for a submodule. This variable is populated by git submodule init from the gitmodules(5) file. See description of update command in git- submodule(1)",
+  },
+  {
+    name: "submodule.&lt;name&gt;.branch",
+    insertValue: "submodule.{cursor}.branch",
+    description:
+      "The remote branch name for a submodule, used by git submodule update --remote. Set this option to override the value found in the .gitmodules file. See git-submodule and gitmodules(5) for details",
+  },
+  {
+    name: "submodule.&lt;name&gt;.fetchRecurseSubmodules",
+    insertValue: "submodule.{cursor}.fetchRecurseSubmodules",
+    description:
+      'This option can be used to control recursive fetching of this submodule. It can be overridden by using the --[no-]recurse-submodules command-line option to "git fetch" and "git pull". This setting will override that from in the gitmodules(5) file',
+  },
+  {
+    name: "submodule.&lt;name&gt;.ignore",
+    insertValue: "submodule.{cursor}.ignore",
+    description:
+      'Defines under what circumstances "git status" and the diff family show a submodule as modified. When set to "all", it will never be considered modified (but it will nonetheless show up in the output of status and commit when it has been staged), "dirty" will ignore all changes to the submodules work tree and takes only differences between the HEAD of the submodule and the commit recorded in the superproject into account"untracked" will additionally let submodules with modified tracked files in their work tree show up. Using "none" (the default when this option is not set) also shows submodules that have untracked files in their work tree as changed. This setting overrides any setting made in .gitmodules for this submodule, both settings can be overridden on the command line by using the "--ignore-submodules" option. The git submodule commands are not affected by this setting',
+  },
+  {
+    name: "tag.sort",
+    description:
+      'This variable controls the sort ordering of tags when displayed by git-tag. Without the "--sort=<value>" option provided, the value of this variable will be used as the default',
+  },
+  {
+    name: "tar.umask",
+    description:
+      'This variable can be used to restrict the permission bits of tar archive entries. The default is 0002, which turns off the world write bit. The special value "user" indicates that the archiving user’s umask will be used instead. See umask(2) and git- archive(1)',
+  },
+  {
+    name: "transfer.fsckObjects",
+    description:
+      "When fetch.fsckObjects or receive.fsckObjects are not set, the value of this variable is used instead. Defaults to false",
+  },
+  {
+    name: "transfer.hideRefs",
+    description:
+      "String(s) receive-pack and upload-pack use to decide which refs to omit from their initial advertisements. Use more than one definition to specify multiple prefix strings. A ref that is under the hierarchies listed in the value of this variable is excluded, and is hidden when responding to git push or git fetch. See receive.hideRefs and uploadpack.hideRefs for program-specific versions of this config",
+  },
+  {
+    name: "transfer.unpackLimit",
+    description:
+      "When fetch.unpackLimit or receive.unpackLimit are not set, the value of this variable is used instead. The default value is 100",
+  },
+  {
+    name: "uploadarchive.allowUnreachable",
+    description:
+      "If true, allow clients to use git archive --remote to request any tree, whether reachable from the ref tips or not. See the discussion in the SECURITY section of git- upload-archive(1) for more details. Defaults to false",
+  },
+  {
+    name: "uploadpack.hideRefs",
+    description:
+      "This variable is the same as transfer.hideRefs, but applies only to upload-pack (and so affects only fetches, not pushes). An attempt to fetch a hidden ref by git fetch will fail. See also uploadpack.allowTipSHA1InWant",
+  },
+  {
+    name: "uploadpack.allowTipSHA1InWant",
+    description:
+      "When uploadpack.hideRefs is in effect, allow upload-pack to accept a fetch request that asks for an object at the tip of a hidden ref (by default, such a request is rejected). see also uploadpack.hideRefs",
+  },
+  {
+    name: "uploadpack.allowReachableSHA1InWant",
+    description:
+      "Allow upload-pack to accept a fetch request that asks for an object that is reachable from any ref tip. However, note that calculating object reachability is computationally expensive. Defaults to false",
+  },
+  {
+    name: "uploadpack.keepAlive",
+    description:
+      "When upload-pack has started pack-objects, there may be a quiet period while pack-objects prepares the pack. Normally it would output progress information, but if --quiet was used for the fetch, pack-objects will output nothing at all until the pack data begins. Some clients and networks may consider the server to be hung and give up. Setting this option instructs upload-pack to send an empty keepalive packet every uploadpack.keepAlive seconds. Setting this option to 0 disables keepalive packets entirely. The default is 5 seconds",
+  },
+  {
+    name: "url.&lt;base&gt;.insteadOf",
+    insertValue: "url.{cursor}.insteadOf",
+    description:
+      "Any URL that starts with this value will be rewritten to start, instead, with <base>. In cases where some site serves a large number of repositories, and serves them with multiple access methods, and some users need to use different access methods, this feature allows people to specify any of the equivalent URLs and have Git automatically rewrite the URL to the best alternative for the particular user, even for a never-before-seen repository on the site. When more than one insteadOf strings match a given URL, the longest match is used",
+  },
+  {
+    name: "url.&lt;base&gt;.pushInsteadOf",
+    insertValue: "url.{cursor}.pushInsteadOf",
+    description:
+      "Any URL that starts with this value will not be pushed to; instead, it will be rewritten to start with <base>, and the resulting URL will be pushed to. In cases where some site serves a large number of repositories, and serves them with multiple access methods, some of which do not allow push, this feature allows people to specify a pull-only URL and have Git automatically use an appropriate URL to push, even for a never-before-seen repository on the site. When more than one pushInsteadOf strings match a given URL, the longest match is used. If a remote has an explicit pushurl, Git will ignore this setting for that remote",
+  },
+  {
+    name: "user.email",
+    priority: 76,
+    description:
+      "Your email address to be recorded in any newly created commits. Can be overridden by the GIT_AUTHOR_EMAIL, GIT_COMMITTER_EMAIL, and EMAIL environment variables. See git- commit-tree(1)",
+  },
+  {
+    name: "user.name",
+    priority: 76,
+    description:
+      "Your full name to be recorded in any newly created commits. Can be overridden by the GIT_AUTHOR_NAME and GIT_COMMITTER_NAME environment variables. See git-commit-tree",
+  },
+  {
+    name: "user.signingKey",
+    description:
+      "If git-tag(1) or git-commit is not selecting the key you want it to automatically when creating a signed tag or commit, you can override the default selection with this variable. This option is passed unchanged to gpg’s --local-user parameter, so you may specify a key using any method that gpg supports",
+  },
+  {
+    name: "versionsort.prereleaseSuffix",
+    description:
+      'When version sort is used in git-tag, prerelease tags (e.g"1.0-rc1") may appear after the main release "1.0". By specifying the suffix "-rc" in this variable, "1.0-rc1" will appear before "1.0"',
+  },
+  {
+    name: "web.browser",
+    description:
+      "Specify a web browser that may be used by some commands. Currently only git- instaweb(1) and git-help may use it",
+  },
+];
+
 const addOptions: Fig.Option[] = [
   {
     name: ["-n", "--dry-run"],
@@ -498,7 +2519,7 @@ const headSuggestions = [
     description: "The most recent commit",
   },
   {
-    name: "HEAD~<N>",
+    name: "HEAD~&lt;N&gt;",
     description: "A specific number of commits",
     insertValue: "HEAD~",
   },
@@ -1130,7 +3151,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "config",
-      description: "Set author",
+      description: "Change Git configuration",
       options: [
         {
           name: "--local",
@@ -1155,26 +3176,6 @@ const completionSpec: Fig.Spec = {
           name: "--global",
           description:
             "For writing options: write to global ~/.gitconfig file rather than the repository .git/config",
-          args: [
-            {
-              name: "key",
-              isVariadic: true,
-              suggestions: [
-                {
-                  name: "user.name",
-                  description: "Config for username",
-                },
-                {
-                  name: "user.email",
-                  description: "Config for email",
-                },
-              ],
-            },
-            {
-              name: "value",
-              isOptional: true,
-            },
-          ],
         },
         {
           name: "--replace-all",
@@ -1353,6 +3354,18 @@ const completionSpec: Fig.Spec = {
             name: "value",
             isOptional: true,
           },
+        },
+      ],
+      args: [
+        {
+          name: "setting",
+          suggestions: configSuggestions.map((suggestion) => ({
+            ...suggestion,
+            icon: "⚙️",
+          })),
+        },
+        {
+          name: "value",
         },
       ],
     },
@@ -2628,7 +4641,7 @@ const completionSpec: Fig.Spec = {
           requiresEquals: true,
           args: {
             isOptional: true,
-            name: "[=< width >[,< name-width >[,< count >]]]",
+            name: "[=< width >[,< name-width >[,&lt; count &gt;]]]",
           },
         },
         {
@@ -2639,7 +4652,7 @@ const completionSpec: Fig.Spec = {
             isVariadic: true,
             optionsCanBreakVariadicArg: false,
             template: "filepaths",
-            name: "[< path >...]",
+            name: "[&lt; path &gt;...]",
           },
         },
       ],


### PR DESCRIPTION
Scraped from the manual page. Descriptions need to be cleaned up still.

Because of Fig's UI and {cursor} support, this is actually **better than fish completions** for git-config (which are often incorrect and slow down the whole shell)