### PR TITLE
fix(pm2): separate help flags

### DIFF
--- a/src/pm2.ts
+++ b/src/pm2.ts
@@ -332,7 +332,7 @@ const sharedOptions: Fig.Option[] = [
     description:
       "Enables all monitoring tools (equivalent to –v8 –event-loop-inspector –trace)",
   },
-  { name: "-h, –-help", description: "Outputs usage information" },
+  { name: ["-h", "–-help"], description: "Outputs usage information" },
 ];
 
 const completionSpec: Fig.Spec = {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix

**What is the current behavior? (You can also link to an open issue here)**
selecting the help option from pm2 will resolve ton `-h,--help`

**What is the new behavior (if this is a feature change)?**
resolve help to `-h`

**Additional info:**