### PR TITLE
feat: add dotenv completion spec

### DIFF
--- a/src/dotenv.ts
+++ b/src/dotenv.ts
@@ -1,0 +1,36 @@
+const completionSpec: Fig.Spec = {
+  name: "dotenv",
+  description: "Loads environment variables from .env",
+  args: {
+    isCommand: true,
+  },
+  options: [
+    {
+      name: "-f",
+      exclusiveOn: ["-h", "-v", "-t"],
+      description: "List of env files to parse",
+      args: {
+        template: "filepaths",
+      },
+    },
+    {
+      name: ["-h", "--help"],
+      exclusiveOn: ["-f", "-v", "-t"],
+      description: "Display help",
+    },
+    {
+      name: ["-v", "--version"],
+      exclusiveOn: ["-f", "-h", "-t"],
+      description: "Show version",
+    },
+    {
+      name: ["-t", "--template"],
+      exclusiveOn: ["-f", "-h", "-v"],
+      description: "Create a template env file",
+      args: {
+        template: "filepaths",
+      },
+    },
+  ],
+};
+export default completionSpec;

--- a/src/dotenv.ts
+++ b/src/dotenv.ts
@@ -1,3 +1,5 @@
+// completion spec for dotenv
+// https://github.com/bkeepers/dotenv
 const completionSpec: Fig.Spec = {
   name: "dotenv",
   description: "Loads environment variables from .env",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

feature: add completion spec for [dotenv](https://github.com/bkeepers/dotenv)

**What is the current behavior? (You can also link to an open issue here)**

does not provide autocomplete for dotenv commands

**What is the new behavior (if this is a feature change)?**

provides autocomplete for dotenv commands
