### PR TITLE
fix(typeorm): remove migrations subcommands

### DIFF
--- a/src/typeorm.ts
+++ b/src/typeorm.ts
@@ -113,7 +113,7 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["migration:create", "migrations:create"],
+      name: "migration:create",
       description: "Creates a new migration file",
       options: [
         cliOptions.help,
@@ -139,7 +139,7 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["migration:generate", "migrations:generate"],
+      name: "migration:generate",
       description:
         "Generates a new migration file with sql needs to be executed to update schema",
       options: [
@@ -180,7 +180,7 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["migration:run", "migrations:run"],
+      name: "migration:run",
       description: "Runs all pending migrations",
       options: [
         cliOptions.help,
@@ -205,7 +205,7 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["migration:revert", "migrations:revert"],
+      name: "migration:revert",
       description: "Reverts last executed migration",
       options: [
         cliOptions.help,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix

**What is the current behavior? (You can also link to an open issue here)**
TypeORM version 0.3.0 removes `migrations:*` commands. ([Release 0.3.0 · typeorm/typeorm](https://github.com/typeorm/typeorm/releases/tag/0.3.0))

![image](https://user-images.githubusercontent.com/50633599/163462835-cca7272c-39de-4283-bd9a-7ca958349a46.png)

**What is the new behavior (if this is a feature change)?**
Don't show the removed commands

**Additional info:**