### PR TITLE
feat(git): support `git-xyz` commands on $PATH

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -549,7 +549,7 @@ const completionSpec: Fig.Spec = {
   description: "The stupid content tracker",
   generateSpec: async (_, executeShellCommand) => {
     const out = await executeShellCommand(
-      "compgen -c | grep git- | cut -c5- | uniq"
+      "compgen -c | grep git- | cut -c5- | sort -u"
     );
     return {
       name: "git",

--- a/src/git.ts
+++ b/src/git.ts
@@ -504,9 +504,61 @@ const headSuggestions = [
   },
 ];
 
+/** Git finds these commands as "git-<name>" on your PATH */
+const optionalCommands: Record<string, Omit<Fig.Subcommand, "name">> = {
+  open: {
+    description: "Open in your browser",
+    options: [
+      {
+        name: ["-c", "--commit"],
+        description: "Open current commit",
+      },
+      {
+        name: ["-i", "--issue"],
+        description: "Open issues page",
+      },
+      {
+        name: ["-s", "--suffix"],
+        description: "Append this suffix",
+        args: {
+          name: "string",
+        },
+      },
+      {
+        name: ["-p", "--print"],
+        description: "Just print the URL",
+      },
+    ],
+  },
+  recent: {
+    description: "Show recent local branches",
+    options: [
+      {
+        name: "-n",
+        description: "Specify a number of branches to show",
+        args: {
+          name: "int",
+        },
+      },
+    ],
+  },
+};
+
 const completionSpec: Fig.Spec = {
   name: "git",
   description: "The stupid content tracker",
+  generateSpec: async (_, executeShellCommand) => {
+    const out = await executeShellCommand(
+      "compgen -c | grep git- | cut -c5- | uniq"
+    );
+    return {
+      name: "git",
+      subcommands: out.split("\n").map((name) => ({
+        name,
+        ...(optionalCommands[name] ?? { description: `Run git-${name}` }),
+      })),
+    };
+  },
   args: {
     name: "alias",
     description: "Custom user defined git alias",

--- a/src/git.ts
+++ b/src/git.ts
@@ -542,6 +542,10 @@ const optionalCommands: Record<string, Omit<Fig.Subcommand, "name">> = {
       },
     ],
   },
+  flow: {
+    description: "Extensions to follow Vincent Driessen's branching model",
+    loadSpec: "git-flow",
+  },
 };
 
 const completionSpec: Fig.Spec = {

--- a/src/git.ts
+++ b/src/git.ts
@@ -551,9 +551,13 @@ const completionSpec: Fig.Spec = {
     const out = await executeShellCommand(
       "compgen -c | grep git- | cut -c5- | sort -u"
     );
+    const trimmed = out.trim();
+    if (trimmed === "") {
+      return { name: "git" };
+    }
     return {
       name: "git",
-      subcommands: out.split("\n").map((name) => ({
+      subcommands: trimmed.split("\n").map((name) => ({
         name,
         ...(optionalCommands[name] ?? { description: `Run git-${name}` }),
       })),


### PR DESCRIPTION
Shows commands found on your $PATH  in the list of subcommands. These commands can also be supported explicitly in the `optionalCommands` array, to add options and arguments. Currently this only supports `git-open`, `git-recent`, and `git-flow` but it's easy to add more.