### PR TITLE
feat: add completion spec for `fly` (alias of `flyctl`)

### DIFF
--- a/src/fly.ts
+++ b/src/fly.ts
@@ -1,0 +1,14 @@
+// Completion spec for fly, alias to the flyctl CLI.
+// See completion spec in the ./flyctl.ts file
+
+// Note: Most installations of flyctl also alias flyctl to fly as a command
+// name and this will become the default name in the future. During the
+// transition, note that where you see flyctl as a command it can be replaced
+// with fly.
+
+import completionSpec from "./flyctl";
+
+export default {
+  ...completionSpec,
+  name: "fly",
+};


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

In addition to #1202, adding completion spec for `fly` command, alias of `flyctl`. Suggested by @jsierles. 

I propose we leave it like this until `flyctl` transitions to `fly`.

> Note: Most installations of `flyctl` also alias `flyctl` to `fly` as a command name and **this will become the default name in the future**. During the transition, note that where you see `flyctl` as a command it can be replaced with `fly`.

Source: https://github.com/superfly/flyctl