### PR TITLE
feat(scp): add hosts and filepaths completions

### DIFF
--- a/src/scp.ts
+++ b/src/scp.ts
@@ -1,14 +1,27 @@
+import { knownHosts, configHosts } from "./ssh";
+
 const completionSpec: Fig.Spec = {
   name: "scp",
   description: "Copies files or directories between hosts on a network",
   args: [
     {
-      name: "source",
+      name: "sources",
       description: "File or directory, local or remote ([user@]host:[path])",
+      isVariadic: true,
+      generators: [
+        knownHosts,
+        configHosts,
+        { template: ["history", "filepaths", "folders"] },
+      ],
     },
     {
       name: "target",
       description: "File or directory, local or remote ([user@]host:[path])",
+      generators: [
+        knownHosts,
+        configHosts,
+        { template: ["history", "filepaths", "folders"] },
+      ],
     },
   ],
   options: [

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -1,6 +1,6 @@
 const knownHostRegex = /(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9]+/; // will match numerical IPs as well as domains/subdomains
 
-const knownHosts: Fig.Generator = {
+export const knownHosts: Fig.Generator = {
   script: "cat ~/.ssh/known_hosts",
   postProcess: function (out, tokens) {
     return out
@@ -20,31 +20,27 @@ const knownHosts: Fig.Generator = {
   trigger: "@",
 };
 
+export const configHosts: Fig.Generator = {
+  script: "cat ~/.ssh/config",
+  postProcess: function (out) {
+    return out
+      .split("\n")
+      .filter((line) => line.trim().startsWith("Host ") && !line.includes("*"))
+      .map((host) => ({
+        name: host.split(" ")[1],
+        description: "SSH host",
+        priority: 90,
+      }));
+  },
+};
+
 const completionSpec: Fig.Spec = {
   name: "ssh",
   description: "Log into a remote machine",
   args: {
     name: "user@hostname",
     description: "Address of remote machine to log into",
-    generators: [
-      {
-        script: "cat ~/.ssh/config",
-        postProcess: function (out) {
-          return out
-            .split("\n")
-            .filter(
-              (line) => line.trim().startsWith("Host ") && !line.includes("*")
-            )
-            .map((host) => ({
-              name: host.split(" ")[1],
-              description: "SSH host",
-              priority: 90,
-            }));
-        },
-      },
-      knownHosts,
-      { template: "history" },
-    ],
+    generators: [knownHosts, configHosts, { template: "history" }],
   },
   options: [
     {


### PR DESCRIPTION
Currently the signature for `scp` is wrong. Like `cp`, it can also take _multiple_ sources and copy to a single destination.