### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ As you type, Fig pops up subcommands, options, and contextually relevant argumen
 ## ⚡️ Installation
 
 * **macOS**:
-  * **Homebrew**: `brew install --cask fig`
+  * **Homebrew**: `brew install --cask fig` and restart your terminal
   * **DMG**: Download from our website: [fig.io](https://fig.io/download)
 * **Windows/Linux**:
   * Join the [waitlist](https://withfig.typeform.com/linux)


### PR DESCRIPTION
in iTerm2 (for my experience) fig will not showing `Debugger(zsh)` in the introduction image on[fig.io](https://fig.io/support/troubleshooting/debug-fig)and maybe better to remind others to restart terminal to following the setting guide.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

docs update

**What is the current behavior? (You can also link to an open issue here)**

better to remind others to restart terminal to following the setting guide.

**What is the new behavior (if this is a feature change)?**

just a remind

**Additional info:**