### PR TITLE
fix: Add isOptional to arguments that needed them

### DIFF
--- a/src/valet.ts
+++ b/src/valet.ts
@@ -140,6 +140,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "path",
         template: "folders",
+        isOptional: true,
       },
       options: [
         global_option_help,
@@ -271,6 +272,7 @@ const completionSpec: Fig.Spec = {
       description: "Tail log file",
       args: {
         name: "key",
+        isOptional: true,
       },
       options: [
         { name: ["-f", "--follow"] },
@@ -428,6 +430,7 @@ const completionSpec: Fig.Spec = {
       description: "Restart the Valet services",
       args: {
         name: "service",
+        isOptional: true,
       },
       options: [
         global_option_help,
@@ -573,6 +576,7 @@ const completionSpec: Fig.Spec = {
       description: "Start the Valet services",
       args: {
         name: "service",
+        isOptional: true,
       },
       options: [
         global_option_help,
@@ -589,6 +593,7 @@ const completionSpec: Fig.Spec = {
       description: "Stop the Valet services",
       args: {
         name: "service",
+        isOptional: true,
       },
       options: [
         global_option_help,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix

**What is the current behavior? (You can also link to an open issue here)**
Fixes #1123 

**What is the new behavior (if this is a feature change)?**
Make commands' whose arguments aren't required optional.
I'm not familiar with Laravel Valet so I looked at the commands [here](https://laravel.com/docs/9.x/valet#other-valet-commands). Let me know if I missed anything/made any mistakes.