### PR TITLE
feat(git): add user config generator

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -3267,6 +3267,9 @@ const completionSpec: Fig.Spec = {
           name: "--get-regexp",
           description:
             "Like --get-all, but interprets the name as a regular expression and writes ou",
+          args: {
+            name: "regexp",
+          },
         },
         {
           name: "--get-urlmatch",
@@ -3425,10 +3428,31 @@ const completionSpec: Fig.Spec = {
       args: [
         {
           name: "setting",
+          // All git config keys are valid
+          suggestCurrentToken: true,
           suggestions: configSuggestions.map((suggestion) => ({
             ...suggestion,
             icon: "⚙️",
           })),
+          generators: {
+            script: "git config --get-regexp '.*'",
+            // This is inefficient but it doesn't need to be faster - most
+            // of the time, you don't need to run `git config` commands,
+            // and when you do it's typically one or two at most.
+            postProcess: (out) =>
+              out
+                .trim()
+                .split("\n")
+                .map((line) => line.slice(0, line.indexOf(" ")))
+                .filter(
+                  (line) =>
+                    line.startsWith("alias.") ||
+                    line.startsWith("branch.") ||
+                    line.startsWith("remote.") ||
+                    !configSuggestions.find(({ name }) => line === name)
+                )
+                .map((name) => ({ name, icon: "⚙️" })),
+          },
         },
         {
           name: "value",


### PR DESCRIPTION
This makes 3 changes:
1. `git config` suggests the current token, since all config keys are valid.
2. Keys from your actual git config (eg. aliases, remotes) are shown
3. `--get-regexp` takes an argument now
<img width="469" alt="Screen Shot 2022-04-08 at 9 27 03 pm" src="https://user-images.githubusercontent.com/52195359/162426940-589c1fbd-9ca0-41fe-b1d8-9f1b93c8a4a1.png">

