### PR TITLE
feat: hide shell syntax commands

### DIFF
--- a/src/-.ts
+++ b/src/-.ts
@@ -2,6 +2,7 @@ const completionSpec: Fig.Spec = {
   name: "-",
   description:
     "ZSH pre-command modifier that prepends a '-' to the argv[0] string",
+	hidden: true,
   args: {
     isCommand: true,
   },

--- a/src/-.ts
+++ b/src/-.ts
@@ -2,7 +2,7 @@ const completionSpec: Fig.Spec = {
   name: "-",
   description:
     "ZSH pre-command modifier that prepends a '-' to the argv[0] string",
-	hidden: true,
+  hidden: true,
   args: {
     isCommand: true,
   },

--- a/src/..ts
+++ b/src/..ts
@@ -1,7 +1,7 @@
 const completionSpec: Fig.Spec = {
   name: ".",
   description: "Source a file",
-	hidden: true,
+  hidden: true,
   args: {
     template: "filepaths",
     isScript: true,

--- a/src/..ts
+++ b/src/..ts
@@ -1,6 +1,7 @@
 const completionSpec: Fig.Spec = {
   name: ".",
   description: "Source a file",
+	hidden: true,
   args: {
     template: "filepaths",
     isScript: true,

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,0 +1,10 @@
+const completionSpec: Fig.Spec = {
+  name: "export",
+  description: "Export variables",
+	hidden: true,
+  args: {
+		isVariadic: true,
+	},
+};
+
+export default completionSpec;

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,10 +1,10 @@
 const completionSpec: Fig.Spec = {
   name: "export",
   description: "Export variables",
-	hidden: true,
+  hidden: true,
   args: {
-		isVariadic: true,
-	},
+    isVariadic: true,
+  },
 };
 
 export default completionSpec;

--- a/src/nocorrect.ts
+++ b/src/nocorrect.ts
@@ -1,6 +1,7 @@
 const completionSpec: Fig.Spec = {
   name: "nocorrect",
   description: "ZSH pre-command modifier that disables correction",
+	hidden: true,
   args: {
     isCommand: true,
   },

--- a/src/nocorrect.ts
+++ b/src/nocorrect.ts
@@ -1,7 +1,7 @@
 const completionSpec: Fig.Spec = {
   name: "nocorrect",
   description: "ZSH pre-command modifier that disables correction",
-	hidden: true,
+  hidden: true,
   args: {
     isCommand: true,
   },

--- a/src/noglob.ts
+++ b/src/noglob.ts
@@ -1,6 +1,7 @@
 const completionSpec: Fig.Spec = {
   name: "noglob",
   description: "ZSH pre-command modifier that disables glob expansion",
+	hidden: true,
   args: {
     isCommand: true,
   },

--- a/src/noglob.ts
+++ b/src/noglob.ts
@@ -1,7 +1,7 @@
 const completionSpec: Fig.Spec = {
   name: "noglob",
   description: "ZSH pre-command modifier that disables glob expansion",
-	hidden: true,
+  hidden: true,
   args: {
     isCommand: true,
   },


### PR DESCRIPTION
This should be merged before https://github.com/withfig/public-site-nextjs/pull/127

These commands will be hidden from the manual, but still accessible.

Sidenote: It's so nice to be back on my _actual_ dev machine instead of my girlfriend's laptop. Back to vim!! 🚀