### PR TITLE
feat(mob): add subcommands aliases

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -264,6 +264,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "thmuch",
+      "name": "Thomas Much",
+      "avatar_url": "https://avatars.githubusercontent.com/u/14270928?v=4",
+      "profile": "https://github.com/thmuch",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/src/mob.ts
+++ b/src/mob.ts
@@ -3,7 +3,7 @@ const completionSpec: Fig.Spec = {
   description: "Fast git handover for remote collaboration with mob.sh",
   subcommands: [
     {
-      name: "start",
+      name: ["start", "s"],
       description: "Start session from base branch in wip branch",
       options: [
         {
@@ -25,7 +25,7 @@ const completionSpec: Fig.Spec = {
       },
     },
     {
-      name: "next",
+      name: ["next", "n"],
       description: "Handover changes in wip branch to next person",
       options: [
         {
@@ -46,7 +46,7 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: "done",
+      name: ["done", "d"],
       description: "Squashes all changes in wip branch to index in base branch",
       options: [
         {
@@ -83,7 +83,7 @@ const completionSpec: Fig.Spec = {
       description: "Removes all orphan wip branches",
     },
     {
-      name: "timer",
+      name: ["timer", "t"],
       description: "Start a <minutes> timer",
       args: {
         name: "minutes",
@@ -105,7 +105,7 @@ const completionSpec: Fig.Spec = {
       description: "Fetch remote state",
     },
     {
-      name: "branch",
+      name: ["branch", "b"],
       description: "Show remote wip branches",
     },
     {
@@ -113,11 +113,11 @@ const completionSpec: Fig.Spec = {
       description: "Show all configuration options",
     },
     {
-      name: "version",
+      name: ["version", "--version", "-v"],
       description: "Show the version",
     },
     {
-      name: "help",
+      name: ["help", "--help", "-h"],
       description: "Show help",
     },
     {

--- a/src/mob.ts
+++ b/src/mob.ts
@@ -113,11 +113,11 @@ const completionSpec: Fig.Spec = {
       description: "Show all configuration options",
     },
     {
-      name: ["version", "--version", "-v"],
+      name: "version",
       description: "Show the version",
     },
     {
-      name: ["help", "--help", "-h"],
+      name: "help",
       description: "Show help",
     },
     {


### PR DESCRIPTION
Updates the "mob" completion spec with frequently used, but undocumented abbreviations of some subcommands.