### PR TITLE
fix(git): correct `log` option

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -4834,7 +4834,7 @@ const completionSpec: Fig.Spec = {
           description: "Show each commit as a single line",
         },
         {
-          name: "--p",
+          name: ["-p", "-u", "--patch"],
           description: "Display the full diff of each commit",
         },
         {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
When the user types `git log `, fig suggests the autocompletion `--p`, which results in the error `fatal: unrecognized argument: --p`. Per the [git docs](https://git-scm.com/docs/git-log#_diff_formatting), the available options for `git log` to generate a patch are `-p`, `-u`, and `--patch`.

**What is the new behavior (if this is a feature change)?**
To display the correct options.