### PR TITLE
feat(deno): add `uninstall` generator

### DIFF
--- a/src/deno.ts
+++ b/src/deno.ts
@@ -728,7 +728,7 @@ const denoUninstall: Fig.Subcommand = {
     "Uninstalls an executable script in the installation root's bin directory",
   args: {
     name: "name",
-    description: "Arguments that will be provided automatically when run",
+    description: "Delete an executable with this name",
     generators: generateInstalledDenoScripts,
   },
   options: [

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -4,6 +4,7 @@
 import { filepaths } from "@fig/autocomplete-generators";
 import {
   generateDocs,
+  generateInstalledDenoScripts,
   generateLintRules,
   generatePreferredFilepaths,
   generateRunnableFiles,
@@ -728,18 +729,7 @@ const denoUninstall: Fig.Subcommand = {
   args: {
     name: "name",
     description: "Arguments that will be provided automatically when run",
-    generators: {
-      script: "\\find ~/.deno/bin -maxdepth 1 -perm -111 -type f",
-      postProcess: (out) =>
-        out
-          .split("\n")
-          .filter((path) => !path.endsWith("/deno"))
-          .map((path) => ({
-            name: path.slice(path.lastIndexOf("/") + 1),
-            icon: "📦",
-            description: path,
-          })),
-    },
+    generators: generateInstalledDenoScripts,
   },
   options: [
     {

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -728,7 +728,18 @@ const denoUninstall: Fig.Subcommand = {
   args: {
     name: "name",
     description: "Arguments that will be provided automatically when run",
-    isVariadic: true,
+    generators: {
+      script: "\\find ~/.deno/bin -maxdepth 1 -perm -111 -type f",
+      postProcess: (out) =>
+        out
+          .split("\n")
+          .filter((path) => !path.endsWith("/deno"))
+          .map((path) => ({
+            name: path.slice(path.lastIndexOf("/") + 1),
+            icon: "📦",
+            description: path,
+          })),
+    },
   },
   options: [
     {

--- a/src/deno/generators.ts
+++ b/src/deno/generators.ts
@@ -347,3 +347,18 @@ export const generateTasks: Fig.Generator = {
     });
   },
 };
+
+// --- Generate installed deno scripts
+
+export const generateInstalledDenoScripts: Fig.Generator = {
+  script: "\\find ~/.deno/bin -maxdepth 1 -perm -111 -type f",
+  postProcess: (out) =>
+    out
+      .split("\n")
+      .filter((path) => !path.endsWith("/deno"))
+      .map((path) => ({
+        name: path.slice(path.lastIndexOf("/") + 1),
+        icon: "📦",
+        description: path,
+      })),
+};


### PR DESCRIPTION
<img width="477" alt="Screen Shot 2022-04-13 at 3 43 42 pm" src="https://user-images.githubusercontent.com/52195359/163108411-a3d005ee-61f4-483e-a55f-f1dae04b31a1.png">

Fun fact I learned while checking the logic: deno will happily delete itself if it's installed to the same location it installs scripts (which, by default, it is)... shooting yourself in the foot is just a `deno uninstall deno` away!