### PR TITLE
feat(deno): update to 1.22

### DIFF
--- a/src/deno.ts
+++ b/src/deno.ts
@@ -2508,6 +2508,9 @@ const completion: Fig.Spec = {
     {
       name: "task",
       description: "Run a task defined in the configuration file",
+      parserDirectives: {
+        optionsMustPrecedeArguments: true,
+      },
       options: [
         {
           name: ["-c", "--config"],

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -1100,6 +1100,14 @@ const completion: Fig.Spec = {
           name: "source_file",
           isOptional: true,
           template: "filepaths",
+          suggestions: [
+            {
+              name: "--builtin",
+              description: "Get documentation for built-in symbols",
+              icon: "fig://icon?type=option",
+              type: "option",
+            },
+          ],
         },
         {
           name: "filter",

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -2550,12 +2550,17 @@ const completion: Fig.Spec = {
           description: "Suppress diagnostic output",
         },
       ],
-      args: {
-        name: "task_name_and_args",
-        isVariadic: true,
-        isOptional: true,
-        generators: generateTasks,
-      },
+      args: [
+        {
+          name: "task_name",
+          generators: generateTasks,
+        },
+        {
+          name: "task_args",
+          isVariadic: true,
+          isOptional: true,
+        },
+      ],
     },
     {
       name: "test",

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -655,6 +655,9 @@ const completion: Fig.Spec = {
       name: "compile",
       description:
         "UNSTABLE: Compile the script into a self contained executable",
+      parserDirectives: {
+        optionsMustPrecedeArguments: true,
+      },
       options: [
         {
           name: "--import-map",
@@ -921,6 +924,7 @@ const completion: Fig.Spec = {
       ],
       args: {
         name: "script_arg",
+        isScript: true,
         isVariadic: true,
         template: "filepaths",
       },
@@ -1415,6 +1419,13 @@ const completion: Fig.Spec = {
         isVariadic: true,
         isOptional: true,
         template: "filepaths",
+        suggestions: [
+          {
+            name: "-",
+            description: "Read from standard input",
+            hidden: true,
+          },
+        ],
       },
     },
     {
@@ -1512,6 +1523,9 @@ const completion: Fig.Spec = {
     {
       name: "install",
       description: "Install script as an executable",
+      parserDirectives: {
+        optionsMustPrecedeArguments: true,
+      },
       options: [
         {
           name: "--import-map",
@@ -1799,6 +1813,7 @@ const completion: Fig.Spec = {
       args: {
         name: "cmd",
         isVariadic: true,
+        isScript: true,
         template: "filepaths",
       },
     },
@@ -2190,6 +2205,9 @@ const completion: Fig.Spec = {
     {
       name: "run",
       description: "Run a JavaScript or TypeScript program",
+      parserDirectives: {
+        optionsMustPrecedeArguments: true,
+      },
       options: [
         {
           name: "--import-map",
@@ -2477,6 +2495,14 @@ const completion: Fig.Spec = {
         name: "script_arg",
         isVariadic: true,
         template: "filepaths",
+        isScript: true,
+        suggestions: [
+          {
+            name: "-",
+            description: "Read from standard input",
+            hidden: true,
+          },
+        ],
       },
     },
     {

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -1,1173 +1,3152 @@
-// This file largely follows the same structure (not order) as deno/cli/flags.rs:
-// https://github.com/denoland/deno/blob/main/cli/flags.rs
-
 import { filepaths } from "@fig/autocomplete-generators";
 import {
   generateDocs,
   generateInstalledDenoScripts,
   generateLintRules,
-  generatePreferredFilepaths,
-  generateRunnableFiles,
   generateTasks,
   generateVersions,
 } from "./deno/generators";
 
-type ExclusiveOn = {
-  exclusiveOn?: string[];
-};
-
-const unsafelyIgnoreCertificateErrorsOption: Fig.Option = {
-  name: "--unsafely-ignore-certificate-errors",
-  description: "DANGER: Disables verification of TLS certificates",
-  isDangerous: true,
-  requiresSeparator: true,
-  args: {
-    name: "host names",
-    description: "Scope ignoring certificate errors to these hosts",
-    isOptional: true,
-  },
-};
-
-const permissionOptions: Fig.Option[] = [
-  {
-    name: ["-A", "--allow-all"],
-    description: "Allow all permissions",
-  },
-  {
-    name: "--allow-env",
-    description: "Allow environment access",
-    requiresSeparator: true,
-    args: {
-      name: "variable",
-      description: "Comma-separated list of environment variables to allow",
-      isOptional: true,
-    },
-  },
-  {
-    name: "--allow-ffi",
-    description: "Allow loading dynamic libraries",
-    requiresSeparator: true,
-    args: {
-      name: "library",
-      description: "The path of the dynamic library to allow",
-      isOptional: true,
-    },
-  },
-  {
-    name: "--allow-hrtime",
-    description: "Allow high resolution time measurement",
-  },
-  {
-    name: "--allow-net",
-    description: "Allow network access",
-    requiresSeparator: true,
-    args: {
-      name: "hosts",
-      isOptional: true,
-    },
-  },
-  {
-    name: "--allow-read",
-    description: "Allow file system read access",
-    requiresSeparator: true,
-    args: {
-      name: "paths",
-      generators: {
-        getQueryTerm: ",",
-        template: "filepaths",
-      },
-      isOptional: true,
-    },
-  },
-  {
-    name: "--allow-run",
-    description: "Allow running subprocesses",
-    requiresSeparator: true,
-    args: {
-      name: "executables",
-      isOptional: true,
-    },
-  },
-  {
-    name: "--allow-write",
-    description: "Allow file system write access",
-    requiresSeparator: true,
-    args: {
-      name: "paths",
-      isOptional: true,
-      generators: {
-        getQueryTerm: ",",
-        template: "filepaths",
-      },
-    },
-  },
-  {
-    name: "--no-prompt",
-    description: "Always throw if the permission wasn't passed",
-  },
-  unsafelyIgnoreCertificateErrorsOption,
-];
-
-function inspectorOptions(options: ExclusiveOn = {}): Fig.Option[] {
-  return [
-    {
-      name: "--inspect",
-      description: "Activate inspector on host:port (default: 127.0.0.1:9229)",
-      requiresSeparator: true,
-      args: {
-        name: "host:port",
-        description: "The host:port to activate the inspector on",
-        isOptional: true,
-      },
-      exclusiveOn: options.exclusiveOn,
-    },
-    {
-      name: "--inspect-brk",
-      description:
-        "Activate inspector on host:port and break at the start of user script (default: 127.0.0.1:9229)",
-      requiresSeparator: true,
-      args: {
-        name: "host:port",
-        description: "The host:port to activate the inspector on",
-        isOptional: true,
-      },
-      exclusiveOn: options.exclusiveOn,
-    },
-  ];
-}
-
-const caFileOption: Fig.Option = {
-  name: "--cert",
-  description: "Load certificate authority from a PEM encoded file",
-  args: {
-    name: "certificate file",
-    description: "The certificate file to load",
-    template: "filepaths",
-  },
-};
-
-const configOption: Fig.Option = {
-  name: ["-c", "--config"],
-  description: "Load a configuration file",
-  args: {
-    name: "config file",
-    description: "The config file to load",
-    generators: generatePreferredFilepaths({
-      names: ["tsconfig.json", "deno.json", "deno.jsonc"],
-    }),
-  },
-};
-
-const importMapOption: Fig.Option = {
-  name: "--import-map",
-  description: "Load an import map from a local file or remote URL",
-  args: {
-    name: "source",
-    description: "The location of the import map (can be a URL)",
-    generators: generatePreferredFilepaths({
-      names: [
-        "importmap.json",
-        "import_map.json",
-        "import-map.json",
-        "imports.json",
-      ],
-    }),
-  },
-};
-
-const lockOption: Fig.Option = {
-  name: "--lock",
-  description: "Check the specified lock file",
-  args: {
-    name: "lock file",
-    description: "The location of the JSON lock file",
-    generators: generatePreferredFilepaths({ names: ["lock.json"] }),
-  },
-};
-
-const lockWriteOption: Fig.Option = {
-  name: "--lock-write",
-  description: "Write lock file",
-  dependsOn: ["--lock"],
-};
-
-const noCheckOption: Fig.Option = {
-  name: "--no-check",
-  description: "Skip type checking modules",
-  requiresSeparator: true,
-  args: {
-    name: "type",
-    description: "Specify the kind of modules to skip type checking",
-    isOptional: true,
-    suggestions: [
-      {
-        name: "remote",
-        description: "Don't check remote modules",
-        icon: "fig://icon?type=string",
-      },
-    ],
-  },
-};
-
-const noRemoteOption: Fig.Option = {
-  name: "--no-remote",
-  description: "Do not resolve remote modules",
-};
-
-const reloadOption: Fig.Option = {
-  name: ["-r", "--reload"],
-  description:
-    "Reload source code cache (recompile TypeScript, download dependencies)",
-  requiresSeparator: true,
-  args: {
-    name: "cache blocklist",
-    description: "A comma-separated list of URLs to block from the cache",
-    isOptional: true,
-  },
-};
-
-const seedOption: Fig.Option = {
-  name: "--seed",
-  description: "Seed Math.random()",
-  args: {
-    name: "number",
-    description: "The number to use as the seed for Math.random()",
-  },
-};
-
-const v8FlagsOption: Fig.Option = {
-  name: "--v8-flags",
-  description: "Set V8 command line options (for help: --v8-flags=--help",
-  requiresSeparator: true,
-  args: {
-    name: "V8 flags",
-    description: "Flags to pass to V8",
-    // TODO: Using `deno run --v8-flags=--help` to generate suggestions
-  },
-};
-
-function watchOption(options: ExclusiveOn & { files: boolean }): Fig.Option {
-  return {
-    name: "--watch",
-    description:
-      "UNSTABLE: Watch for file changes and restart process automatically",
-    exclusiveOn: options.exclusiveOn,
-    requiresSeparator: options.files ? true : undefined,
-    args: options.files
-      ? {
-          name: "files",
-          isOptional: true,
-          generators: {
-            template: "filepaths",
-            getQueryTerm: ",",
-          },
-        }
-      : undefined,
-  };
-}
-
-const noClearScreenOption: Fig.Option = {
-  name: "--no-clear-screen",
-  description: "Do not clear terminal screen when under watch mode",
-  dependsOn: ["--watch"],
-};
-
-const compatOption: Fig.Option = {
-  name: "--compat",
-  dependsOn: ["--unstable"],
-  description:
-    "Node compatibility mode. Currently only enables builtin modules like 'fs'",
-};
-
-const locationOption: Fig.Option = {
-  name: "--location",
-  description: "Value of 'globalThis.location' used by some web APIs",
-  args: {
-    name: "URL",
-  },
-};
-
-const cachedOnlyOption: Fig.Option = {
-  name: "--cached-only",
-  description: "Require that remote dependencies are already cached",
-};
-
-const compileOptions: Fig.Option[] = [
-  importMapOption,
-  noRemoteOption,
-  configOption,
-  noCheckOption,
-  reloadOption,
-  lockOption,
-  lockWriteOption,
-  caFileOption,
-];
-
-/**
- * Generate an array of options that control runtime behavior.
- *
- * This function mirrors the `runtime_args` function:
- * https://github.com/denoland/deno/blob/930cb0a/cli/flags.rs#L1383
- */
-function runtimeOptions(init: {
-  perms: boolean;
-  inspector: boolean;
-  inspectorExclusiveOn?: string[];
-}): Fig.Option[] {
-  const options = [
-    // Without this spread, calling runtimeOptions would mutate compileOptions
-    ...compileOptions,
-  ];
-  if (init.perms) {
-    options.push(...permissionOptions);
-  }
-  if (init.inspector) {
-    const inspector = inspectorOptions({
-      exclusiveOn: init.inspectorExclusiveOn,
-    });
-    options.push(...inspector);
-  }
-  options.push(
-    cachedOnlyOption,
-    locationOption,
-    v8FlagsOption,
-    seedOption,
-    compatOption
-  );
-  return options;
-}
-
-const denoRun: Fig.Subcommand = {
-  name: "run",
-  description: "Run a JavaScript or TypeScript program",
-  args: {
-    name: "script",
-    description: "The JavaScript or TypeScript file to run",
-    generators: generateRunnableFiles,
-    isScript: true,
-    suggestions: [
-      {
-        name: "-",
-        description: "Read from standard input",
-        hidden: true,
-      },
-    ],
-  },
-  parserDirectives: {
-    optionsMustPrecedeArguments: true,
-  },
-  options: [
-    ...runtimeOptions({
-      perms: true,
-      inspector: true,
-      inspectorExclusiveOn: ["--watch"],
-    }),
-    watchOption({
-      files: true,
-      exclusiveOn: ["--inspect", "--inspect-brk"],
-    }),
-    noClearScreenOption,
-  ],
-};
-
-const denoTest: Fig.Subcommand = {
-  name: "test",
-  description: "Run tests using Deno's built-in test runner",
-  args: {
-    name: "paths",
-    description: "The paths of tests to run",
-    isOptional: true,
-    isVariadic: true,
-    generators: filepaths({
-      matches: /(\.|_)?test\.(m?(j|t)sx?)$/,
-      editFileSuggestions: { priority: 75 },
-    }),
-  },
-  options: [
-    ...runtimeOptions({ perms: true, inspector: true }),
-    {
-      name: "--ignore",
-      description: "Ignore files",
-      requiresSeparator: true,
-      args: {
-        name: "Files to ignore",
-        description: "Files matching this pattern will be ignored",
-        template: "filepaths",
-      },
-    },
-    {
-      name: "--no-run",
-      description: "Cache test modules, but don't run tests",
-      exclusiveOn: ["--watch"],
-    },
-    {
-      name: "--doc",
-      description: "UNSTABLE: Type check code blocks in documentation",
-    },
-    {
-      name: "--fail-fast",
-      description:
-        "Stop after N errors (defaults to stopping after the first error)",
-      requiresSeparator: true,
-      args: {
-        name: "number",
-        isOptional: true,
-      },
-    },
-    {
-      name: "--allow-none",
-      description: "Don't return error code if no test files are found",
-    },
-    {
-      name: "--filter",
-      description: "Run tests with this string or pattern in the test name",
-      args: {
-        name: "pattern",
-        description: "The pattern to match against",
-      },
-    },
-    {
-      name: "--shuffle",
-      description: "UNSTABLE: Shuffle the order in which tests are run",
-      requiresSeparator: true,
-      args: {
-        name: "number",
-        isOptional: true,
-      },
-    },
-    {
-      name: "--coverage",
-      description: "UNSTABLE: Collect coverage profile data into the directory",
-      requiresSeparator: true,
-      args: {
-        name: "directory",
-        description: "The directory to use for coverage data",
-        template: "folders",
-      },
-      exclusiveOn: ["--watch"],
-    },
-    {
-      name: ["-j", "--jobs"],
-      description:
-        "Set the number of parallel workers. With no value, the number of CPU cores. Defaults to 1 if omitted",
-      args: {
-        name: "number",
-        description:
-          "The number of parallel workers (defaults to number of CPU cores)",
-        isOptional: true,
-      },
-    },
-    watchOption({
-      files: false,
-      exclusiveOn: ["--no-run", "--coverage"],
-    }),
-    noClearScreenOption,
-  ],
-};
-
-const denoFmt: Fig.Subcommand = {
-  name: "fmt",
-  description: "Auto-format JavaScript, TypeScript, Markdown, and JSON files",
-  args: {
-    name: "files",
-    description: "Files to format",
-    isOptional: true,
-    isVariadic: true,
-    generators: filepaths({
-      matches: /\.(mjs|jsx?|tsx?|jsonc?|md)$/i,
-      editFileSuggestions: { priority: 75 },
-    }),
-    suggestions: [
-      {
-        name: "-",
-        description: "Read from standard input",
-        hidden: true,
-      },
-    ],
-  },
-  options: [
-    configOption,
-    {
-      name: "--check",
-      description: "Check if the source files are formatted",
-    },
-    {
-      name: "--ext",
-      description: "Set standard input (stdin) content type",
-      args: {
-        name: "extension",
-        description: "The extension to format input as",
-        suggestions: ["ts", "tsx", "js", "jsx", "md", "json", "jsonc"],
-      },
-    },
-    {
-      name: "--ignore",
-      description: "Ignore formatting particular source files",
-      requiresSeparator: true,
-      args: {
-        name: "Files to ignore",
-        template: "filepaths",
-      },
-    },
-    watchOption({ files: false }),
-    noClearScreenOption,
-    {
-      name: "--options-use-tabs",
-      description: "Use tabs instead of spaces",
-    },
-    {
-      name: "--options-line-width",
-      description: "Define the maximum line width",
-      args: {
-        name: "width",
-      },
-    },
-    {
-      name: "--options-indent-width",
-      description: "Set the number of spaces to use for indentation",
-      args: {
-        name: "width",
-      },
-    },
-    {
-      name: "--options-single-quote",
-      description: "Use single quotes",
-    },
-    {
-      name: "--options-prose-wrap",
-      description:
-        "Define how markdown prose should be wrapped (default: always)",
-      args: {
-        default: "always",
-        name: "wrap",
-        suggestions: [
-          {
-            name: "always",
-            icon: "fig://icon?type=string",
-            description: "Hard-wrap the entire file",
-          },
-          {
-            name: "never",
-            icon: "fig://icon?type=string",
-            description: "Don't hard-wrap text",
-          },
-          {
-            name: "preserve",
-            icon: "fig://icon?type=string",
-            description: "Hard-wrap text that's changed",
-          },
-        ],
-      },
-    },
-  ],
-};
-
-const denoLint: Fig.Subcommand = {
-  name: "lint",
-  description: "Lint JavaScript and TypeScript source code",
-  args: {
-    name: "files",
-    description: "Files to lint",
-    isOptional: true,
-    isVariadic: true,
-    generators: generateRunnableFiles,
-  },
-  options: [
-    configOption,
-    {
-      name: "--rules",
-      description: "List available rules",
-      exclusiveOn: ["--rules-tags", "--rules-include", "--rules-exclude"],
-    },
-    {
-      name: "--ignore",
-      description: "Ignore linting particular source files",
-      requiresSeparator: true,
-      args: {
-        name: "files",
-        template: "filepaths",
-        description: "The files to ignore",
-        isOptional: true,
-      },
-    },
-    {
-      name: "--json",
-      description: "Output lint result in JSON format",
-    },
-    {
-      name: "--rules-tags",
-      description: "Use a set of rules with a tag",
-      exclusiveOn: ["--rules"],
-      args: {
-        name: "rules",
-        generators: generateLintRules,
-      },
-    },
-    {
-      name: "--rules-include",
-      description: "Include lint rules",
-      exclusiveOn: ["--rules"],
-      args: {
-        name: "rules",
-        generators: generateLintRules,
-      },
-    },
-    {
-      name: "--rules-exclude",
-      description: "Exclude lint rules",
-      exclusiveOn: ["--rules"],
-      args: {
-        name: "rules",
-        generators: generateLintRules,
-      },
-    },
-    watchOption({ files: false }),
-    noClearScreenOption,
-  ],
-};
-
-const denoDoc: Fig.Subcommand = {
-  name: "doc",
-  description: "Show documentation for a module",
-  args: [
-    {
-      name: "scope",
-      description: "The scope to get documentation for",
-      // From the user's perspective, --builtin is a flag that means "show me
-      // documentation for built-in symbols", but it's actually more like a
-      // file that just happens to always be equivalent to Deno's types.
-      suggestions: [
-        {
-          name: "--builtin",
-          description: "Get documentation for built-in symbols",
-          icon: "fig://icon?type=option",
-        },
-      ],
-      generators: generateRunnableFiles,
-      isOptional: true,
-    },
-    {
-      name: "filter",
-      description: "The symbol to get documentation for (must exist in scope)",
-      isOptional: true,
-      // This generator helps you construct a filter by suggesting top level
-      // symbol from the provided scope, and more specific filter after "."
-      generators: generateDocs,
-    },
-  ],
-  options: [
-    importMapOption,
-    reloadOption,
-    {
-      name: "--json",
-      description: "Output documentation in JSON format",
-    },
-    {
-      name: "--private",
-      description: "Output private documentation",
-    },
-  ],
-};
-
-const denoInstall: Fig.Subcommand = {
-  name: "install",
-  description: "Install a script as an executable",
-  parserDirectives: {
-    optionsMustPrecedeArguments: true,
-  },
-  args: [
-    {
-      name: "source",
-      description: "A local or remote JavaScript or TypeScript file",
-      generators: generateRunnableFiles,
-    },
-    {
-      name: "args",
-      description: "Arguments that will be provided automatically when run",
-      isVariadic: true,
-      isOptional: true,
-    },
-  ],
-  options: [
-    ...runtimeOptions({ perms: true, inspector: true }),
-    {
-      name: ["-n", "--name"],
-      description: "Name of the executable",
-      args: {
-        name: "name",
-        description: "The name the executable will have",
-      },
-    },
-    {
-      name: ["-f", "--force"],
-      description: "Forcefully overwrite an existing installation",
-    },
-    {
-      name: "--root",
-      description: "The installation root",
-      args: {
-        name: "directory",
-        description: "The directory that the script will be installed to",
-        template: "folders",
-      },
-    },
-  ],
-};
-
-const denoUninstall: Fig.Subcommand = {
-  name: "uninstall",
-  description:
-    "Uninstalls an executable script in the installation root's bin directory",
-  args: {
-    name: "name",
-    description: "Delete an executable with this name",
-    generators: generateInstalledDenoScripts,
-  },
-  options: [
-    {
-      name: "--root",
-      description: "The installation root",
-      args: {
-        name: "directory",
-        description: "The directory that the script will be uninstalled from",
-        template: "folders",
-      },
-    },
-  ],
-};
-
-const denoLsp: Fig.Subcommand = {
-  name: "lsp",
-  description: "Start the language server",
-};
-
-const denoTypes: Fig.Subcommand = {
-  name: "types",
-  description: "Print Deno's runtime TypeScript declarations",
-};
-
-const denoUpgrade: Fig.Subcommand = {
-  name: "upgrade",
-  description: "Upgrade the deno executable",
-  options: [
-    {
-      name: "--version",
-      description: "The version to upgrade to",
-      args: {
-        name: "version",
-        generators: generateVersions,
-      },
-    },
-    {
-      name: "--output",
-      description: "Output path of the downloaded binary",
-      args: {
-        name: "path",
-        template: "filepaths",
-      },
-    },
-    {
-      name: "--dry-run",
-      description: "Perform all checks without replacing the old version",
-    },
-    {
-      name: "--canary",
-      description: "Upgrade to a canary build",
-    },
-    caFileOption,
-  ],
-};
-
-const denoEval: Fig.Subcommand = {
-  name: "eval",
-  insertValue: "eval '{cursor}'",
-  description: "Evaluate JavaScript from the command line",
-  options: [
-    ...runtimeOptions({ perms: false, inspector: true }),
-    {
-      name: "--ext",
-      description: "Set standard input (stdin) content type",
-      args: {
-        name: "extension",
-        description: "Interpret stdin as this type of file",
-        default: "ts",
-        suggestions: ["ts", "tsx", "js", "jsx"],
-      },
-    },
-    {
-      name: ["-p", "--print"],
-      description: "Print the result to stdout",
-    },
-  ],
-  args: {
-    name: "code",
-    isVariadic: true,
-  },
-};
-
-const denoCompletions: Fig.Subcommand = {
-  name: "completions",
-  description: "Generate shell completions",
-  args: {
-    name: "shell",
-    description: "Generate completions for this shell",
-    suggestions: [
-      { name: "zsh", icon: "fig://icon?type=string" },
-      { name: "bash", icon: "fig://icon?type=string" },
-      { name: "fish", icon: "fig://icon?type=string" },
-      { name: "powershell", icon: "fig://icon?type=string" },
-      { name: "fig", icon: "fig://icon?type=string" },
-    ],
-  },
-};
-
-const denoCoverage: Fig.Subcommand = {
-  name: "coverage",
-  description: "Print coverage reports from coverage profiles",
-  options: [
-    {
-      name: "--ignore",
-      description: "Ignore coverage files",
-      requiresSeparator: true,
-      args: {
-        name: "pattern",
-        description: "Ignore files matching this regex pattern",
-        template: "filepaths",
-      },
-    },
-    {
-      name: "--include",
-      description: "Include source files in the report",
-      isRepeatable: true,
-      requiresSeparator: true,
-      args: {
-        name: "pattern",
-        description: "Include files matching this regex pattern",
-        template: "filepaths",
-      },
-    },
-    {
-      name: "--exclude",
-      description: "Exclude source files from the report",
-      isRepeatable: true,
-      requiresSeparator: true,
-      args: {
-        name: "pattern",
-        description: "Exclude files matching this regex pattern",
-        template: "filepaths",
-      },
-    },
-    {
-      name: "--lcov",
-      description: "Output coverage in the lcov format",
-    },
-    {
-      name: "--output",
-      description: "Output file (defaults to stdout) for lcov",
-      dependsOn: ["--lcov"],
-      requiresSeparator: true,
-      args: {
-        name: "outfile",
-        template: "filepaths",
-        suggestCurrentToken: true,
-      },
-    },
-  ],
-  args: {
-    name: "coverage directory",
-    isVariadic: true,
-    template: "folders",
-  },
-};
-
-const denoInfo: Fig.Subcommand = {
-  name: "info",
-  description: "Show info about the cache or info related to a source file",
-  options: [
-    reloadOption,
-    caFileOption,
-    importMapOption,
-    {
-      name: "--location",
-      description: "Show files used for origin-bound APIs (like Web Storage)",
-      args: {
-        name: "URL",
-        description: "Show files used for this location",
-      },
-    },
-    {
-      name: "--json",
-      description: "UNSTABLE: Output information as JSON",
-    },
-  ],
-  args: {
-    name: "file",
-    description: "The source file to show information for",
-    isOptional: true,
-    generators: generateRunnableFiles,
-  },
-};
-
-const denoRepl: Fig.Subcommand = {
-  name: "repl",
-  description: "Open an interactive read-eval-print loop",
-  options: [
-    ...runtimeOptions({ perms: false, inspector: true }),
-    unsafelyIgnoreCertificateErrorsOption,
-    {
-      name: "--eval",
-      insertValue: "--eval '{cursor}'",
-      description: "Evaluate this code when the REPL starts",
-      args: {
-        name: "code",
-        description: "The code to evaluate",
-      },
-    },
-  ],
-};
-
-const denoCompile: Fig.Subcommand = {
-  name: "compile",
-  description: "UNSTABLE: Compile the script into a self-contained executable",
-  args: [
-    {
-      name: "script",
-      description: "The source to be compiled",
-      generators: generateRunnableFiles,
-    },
-    {
-      name: "arguments",
-      description: "Arguments to be provided to the script",
-      isOptional: true,
-      isVariadic: true,
-    },
-  ],
-  options: [
-    ...runtimeOptions({ perms: true, inspector: false }),
-    {
-      name: ["-o", "--output"],
-      description: "Location of the output binary (default: ./<inferred-name>)",
-      args: {
-        name: "destination",
-        // Using folders because users probably don't want to select
-        // the name of a pre-existing file
-        template: "folders",
-      },
-    },
-    {
-      name: "--target",
-      description: "The target OS architecture",
-      args: {
-        name: "arch",
-        suggestions: [
-          { name: "x86_64-unknown-linux-gnu", icon: "fig://icon?type=cpu" },
-          { name: "x86_64-pc-windows-msvc", icon: "fig://icon?type=cpu" },
-          { name: "x86_64-apple-darwin", icon: "fig://icon?type=cpu" },
-          { name: "aarch64-apple-darwin", icon: "fig://icon?type=cpu" },
-        ],
-      },
-    },
-  ],
-};
-
-const denoCache: Fig.Subcommand = {
-  name: "cache",
-  description: "Cache and compile remote dependencies, recursively",
-  args: {
-    name: "script",
-    description: "The script(s) to cache",
-    generators: generateRunnableFiles,
-    isVariadic: true,
-  },
-  options: compileOptions,
-};
-
-const denoBench: Fig.Subcommand = {
-  name: "bench",
-  description: "Run benchmarks using Deno's built-in bench tool",
-  args: {
-    name: "files",
-    isVariadic: true,
-    isOptional: true,
-    generators: filepaths({
-      matches: /[_\.]bench\.m?[jt]sx?/,
-      suggestFolders: "always",
-    }),
-  },
-  options: [
-    ...runtimeOptions({ perms: true, inspector: false }),
-    {
-      name: "--ignore",
-      description: "Ignore files",
-      requiresSeparator: true,
-      args: {
-        name: "files",
-        generators: {
-          getQueryTerm: ",",
-          template: "filepaths",
-        },
-      },
-    },
-    {
-      name: "--filter",
-      description: "Run benchmarks with this string or pattern in the name",
-      args: {
-        name: "filter",
-      },
-    },
-    watchOption({ files: false }),
-    noClearScreenOption,
-  ],
-};
-
-const denoTask: Fig.Subcommand = {
-  name: "task",
-  description: "Run a task defined in the configuration file",
-  args: [
-    {
-      name: "task",
-      generators: generateTasks,
-    },
-    {
-      name: "args",
-      description: "Arguments to pass to the task",
-      isOptional: true,
-      isVariadic: true,
-    },
-  ],
-  options: [configOption],
-};
-
-const denoBundle: Fig.Subcommand = {
-  name: "bundle",
-  description: "Bundle module and dependencies into a single file",
-  args: [
-    {
-      name: "source",
-      description: "The source file to bundle",
-      generators: generateRunnableFiles,
-    },
-    {
-      name: "output",
-      description: "The output file",
-      template: "folders",
-      isOptional: true,
-    },
-  ],
-  options: compileOptions,
-};
-
-const denoVendor: Fig.Subcommand = {
-  name: "vendor",
-  description: "Vendor remote modules into a local directory",
-  args: {
-    name: "specifiers",
-    isVariadic: true,
-    generators: generateRunnableFiles,
-  },
-  options: [
-    {
-      name: "--output",
-      description: "The directory to output the vendored modules to",
-      args: {
-        name: "destination",
-        template: "folders",
-        suggestCurrentToken: true,
-      },
-    },
-    {
-      name: ["-f", "--force"],
-      description:
-        "Forcefully overwrite existing files in the output directory",
-    },
-    configOption,
-    importMapOption,
-    lockOption,
-    reloadOption,
-    caFileOption,
-  ],
-};
-
-const subcommands: Fig.Subcommand[] = [
-  denoBench,
-  denoBundle,
-  denoCache,
-  denoCompile,
-  denoCompletions,
-  denoCoverage,
-  denoDoc,
-  denoEval,
-  denoFmt,
-  denoInfo,
-  denoInstall,
-  denoUninstall,
-  denoLint,
-  denoLsp,
-  denoRepl,
-  denoRun,
-  denoTask,
-  denoTest,
-  denoTypes,
-  denoUpgrade,
-  denoVendor,
-];
-
-const completionSpec: Fig.Spec = {
+const completion: Fig.Spec = {
   name: "deno",
   description: "A secure JavaScript and TypeScript runtime",
   subcommands: [
-    ...subcommands,
+    {
+      name: "bench",
+      description: "Run benchmarks",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--check",
+          description: "Type check modules",
+          exclusiveOn: ["--no-check"],
+          requiresSeparator: true,
+          args: {
+            name: "check",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-read",
+          description: "Allow file system read access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-read",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-write",
+          description: "Allow file system write access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-write",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-net",
+          description: "Allow network access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-net",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--unsafely-ignore-certificate-errors",
+          description: "DANGER: Disables verification of TLS certificates",
+          requiresSeparator: true,
+          args: {
+            name: "unsafely-ignore-certificate-errors",
+            description: "Scope ignoring certificate errors to these hosts",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-env",
+          description: "Allow environment access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-env",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-run",
+          description: "Allow running subprocesses",
+          requiresSeparator: true,
+          args: {
+            name: "allow-run",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-ffi",
+          description: "Allow loading dynamic libraries",
+          requiresSeparator: true,
+          args: {
+            name: "allow-ffi",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--location",
+          description: "Value of 'globalThis.location' used by some web APIs",
+          args: {
+            name: "location",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--v8-flags",
+          description: "Set V8 command line options",
+          requiresSeparator: true,
+          args: {
+            name: "v8-flags",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--seed",
+          description: "Set the random number generator seed",
+          args: {
+            name: "seed",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--ignore",
+          description: "Ignore files",
+          requiresSeparator: true,
+          args: {
+            name: "ignore",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--filter",
+          description:
+            "Run benchmarks with this string or pattern in the bench name",
+          args: {
+            name: "filter",
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: "--allow-hrtime",
+          description: "Allow high resolution time measurement",
+        },
+        {
+          name: ["-A", "--allow-all"],
+          description: "Allow all permissions",
+        },
+        {
+          name: "--prompt",
+          description:
+            "Deprecated: Fallback to prompt if required permission wasn't passed",
+        },
+        {
+          name: "--no-prompt",
+          description: "Always throw if required permission wasn't passed",
+        },
+        {
+          name: "--cached-only",
+          description: "Require that remote dependencies are already cached",
+        },
+        {
+          name: "--enable-testing-features-do-not-use",
+          description:
+            "INTERNAL: Enable internal features used during integration testing",
+        },
+        {
+          name: "--compat",
+          description: "UNSTABLE: Node compatibility mode",
+        },
+        {
+          name: "--watch",
+          description:
+            "UNSTABLE: Watch for file changes and restart automatically",
+        },
+        {
+          name: "--no-clear-screen",
+          description: "Do not clear terminal screen when under watch mode",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: [
+        {
+          name: "files",
+          isVariadic: true,
+          isOptional: true,
+        },
+        {
+          name: "script_arg",
+          isVariadic: true,
+          isOptional: true,
+          template: "filepaths",
+        },
+      ],
+    },
+    {
+      name: "bundle",
+      description: "Bundle module and dependencies into single file",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--check",
+          description: "Type check modules",
+          exclusiveOn: ["--no-check"],
+          requiresSeparator: true,
+          args: {
+            name: "check",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: "--watch",
+          description:
+            "UNSTABLE: Watch for file changes and restart automatically",
+        },
+        {
+          name: "--no-clear-screen",
+          description: "Do not clear terminal screen when under watch mode",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: [
+        {
+          name: "source_file",
+          template: "filepaths",
+        },
+        {
+          name: "out_file",
+          isOptional: true,
+          template: "filepaths",
+        },
+      ],
+    },
+    {
+      name: "cache",
+      description: "Cache the dependencies",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--check",
+          description: "Type check modules",
+          exclusiveOn: ["--no-check"],
+          requiresSeparator: true,
+          args: {
+            name: "check",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "file",
+        isVariadic: true,
+        template: "filepaths",
+      },
+    },
+    {
+      name: "check",
+      description: "Type-check the dependencies",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: "--remote",
+          description: "Type-check all modules, including remote",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "file",
+        isVariadic: true,
+        template: "filepaths",
+      },
+    },
+    {
+      name: "compile",
+      description:
+        "UNSTABLE: Compile the script into a self contained executable",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--check",
+          description: "Type check modules",
+          exclusiveOn: ["--no-check"],
+          requiresSeparator: true,
+          args: {
+            name: "check",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-read",
+          description: "Allow file system read access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-read",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-write",
+          description: "Allow file system write access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-write",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-net",
+          description: "Allow network access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-net",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--unsafely-ignore-certificate-errors",
+          description: "DANGER: Disables verification of TLS certificates",
+          requiresSeparator: true,
+          args: {
+            name: "unsafely-ignore-certificate-errors",
+            description: "Scope ignoring certificate errors to these hosts",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-env",
+          description: "Allow environment access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-env",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-run",
+          description: "Allow running subprocesses",
+          requiresSeparator: true,
+          args: {
+            name: "allow-run",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-ffi",
+          description: "Allow loading dynamic libraries",
+          requiresSeparator: true,
+          args: {
+            name: "allow-ffi",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--location",
+          description: "Value of 'globalThis.location' used by some web APIs",
+          args: {
+            name: "location",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--v8-flags",
+          description: "Set V8 command line options",
+          requiresSeparator: true,
+          args: {
+            name: "v8-flags",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--seed",
+          description: "Set the random number generator seed",
+          args: {
+            name: "seed",
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-o", "--output"],
+          description: "Output file (defaults to $PWD/<inferred-name>)",
+          args: {
+            name: "output",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--target",
+          description: "Target OS architecture",
+          args: {
+            name: "target",
+            isOptional: true,
+            suggestions: [
+              { name: "x86_64-unknown-linux-gnu", icon: "fig://icon?type=cpu" },
+              { name: "x86_64-pc-windows-msvc", icon: "fig://icon?type=cpu" },
+              { name: "x86_64-apple-darwin", icon: "fig://icon?type=cpu" },
+              { name: "aarch64-apple-darwin", icon: "fig://icon?type=cpu" },
+            ],
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: "--allow-hrtime",
+          description: "Allow high resolution time measurement",
+        },
+        {
+          name: ["-A", "--allow-all"],
+          description: "Allow all permissions",
+        },
+        {
+          name: "--prompt",
+          description:
+            "Deprecated: Fallback to prompt if required permission wasn't passed",
+        },
+        {
+          name: "--no-prompt",
+          description: "Always throw if required permission wasn't passed",
+        },
+        {
+          name: "--cached-only",
+          description: "Require that remote dependencies are already cached",
+        },
+        {
+          name: "--enable-testing-features-do-not-use",
+          description:
+            "INTERNAL: Enable internal features used during integration testing",
+        },
+        {
+          name: "--compat",
+          description: "UNSTABLE: Node compatibility mode",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "script_arg",
+        isVariadic: true,
+        template: "filepaths",
+      },
+    },
+    {
+      name: "completions",
+      description: "Generate shell completions",
+      options: [
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "shell",
+        suggestions: ["bash", "fish", "powershell", "zsh", "fig"],
+      },
+    },
+    {
+      name: "coverage",
+      description: "Print coverage reports",
+      options: [
+        {
+          name: "--ignore",
+          description: "Ignore coverage files",
+          requiresSeparator: true,
+          args: {
+            name: "ignore",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--include",
+          description: "Include source files in the report",
+          isRepeatable: true,
+          requiresSeparator: true,
+          args: {
+            name: "include",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--exclude",
+          description: "Exclude source files from the report",
+          isRepeatable: true,
+          requiresSeparator: true,
+          args: {
+            name: "exclude",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--output",
+          description: "Output file (defaults to stdout) for lcov",
+          requiresSeparator: true,
+          args: {
+            name: "output",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--lcov",
+          description: "Output coverage report in lcov format",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "files",
+        isVariadic: true,
+        template: "filepaths",
+      },
+    },
+    {
+      name: "doc",
+      description: "Show documentation for a module",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--json",
+          description: "Output documentation in JSON format",
+        },
+        {
+          name: "--private",
+          description: "Output private documentation",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: [
+        {
+          name: "source_file",
+          isOptional: true,
+          template: "filepaths",
+        },
+        {
+          name: "filter",
+          isOptional: true,
+          generators: generateDocs,
+        },
+      ],
+    },
+    {
+      name: "eval",
+      description: "Eval script",
+      insertValue: "eval '{cursor}'",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--check",
+          description: "Type check modules",
+          exclusiveOn: ["--no-check"],
+          requiresSeparator: true,
+          args: {
+            name: "check",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--inspect",
+          description:
+            "Activate inspector on host:port (default: 127.0.0.1:9229)",
+          requiresSeparator: true,
+          args: {
+            name: "inspect",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--inspect-brk",
+          description:
+            "Activate inspector on host:port and break at start of user script",
+          requiresSeparator: true,
+          args: {
+            name: "inspect-brk",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--location",
+          description: "Value of 'globalThis.location' used by some web APIs",
+          args: {
+            name: "location",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--v8-flags",
+          description: "Set V8 command line options",
+          requiresSeparator: true,
+          args: {
+            name: "v8-flags",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--seed",
+          description: "Set the random number generator seed",
+          args: {
+            name: "seed",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--ext",
+          description: "Set standard input (stdin) content type",
+          args: {
+            name: "ext",
+            isOptional: true,
+            suggestions: ["ts", "tsx", "js", "jsx"],
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: "--cached-only",
+          description: "Require that remote dependencies are already cached",
+        },
+        {
+          name: "--enable-testing-features-do-not-use",
+          description:
+            "INTERNAL: Enable internal features used during integration testing",
+        },
+        {
+          name: "--compat",
+          description: "UNSTABLE: Node compatibility mode",
+        },
+        {
+          name: ["-T", "--ts"],
+          description: "Treat eval input as TypeScript",
+        },
+        {
+          name: ["-p", "--print"],
+          description: "Print result to stdout",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "code_arg",
+        isVariadic: true,
+      },
+    },
+    {
+      name: "fmt",
+      description: "Format source files",
+      options: [
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--ext",
+          description: "Set standard input (stdin) content type",
+          args: {
+            name: "ext",
+            isOptional: true,
+            suggestions: ["ts", "tsx", "js", "jsx", "md", "json", "jsonc"],
+          },
+        },
+        {
+          name: "--ignore",
+          description: "Ignore formatting particular source files",
+          requiresSeparator: true,
+          args: {
+            name: "ignore",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--options-line-width",
+          description: "Define maximum line width. Defaults to 80",
+          args: {
+            name: "options-line-width",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--options-indent-width",
+          description: "Define indentation width. Defaults to 2",
+          args: {
+            name: "options-indent-width",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--options-prose-wrap",
+          description: "Define how prose should be wrapped. Defaults to always",
+          args: {
+            name: "options-prose-wrap",
+            isOptional: true,
+            suggestions: ["always", "never", "preserve"],
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--check",
+          description: "Check if the source files are formatted",
+        },
+        {
+          name: "--watch",
+          description:
+            "UNSTABLE: Watch for file changes and restart automatically",
+        },
+        {
+          name: "--no-clear-screen",
+          description: "Do not clear terminal screen when under watch mode",
+        },
+        {
+          name: "--options-use-tabs",
+          description:
+            "Use tabs instead of spaces for indentation. Defaults to false",
+        },
+        {
+          name: "--options-single-quote",
+          description: "Use single quotes. Defaults to false",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "files",
+        isVariadic: true,
+        isOptional: true,
+        template: "filepaths",
+      },
+    },
+    {
+      name: "info",
+      description: "Show info about cache or info related to source file",
+      options: [
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--location",
+          description:
+            "Show files used for origin bound APIs like the Web Storage API when running a script with '--location=<HREF>'",
+          args: {
+            name: "location",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          hidden: true,
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--json",
+          description: "UNSTABLE: Outputs the information in JSON format",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "file",
+        isOptional: true,
+        template: "filepaths",
+      },
+    },
+    {
+      name: "install",
+      description: "Install script as an executable",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--check",
+          description: "Type check modules",
+          exclusiveOn: ["--no-check"],
+          requiresSeparator: true,
+          args: {
+            name: "check",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-read",
+          description: "Allow file system read access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-read",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-write",
+          description: "Allow file system write access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-write",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-net",
+          description: "Allow network access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-net",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--unsafely-ignore-certificate-errors",
+          description: "DANGER: Disables verification of TLS certificates",
+          requiresSeparator: true,
+          args: {
+            name: "unsafely-ignore-certificate-errors",
+            description: "Scope ignoring certificate errors to these hosts",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-env",
+          description: "Allow environment access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-env",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-run",
+          description: "Allow running subprocesses",
+          requiresSeparator: true,
+          args: {
+            name: "allow-run",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-ffi",
+          description: "Allow loading dynamic libraries",
+          requiresSeparator: true,
+          args: {
+            name: "allow-ffi",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--inspect",
+          description:
+            "Activate inspector on host:port (default: 127.0.0.1:9229)",
+          requiresSeparator: true,
+          args: {
+            name: "inspect",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--inspect-brk",
+          description:
+            "Activate inspector on host:port and break at start of user script",
+          requiresSeparator: true,
+          args: {
+            name: "inspect-brk",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--location",
+          description: "Value of 'globalThis.location' used by some web APIs",
+          args: {
+            name: "location",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--v8-flags",
+          description: "Set V8 command line options",
+          requiresSeparator: true,
+          args: {
+            name: "v8-flags",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--seed",
+          description: "Set the random number generator seed",
+          args: {
+            name: "seed",
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-n", "--name"],
+          description: "Executable file name",
+          args: {
+            name: "name",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--root",
+          description: "Installation root",
+          args: {
+            name: "root",
+            isOptional: true,
+            template: "folders",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: "--allow-hrtime",
+          description: "Allow high resolution time measurement",
+        },
+        {
+          name: ["-A", "--allow-all"],
+          description: "Allow all permissions",
+        },
+        {
+          name: "--prompt",
+          description:
+            "Deprecated: Fallback to prompt if required permission wasn't passed",
+        },
+        {
+          name: "--no-prompt",
+          description: "Always throw if required permission wasn't passed",
+        },
+        {
+          name: "--cached-only",
+          description: "Require that remote dependencies are already cached",
+        },
+        {
+          name: "--enable-testing-features-do-not-use",
+          description:
+            "INTERNAL: Enable internal features used during integration testing",
+        },
+        {
+          name: "--compat",
+          description: "UNSTABLE: Node compatibility mode",
+        },
+        {
+          name: ["-f", "--force"],
+          description: "Forcefully overwrite existing installation",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "cmd",
+        isVariadic: true,
+        template: "filepaths",
+      },
+    },
+    {
+      name: "uninstall",
+      description: "Uninstall a script previously installed with deno install",
+      options: [
+        {
+          name: "--root",
+          description: "Installation root",
+          args: {
+            name: "root",
+            isOptional: true,
+            template: "folders",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "name",
+        generators: generateInstalledDenoScripts,
+      },
+    },
+    {
+      name: "lsp",
+      description: "Start the language server",
+      options: [
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+    },
+    {
+      name: "lint",
+      description: "Lint source files",
+      options: [
+        {
+          name: "--rules-tags",
+          description: "Use set of rules with a tag",
+          exclusiveOn: ["--rules"],
+          requiresSeparator: true,
+          args: {
+            name: "rules-tags",
+            isOptional: true,
+            generators: generateLintRules,
+          },
+        },
+        {
+          name: "--rules-include",
+          description: "Include lint rules",
+          exclusiveOn: ["--rules"],
+          requiresSeparator: true,
+          args: {
+            name: "rules-include",
+            isOptional: true,
+            generators: generateLintRules,
+          },
+        },
+        {
+          name: "--rules-exclude",
+          description: "Exclude lint rules",
+          exclusiveOn: ["--rules"],
+          requiresSeparator: true,
+          args: {
+            name: "rules-exclude",
+            isOptional: true,
+            generators: generateLintRules,
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--ignore",
+          description: "Ignore linting particular source files",
+          requiresSeparator: true,
+          args: {
+            name: "ignore",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--rules",
+          description: "List available rules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--json",
+          description: "Output lint result in JSON format",
+        },
+        {
+          name: "--watch",
+          description:
+            "UNSTABLE: Watch for file changes and restart automatically",
+        },
+        {
+          name: "--no-clear-screen",
+          description: "Do not clear terminal screen when under watch mode",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "files",
+        isVariadic: true,
+        isOptional: true,
+        template: "filepaths",
+      },
+    },
+    {
+      name: "repl",
+      description: "Read Eval Print Loop",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--check",
+          description: "Type check modules",
+          exclusiveOn: ["--no-check"],
+          requiresSeparator: true,
+          args: {
+            name: "check",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--inspect",
+          description:
+            "Activate inspector on host:port (default: 127.0.0.1:9229)",
+          requiresSeparator: true,
+          args: {
+            name: "inspect",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--inspect-brk",
+          description:
+            "Activate inspector on host:port and break at start of user script",
+          requiresSeparator: true,
+          args: {
+            name: "inspect-brk",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--location",
+          description: "Value of 'globalThis.location' used by some web APIs",
+          args: {
+            name: "location",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--v8-flags",
+          description: "Set V8 command line options",
+          requiresSeparator: true,
+          args: {
+            name: "v8-flags",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--seed",
+          description: "Set the random number generator seed",
+          args: {
+            name: "seed",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--eval-file",
+          description:
+            "Evaluates the provided file(s) as scripts when the REPL starts. Accepts file paths and URLs",
+          requiresSeparator: true,
+          args: {
+            name: "eval-file",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--eval",
+          description: "Evaluates the provided code when the REPL starts",
+          args: {
+            name: "eval",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--unsafely-ignore-certificate-errors",
+          description: "DANGER: Disables verification of TLS certificates",
+          requiresSeparator: true,
+          args: {
+            name: "unsafely-ignore-certificate-errors",
+            description: "Scope ignoring certificate errors to these hosts",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: "--cached-only",
+          description: "Require that remote dependencies are already cached",
+        },
+        {
+          name: "--enable-testing-features-do-not-use",
+          description:
+            "INTERNAL: Enable internal features used during integration testing",
+        },
+        {
+          name: "--compat",
+          description: "UNSTABLE: Node compatibility mode",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+    },
+    {
+      name: "run",
+      description: "Run a JavaScript or TypeScript program",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--check",
+          description: "Type check modules",
+          exclusiveOn: ["--no-check"],
+          requiresSeparator: true,
+          args: {
+            name: "check",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-read",
+          description: "Allow file system read access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-read",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-write",
+          description: "Allow file system write access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-write",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-net",
+          description: "Allow network access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-net",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--unsafely-ignore-certificate-errors",
+          description: "DANGER: Disables verification of TLS certificates",
+          requiresSeparator: true,
+          args: {
+            name: "unsafely-ignore-certificate-errors",
+            description: "Scope ignoring certificate errors to these hosts",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-env",
+          description: "Allow environment access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-env",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-run",
+          description: "Allow running subprocesses",
+          requiresSeparator: true,
+          args: {
+            name: "allow-run",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-ffi",
+          description: "Allow loading dynamic libraries",
+          requiresSeparator: true,
+          args: {
+            name: "allow-ffi",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--inspect",
+          description:
+            "Activate inspector on host:port (default: 127.0.0.1:9229)",
+          requiresSeparator: true,
+          args: {
+            name: "inspect",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--inspect-brk",
+          description:
+            "Activate inspector on host:port and break at start of user script",
+          requiresSeparator: true,
+          args: {
+            name: "inspect-brk",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--location",
+          description: "Value of 'globalThis.location' used by some web APIs",
+          args: {
+            name: "location",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--v8-flags",
+          description: "Set V8 command line options",
+          requiresSeparator: true,
+          args: {
+            name: "v8-flags",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--seed",
+          description: "Set the random number generator seed",
+          args: {
+            name: "seed",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--watch",
+          description:
+            "UNSTABLE: Watch for file changes and restart automatically",
+          exclusiveOn: ["--inspect", "--inspect-brk"],
+          requiresSeparator: true,
+          args: {
+            name: "watch",
+            isVariadic: true,
+            isOptional: true,
+            generators: {
+              template: "filepaths",
+              getQueryTerm: ",",
+            },
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: "--allow-hrtime",
+          description: "Allow high resolution time measurement",
+        },
+        {
+          name: ["-A", "--allow-all"],
+          description: "Allow all permissions",
+        },
+        {
+          name: "--prompt",
+          description:
+            "Deprecated: Fallback to prompt if required permission wasn't passed",
+        },
+        {
+          name: "--no-prompt",
+          description: "Always throw if required permission wasn't passed",
+        },
+        {
+          name: "--cached-only",
+          description: "Require that remote dependencies are already cached",
+        },
+        {
+          name: "--enable-testing-features-do-not-use",
+          description:
+            "INTERNAL: Enable internal features used during integration testing",
+        },
+        {
+          name: "--compat",
+          description: "UNSTABLE: Node compatibility mode",
+        },
+        {
+          name: "--no-clear-screen",
+          description: "Do not clear terminal screen when under watch mode",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "script_arg",
+        isVariadic: true,
+        template: "filepaths",
+      },
+    },
+    {
+      name: "task",
+      description: "Run a task defined in the configuration file",
+      options: [
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "task_name_and_args",
+        isVariadic: true,
+        isOptional: true,
+        generators: generateTasks,
+      },
+    },
+    {
+      name: "test",
+      description: "Run tests",
+      options: [
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--no-check",
+          description: "Skip type checking modules",
+          requiresSeparator: true,
+          args: {
+            name: "no-check",
+            isVariadic: true,
+            isOptional: true,
+            suggestions: [
+              {
+                name: "remote",
+                description: "Don't check remote modules",
+              },
+            ],
+          },
+        },
+        {
+          name: "--check",
+          description: "Type check modules",
+          exclusiveOn: ["--no-check"],
+          requiresSeparator: true,
+          args: {
+            name: "check",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-read",
+          description: "Allow file system read access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-read",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-write",
+          description: "Allow file system write access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-write",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--allow-net",
+          description: "Allow network access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-net",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--unsafely-ignore-certificate-errors",
+          description: "DANGER: Disables verification of TLS certificates",
+          requiresSeparator: true,
+          args: {
+            name: "unsafely-ignore-certificate-errors",
+            description: "Scope ignoring certificate errors to these hosts",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-env",
+          description: "Allow environment access",
+          requiresSeparator: true,
+          args: {
+            name: "allow-env",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-run",
+          description: "Allow running subprocesses",
+          requiresSeparator: true,
+          args: {
+            name: "allow-run",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--allow-ffi",
+          description: "Allow loading dynamic libraries",
+          requiresSeparator: true,
+          args: {
+            name: "allow-ffi",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--inspect",
+          description:
+            "Activate inspector on host:port (default: 127.0.0.1:9229)",
+          requiresSeparator: true,
+          args: {
+            name: "inspect",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--inspect-brk",
+          description:
+            "Activate inspector on host:port and break at start of user script",
+          requiresSeparator: true,
+          args: {
+            name: "inspect-brk",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--location",
+          description: "Value of 'globalThis.location' used by some web APIs",
+          args: {
+            name: "location",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--v8-flags",
+          description: "Set V8 command line options",
+          requiresSeparator: true,
+          args: {
+            name: "v8-flags",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--seed",
+          description: "Set the random number generator seed",
+          args: {
+            name: "seed",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--ignore",
+          description: "Ignore files",
+          requiresSeparator: true,
+          args: {
+            name: "ignore",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--fail-fast",
+          description:
+            "Stop after N errors. Defaults to stopping after first failure",
+          requiresSeparator: true,
+          args: {
+            name: "fail-fast",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--filter",
+          description: "Run tests with this string or pattern in the test name",
+          args: {
+            name: "filter",
+            isOptional: true,
+          },
+        },
+        {
+          name: "--shuffle",
+          description:
+            "(UNSTABLE): Shuffle the order in which the tests are run",
+          requiresSeparator: true,
+          args: {
+            name: "shuffle",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--coverage",
+          description: "UNSTABLE: Collect coverage profile data into DIR",
+          exclusiveOn: ["--inspect", "--inspect-brk"],
+          requiresSeparator: true,
+          args: {
+            name: "coverage",
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-j", "--jobs"],
+          description:
+            "Number of parallel workers, defaults to # of CPUs when no value is provided. Defaults to 1 when the option is not present",
+          args: {
+            name: "jobs",
+            isVariadic: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--no-remote",
+          description: "Do not resolve remote modules",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: "--lock-write",
+          description: "Write lock file (use with --lock)",
+        },
+        {
+          name: "--allow-hrtime",
+          description: "Allow high resolution time measurement",
+        },
+        {
+          name: ["-A", "--allow-all"],
+          description: "Allow all permissions",
+        },
+        {
+          name: "--prompt",
+          description:
+            "Deprecated: Fallback to prompt if required permission wasn't passed",
+        },
+        {
+          name: "--no-prompt",
+          description: "Always throw if required permission wasn't passed",
+        },
+        {
+          name: "--cached-only",
+          description: "Require that remote dependencies are already cached",
+        },
+        {
+          name: "--enable-testing-features-do-not-use",
+          description:
+            "INTERNAL: Enable internal features used during integration testing",
+        },
+        {
+          name: "--compat",
+          description: "UNSTABLE: Node compatibility mode",
+        },
+        {
+          name: "--no-run",
+          description: "Cache test modules, but don't run tests",
+        },
+        {
+          name: "--trace-ops",
+          description:
+            "Enable tracing of async ops. Useful when debugging leaking ops in test, but impacts test execution time",
+        },
+        {
+          name: "--doc",
+          description: "UNSTABLE: type check code blocks",
+        },
+        {
+          name: "--allow-none",
+          description: "Don't return error code if no test files are found",
+        },
+        {
+          name: "--watch",
+          description:
+            "UNSTABLE: Watch for file changes and restart automatically",
+          exclusiveOn: ["--no-run", "--coverage"],
+        },
+        {
+          name: "--no-clear-screen",
+          description: "Do not clear terminal screen when under watch mode",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: [
+        {
+          name: "files",
+          isVariadic: true,
+          isOptional: true,
+          template: "filepaths",
+        },
+        {
+          name: "script_arg",
+          isVariadic: true,
+          isOptional: true,
+          template: "filepaths",
+        },
+      ],
+    },
+    {
+      name: "types",
+      description: "Print runtime TypeScript declarations",
+      options: [
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+    },
+    {
+      name: "upgrade",
+      description: "Upgrade deno executable to given version",
+      options: [
+        {
+          name: "--version",
+          description: "The version to upgrade to",
+          args: {
+            name: "version",
+            isOptional: true,
+            generators: generateVersions,
+          },
+        },
+        {
+          name: "--output",
+          description: "The path to output the updated version to",
+          args: {
+            name: "output",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--dry-run",
+          description: "Perform all checks without replacing old exe",
+        },
+        {
+          name: ["-f", "--force"],
+          description: "Replace current exe even if not out-of-date",
+        },
+        {
+          name: "--canary",
+          description: "Upgrade to canary builds",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+    },
+    {
+      name: "vendor",
+      description: "Vendor remote modules into a local directory",
+      options: [
+        {
+          name: "--output",
+          description: "The directory to output the vendored modules to",
+          args: {
+            name: "output",
+            isOptional: true,
+            template: "folders",
+          },
+        },
+        {
+          name: ["-c", "--config"],
+          description: "Specify the configuration file",
+          exclusiveOn: ["--no-config"],
+          args: {
+            name: "config",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--import-map",
+          description: "Load import map file",
+          args: {
+            name: "import-map",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--lock",
+          description: "Check the specified lock file",
+          args: {
+            name: "lock",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-r", "--reload"],
+          description: "Reload source code cache (recompile TypeScript)",
+          requiresSeparator: true,
+          args: {
+            name: "reload",
+            isVariadic: true,
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--cert",
+          description: "Load certificate authority from PEM encoded file",
+          args: {
+            name: "cert",
+            isOptional: true,
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: ["-f", "--force"],
+          description:
+            "Forcefully overwrite conflicting files in existing output directory",
+        },
+        {
+          name: "--no-config",
+          description: "Disable automatic loading of the configuration file",
+          exclusiveOn: ["-c", "--config"],
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
+      args: {
+        name: "specifiers",
+        isVariadic: true,
+      },
+    },
     {
       name: "help",
-      description: "Print help information for the CLI or a subcommand",
+      description: "Print this message or the help of the given subcommand(s)",
+      options: [
+        {
+          name: ["-L", "--log-level"],
+          description: "Set log level",
+          hidden: true,
+          args: {
+            name: "log-level",
+            isOptional: true,
+            suggestions: ["debug", "info"],
+          },
+        },
+        {
+          name: "--unstable",
+          description: "Enable unstable features and APIs",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Suppress diagnostic output",
+        },
+      ],
       args: {
         name: "subcommand",
-        description: "The subcommand to get help with",
         isOptional: true,
-        template: "help",
       },
     },
   ],
   options: [
     {
-      name: ["-h", "--help"],
-      description: "Prints help information",
-      isPersistent: true,
-      priority: 40,
-    },
-    {
       name: ["-L", "--log-level"],
       description: "Set log level",
-      isPersistent: true,
-      priority: 40,
+      hidden: true,
       args: {
-        name: "level",
-        suggestions: ["info", "debug"],
+        name: "log-level",
+        isOptional: true,
+        suggestions: ["debug", "info"],
       },
     },
     {
-      name: ["-q", "--quiet"],
-      description:
-        "Suppress diagnostic output (restrict stderr messages to errors)",
-      isPersistent: true,
+      name: ["-h", "--help"],
+      description: "Print help information",
+    },
+    {
+      name: ["-V", "--version"],
+      description: "Print version information",
     },
     {
       name: "--unstable",
       description: "Enable unstable features and APIs",
-      isPersistent: true,
     },
     {
-      name: "--version",
-      description: "Prints version information, including TypeScript and V8",
-      exclusiveOn: ["-V"],
-    },
-    {
-      name: "-V",
-      description: "Prints Deno's version",
-      exclusiveOn: ["--version"],
-      priority: 25,
+      name: ["-q", "--quiet"],
+      description: "Suppress diagnostic output",
     },
   ],
 };
 
-export default completionSpec;
+export default completion;

--- a/src/deno/generators.ts
+++ b/src/deno/generators.ts
@@ -334,7 +334,7 @@ export const generateTasks: Fig.Generator = {
     if (config === null) {
       return [];
     }
-    return Object.entries(config.tasks).map(([name, command]) => {
+    return Object.entries(config.tasks || {}).map(([name, command]) => {
       const fig = config.fig?.[name] || {};
       return {
         name,


### PR DESCRIPTION
This uses the completions generated by `deno completions fig`, which should make it easier to switch to automatic PRs in the future if we go down that route with it. Even if not, this _massively_ simplifies the amount of work it'll be to update the deno spec.

Because it's generated by the CLI itself it's missing some quality of life stuff that I've manually added to it over the last 8 months, when it's added back in I'll mark the PR as ready.
