### PR TITLE
fix(yarn): correct workspace parsing for 1.x.x

### DIFF
--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1355,24 +1355,34 @@ const completionSpec: Fig.Spec = {
         const version = await executeShellCommand("yarn --version");
         const isYarnV1 = version.startsWith("1.");
 
-        // Only use info in yarn workspaces info 1.X.X
-        const versionedCommand = isYarnV1 ? "info" : "list --json";
+        const getWorkspacesDefinitionsV1 = async () => {
+          const out = await executeShellCommand(`yarn workspaces info`);
+
+          const startJson = out.indexOf("{");
+          const endJson = out.lastIndexOf("}");
+
+          return Object.entries(
+            JSON.parse(out.slice(startJson, endJson + 1)) as Record<
+              string,
+              { location: string }
+            >
+          ).map(([name, { location }]) => ({
+            name,
+            location,
+          }));
+        };
+
+        const getWorkspacesDefinitionsVOther = async () => {
+          const out = await executeShellCommand(`yarn workspaces list --json`);
+          return out.split("\n").map((line) => JSON.parse(line.trim()));
+        };
 
         try {
-          const out = await executeShellCommand(
-            `yarn workspaces ${versionedCommand}`
-          );
-
           const workspacesDefinitions = isYarnV1
             ? // transform Yarn V1 output to array of workspaces like Yarn V2
-              Object.entries(
-                JSON.parse(out) as Record<string, { location: string }>
-              ).map(([name, { location }]) => ({
-                name,
-                location,
-              }))
+              await getWorkspacesDefinitionsV1()
             : // in yarn v>=2.0.0, workspaces definitions are a list of JSON lines
-              out.split("\n").map((line) => JSON.parse(line.trim()));
+              await getWorkspacesDefinitionsVOther();
 
           const subcommands: Fig.Subcommand[] = workspacesDefinitions.map(
             ({ name, location }: { name: string; location: string }) => ({

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1372,6 +1372,7 @@ const completionSpec: Fig.Spec = {
           }));
         };
 
+        // For yarn >= 2.0.0
         const getWorkspacesDefinitionsVOther = async () => {
           const out = await executeShellCommand(`yarn workspaces list --json`);
           return out.split("\n").map((line) => JSON.parse(line.trim()));


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**

Running `yarn workspace` returns no workspace

**What is the new behavior (if this is a feature change)?**

It now returns workspaces normally

**Additional info:**

This is a follow-up to #1141  in which I did not clean up the output of the `workspace info` command

This is the output you get running `yarn workspaces info` in yarn 1.22.18.

```log
yarn workspaces v1.22.18
{
  "storybook": {
    "location": "storybook/intro",
    "workspaceDependencies": [],
    "mismatchedWorkspaceDependencies": []
  },
  "storybook-vue": {
    "location": "storybook/vue",
    "workspaceDependencies": [],
    "mismatchedWorkspaceDependencies": []
  }
}
✨  Done in 0.03s.
```