### PR TITLE
fix(hugo): remove archetype file extension in --kind option

### DIFF
--- a/src/hugo.ts
+++ b/src/hugo.ts
@@ -877,7 +877,7 @@ const completionSpec: Fig.Spec = {
                 script: "ls ./archetypes/",
                 postProcess: (output) =>
                   output.split("\n").map((fileName) => ({
-                    name: fileName.substring(0, fileName.lastIndexOf(".")),
+                    name: fileName.slice(0, fileName.lastIndexOf(".")),
                     icon: "fig://icon?type=string",
                   })),
               },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix
**What is the current behavior? (You can also link to an open issue here)**
Fixes: #1213 
**What is the new behavior (if this is a feature change)?**
No
**Additional info:**
Remove archetype file extensions in --kind option hints