### PR TITLE
Update Remotion completions for 3.0

### DIFF
--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -124,6 +124,7 @@ const renderOptions: Fig.Option[] = [
         {
           type: "arg",
           displayName: "[json string]",
+          insertValue: "'{cursor}'",
         },
       ],
     },
@@ -669,6 +670,7 @@ const completionSpec: Fig.Spec = {
               {
                 type: "arg",
                 displayName: "[json string]",
+                insertValue: "'{cursor}'",
               },
             ],
           },

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -489,7 +489,10 @@ const completionSpec: Fig.Spec = {
                     "Type of CPU architecture to use for the Lambda function",
                   args: {
                     name: "architecture",
-                    suggestions: [{ name: "x86_64" }, { name: "arm64" }],
+                    suggestions: [
+                      { name: "x86_64", icon: "fig://icon?type=cpu" },
+                      { name: "arm64", icon: "fig://icon?type=cpu" },
+                    ],
                   },
                 },
                 {

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -1,9 +1,227 @@
+const globalLambdaOptions: Fig.Option[] = [
+  {
+    name: "--quiet",
+    description: "Print less output",
+  },
+  {
+    name: "-q",
+    hidden: true,
+    description: "Print less output",
+  },
+  {
+    name: "--yes",
+    description: "Skip confirmation",
+  },
+  {
+    name: "--force",
+    hidden: true,
+    isDangerous: true,
+    description: "Skip confirmation",
+  },
+  {
+    name: "-y",
+    isDangerous: true,
+    hidden: true,
+    description: "Skip confirmation",
+  },
+  {
+    name: "-f",
+    isDangerous: true,
+    hidden: true,
+    description: "Skip confirmation",
+  },
+  {
+    name: "--region",
+    description: "The AWS region specifier",
+    args: {
+      suggestions: [
+        {
+          name: "us-east-1",
+          description: "North Virginia",
+        },
+        {
+          name: "us-east-2",
+          description: "Ohio",
+        },
+        {
+          name: "eu-central-1",
+          description: "Frankfurt",
+        },
+        {
+          name: "eu-west-1",
+          description: "Ireland",
+        },
+        {
+          name: "eu-west-2",
+          description: "London",
+        },
+        {
+          name: "us-west-2",
+          description: "Oregon",
+        },
+        {
+          name: "ap-south-1",
+          description: "Mumbai",
+        },
+        {
+          name: "ap-southeast-1",
+          description: "Singapore",
+        },
+        {
+          name: "ap-southeast-2",
+          description: "Sydney",
+        },
+        {
+          name: "ap-northeast-1",
+          description: "Tokyo",
+        },
+      ],
+    },
+  },
+];
+
 const completionSpec: Fig.Spec = {
   name: "remotion",
+
   description: "Create videos programmatically in React",
   subcommands: [
     {
+      name: "lambda",
+
+      description: "Access functionality of @remotion/lambda",
+      subcommands: [
+        {
+          name: "functions",
+
+          description: "Manage functions on AWS Lambda",
+          subcommands: [
+            {
+              name: "ls",
+              description: "List deployed functions",
+              options: globalLambdaOptions,
+            },
+            {
+              name: "deploy",
+              description:
+                "Deploy a function if one with the same parameters doesn't exist",
+              options: [
+                {
+                  name: "--memory",
+                  description: "Amount of memory in MB to allocate",
+                  insertValue: "--memory=",
+                  args: {
+                    name: "sizeInMegabytes",
+                  },
+                },
+                {
+                  name: "--disk",
+                  description: "Amount of disk space in MB to allocate",
+                  insertValue: "--disk=",
+                  args: {
+                    name: "diskInMegabytes",
+                  },
+                },
+                {
+                  name: "--architecture",
+                  description:
+                    "Type of CPU architecture to use for the Lambda function",
+                  insertValue: "--architecture=",
+                  args: {
+                    name: "architecture",
+                    suggestions: [{ name: "x86_64" }, { name: "arm64" }],
+                  },
+                },
+                {
+                  name: "--disable-cloudwatch",
+                  description: "Disable CloudWatch logging",
+
+                  exclusiveOn: ["--retention-period"],
+                },
+                {
+                  name: "--retention-period",
+                  description: "CloudWatch log retention period in days",
+                  exclusiveOn: ["--disable-cloudwatch"],
+                  args: {
+                    name: "retentionPeriodInDays",
+                  },
+                },
+                ...globalLambdaOptions,
+              ],
+            },
+            {
+              name: "rmall",
+              description: "Remove all functions in a region",
+              isDangerous: true,
+              options: globalLambdaOptions,
+            },
+            {
+              name: "rm",
+
+              description: "Remove a function",
+              args: {
+                name: "function-name",
+                description: "ID of your function",
+                suggestCurrentToken: true,
+              },
+              options: globalLambdaOptions,
+            },
+          ],
+          options: globalLambdaOptions,
+        },
+        {
+          name: "sites",
+
+          options: globalLambdaOptions,
+          subcommands: [
+            {
+              name: "ls",
+              description: "List sites",
+              options: globalLambdaOptions,
+            },
+            {
+              name: "rmall",
+              description: "Remove all sites in a region",
+              isDangerous: true,
+              options: globalLambdaOptions,
+            },
+            {
+              name: "rm",
+
+              description: "Remove a site",
+              args: {
+                name: "site-name",
+                description: "ID of your site",
+                suggestCurrentToken: true,
+              },
+              options: globalLambdaOptions,
+            },
+            {
+              name: "create",
+              description: "Create or update a site",
+
+              options: [
+                ...globalLambdaOptions,
+                {
+                  name: "--site-name",
+                  insertValue: "--site-name=",
+                  args: {
+                    name: "How the folder in S3 should be named.",
+                  },
+                },
+              ],
+              args: {
+                name: "entry",
+                template: ["filepaths"],
+              },
+            },
+          ],
+        },
+      ],
+      options: [...globalLambdaOptions],
+    },
+    {
       name: "render",
+
       priority: 60,
       description:
         "Render a video based on the entry point, the composition ID and save it to the output location",
@@ -15,6 +233,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "comp-id",
           description: "The composition ID",
+
           suggestions: [
             {
               type: "arg",
@@ -24,6 +243,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "output",
+
           template: ["filepaths"],
           suggestions: ["out.mp4"],
         },

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -1,3 +1,118 @@
+const renderOptions: Fig.Option[] = [
+  {
+    name: "--props",
+    insertValue: "--props=",
+    description: "Pass input props as filename or as JSON",
+    args: {
+      template: ["filepaths"],
+      suggestions: [
+        {
+          type: "arg",
+          displayName: "[json string]",
+        },
+      ],
+    },
+  },
+  {
+    name: "--quality",
+    insertValue: "--quality=",
+    description: "Quality for rendered frames, JPEG only, 0-100",
+    args: {
+      default: "80",
+      suggestions: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map((e) => ({
+        name: e.toString(),
+      })),
+    },
+  },
+  {
+    name: "--codec",
+    insertValue: "--codec=",
+    description: "Video of audio codec",
+    args: {
+      default: "h264",
+      suggestions: [
+        { name: "h264" },
+        { name: "h265" },
+        { name: "png" },
+        { name: "vp8" },
+        { name: "vp9" },
+        { name: "mp3" },
+        { name: "aac" },
+        { name: "wav" },
+        { name: "prores" },
+        { name: "h264-mkv" },
+      ],
+    },
+  },
+  {
+    name: "--crf",
+    insertValue: "--crf=",
+    description: "FFMPEG CRF value, controls quality, see docs for info",
+  },
+  {
+    name: "--frames",
+    insertValue: "--frames=",
+
+    description: "Render a portion or a still of a video, 0-9, 50",
+    args: {
+      name: "frames",
+    },
+  },
+  {
+    name: "--log",
+    insertValue: "--log=",
+    description: 'Log level, "error", "warning", "verbose", "info" (default)',
+    args: {
+      default: "info",
+      suggestions: [
+        { name: "error" },
+        { name: "warning" },
+        { name: "verbose" },
+        { name: "info" },
+      ],
+    },
+  },
+  {
+    name: "prores-profile",
+    insertValue: "--prores-profile=",
+    description: "ProRes profile, need --codec=prores to be set",
+    args: {
+      suggestions: ["4444-xq", "4444", "hq", "standard", "light", "proxy"],
+    },
+  },
+  {
+    name: "--image-format",
+    insertValue: "--image-format=",
+    description: 'Format to render the frames in, "jpeg" or "png"',
+    args: {
+      suggestions: [
+        {
+          name: "jpeg",
+        },
+        {
+          name: "png",
+        },
+      ],
+    },
+  },
+  {
+    name: "--pixel-format",
+    insertValue: "--pixel-format=",
+    description: "Custom pixel format, see docs for available values",
+    args: {
+      suggestions: [
+        { name: "yuv420p" },
+        { name: "yuv422p" },
+        { name: "yuv444p" },
+        { name: "yuv420p10le" },
+        { name: "yuv422p10le" },
+        { name: "yuv444p10le" },
+        { name: "yuva420p" },
+      ],
+    },
+  },
+];
+
 const globalLambdaOptions: Fig.Option[] = [
   {
     name: "--quiet",
@@ -87,12 +202,61 @@ const completionSpec: Fig.Spec = {
   subcommands: [
     {
       name: "lambda",
-
       description: "Access functionality of @remotion/lambda",
       subcommands: [
         {
-          name: "functions",
+          name: "render",
+          description: "Render media on Lambda",
 
+          args: [
+            {
+              name: "serve-url",
+              description: "URL or name of the site",
+            },
+            {
+              name: "composition-id",
+              description: "Name of the composition",
+            },
+            {
+              name: "out-name",
+              description:
+                "Where the output should be downloaded. No download it omitted",
+              isOptional: true,
+            },
+          ],
+          options: [
+            {
+              name: "--max-retries",
+              insertValue: "--max-retries=",
+              description:
+                "How many times a chunk can be retried before the render times out",
+              args: {
+                name: "numberOfRetries",
+              },
+            },
+            {
+              name: "--privacy",
+              insertValue: "--privacy=",
+              args: {
+                name: "privacy",
+                default: "public",
+                suggestions: ["public", "private"],
+              },
+            },
+            {
+              name: "--frames-per-lambda",
+              insertValue: "--frames-per-lambda=",
+              description: "How many frames should be rendered per chunk",
+              args: {
+                name: "framesPerLambda",
+              },
+            },
+            ...renderOptions,
+            ...globalLambdaOptions,
+          ],
+        },
+        {
+          name: "functions",
           description: "Manage functions on AWS Lambda",
           subcommands: [
             {
@@ -156,7 +320,6 @@ const completionSpec: Fig.Spec = {
             },
             {
               name: "rm",
-
               description: "Remove a function",
               args: {
                 name: "function-name",
@@ -250,50 +413,8 @@ const completionSpec: Fig.Spec = {
       ],
       options: [
         {
-          name: "--props",
-          description: "Pass input props as filename or as JSON",
-          args: {
-            template: ["filepaths"],
-            suggestions: [
-              {
-                type: "arg",
-                displayName: "[json string]",
-              },
-            ],
-          },
-        },
-        {
           name: "--concurrency",
           description: "How many frames to render in parallel",
-        },
-        {
-          name: "--image-format",
-          description: 'Format to render the frames in, "jpeg" or "png"',
-          args: {
-            suggestions: [
-              {
-                name: "jpeg",
-              },
-              {
-                name: "png",
-              },
-            ],
-          },
-        },
-        {
-          name: "--pixel-format",
-          description: "Custom pixel format, see docs for available values",
-          args: {
-            suggestions: [
-              { name: "yuv420p" },
-              { name: "yuv422p" },
-              { name: "yuv444p" },
-              { name: "yuv420p10le" },
-              { name: "yuv422p10le" },
-              { name: "yuv444p10le" },
-              { name: "yuva420p" },
-            ],
-          },
         },
         {
           name: "--config",
@@ -302,18 +423,7 @@ const completionSpec: Fig.Spec = {
             template: "filepaths",
           },
         },
-        {
-          name: "--quality",
-          description: "Quality for rendered frames, JPEG only, 0-100",
-          args: {
-            default: "80",
-            suggestions: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map(
-              (e) => ({
-                name: e.toString(),
-              })
-            ),
-          },
-        },
+        ...renderOptions,
         {
           name: "--overwrite",
           description: "Overwrite if file exists, default true",
@@ -323,29 +433,6 @@ const completionSpec: Fig.Spec = {
           description: "Output as an image sequence",
         },
         {
-          name: "--codec",
-          description: "Video of audio codec",
-          args: {
-            default: "h264",
-            suggestions: [
-              { name: "h264" },
-              { name: "h265" },
-              { name: "png" },
-              { name: "vp8" },
-              { name: "vp9" },
-              { name: "mp3" },
-              { name: "aac" },
-              { name: "wav" },
-              { name: "prores" },
-              { name: "h264-mkv" },
-            ],
-          },
-        },
-        {
-          name: "--crf",
-          description: "FFMPEG CRF value, controls quality, see docs for info",
-        },
-        {
           name: "--browser-executable",
           description: "Custom path for browser executable",
           args: {
@@ -353,29 +440,8 @@ const completionSpec: Fig.Spec = {
           },
         },
         {
-          name: "--frames",
-          description: "Render a portion or a still of a video, 0-9, 50",
-          args: {
-            name: "frames",
-          },
-        },
-        {
           name: "--bundle-cache",
           description: "Cache webpack bundle, boolean, default true",
-        },
-        {
-          name: "--log",
-          description:
-            'Log level, "error", "warning", "verbose", "info" (default)',
-          args: {
-            default: "info",
-            suggestions: [
-              { name: "error" },
-              { name: "warning" },
-              { name: "verbose" },
-              { name: "info" },
-            ],
-          },
         },
         {
           name: "--port",

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -52,7 +52,6 @@ const localRenderAndStillOptions: Fig.Option[] = [
 const lambdaRenderAndStillOptions: Fig.Option[] = [
   {
     name: "--max-retries",
-    insertValue: "--max-retries=",
     description:
       "How many times a chunk can be retried before the render times out",
     args: {
@@ -61,7 +60,6 @@ const lambdaRenderAndStillOptions: Fig.Option[] = [
   },
   {
     name: "--privacy",
-    insertValue: "--privacy=",
     args: {
       name: "privacy",
       default: "public",
@@ -70,7 +68,6 @@ const lambdaRenderAndStillOptions: Fig.Option[] = [
   },
   {
     name: "--frames-per-lambda",
-    insertValue: "--frames-per-lambda=",
     description: "How many frames should be rendered per chunk",
     args: {
       name: "framesPerLambda",
@@ -100,7 +97,6 @@ const stillOptions: Fig.Option[] = [
 const renderOptions: Fig.Option[] = [
   {
     name: "--gl",
-    insertValue: "--gl=",
     description: "Which OpenGL renderer to use",
     args: {
       suggestions: ["angle", "egl", "swiftshader", "swangle"],
@@ -108,7 +104,6 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--timeout",
-    insertValue: "--timeout=",
     description:
       "The time in milisecond that a delayRender() may take before it times out",
   },
@@ -122,7 +117,6 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--props",
-    insertValue: "--props=",
     description: "Pass input props as filename or as JSON",
     args: {
       template: ["filepaths"],
@@ -136,7 +130,6 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--quality",
-    insertValue: "--quality=",
     description: "Quality for rendered frames, JPEG only, 0-100",
     args: {
       default: "80",
@@ -147,7 +140,6 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--scale",
-    insertValue: "--scale=",
     description: "Upscale or downscale or the dimensions of the video",
     args: {
       default: "1",
@@ -158,7 +150,6 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--codec",
-    insertValue: "--codec=",
     description: "Video of audio codec",
     args: {
       default: "h264",
@@ -178,13 +169,10 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--crf",
-    insertValue: "--crf=",
     description: "FFMPEG CRF value, controls quality, see docs for info",
   },
   {
     name: "--frames",
-    insertValue: "--frames=",
-
     description: "Render a portion or a still of a video, 0-9, 50",
     args: {
       name: "frames",
@@ -192,7 +180,6 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--log",
-    insertValue: "--log=",
     description: 'Log level, "error", "warning", "verbose", "info" (default)',
     args: {
       default: "info",
@@ -206,7 +193,6 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--prores-profile",
-    insertValue: "--prores-profile=",
     description: "ProRes profile, need --codec=prores to be set",
     args: {
       suggestions: ["4444-xq", "4444", "hq", "standard", "light", "proxy"],
@@ -214,7 +200,6 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--image-format",
-    insertValue: "--image-format=",
     description: 'Format to render the frames in, "jpeg" or "png"',
     args: {
       suggestions: [
@@ -229,7 +214,6 @@ const renderOptions: Fig.Option[] = [
   },
   {
     name: "--pixel-format",
-    insertValue: "--pixel-format=",
     description: "Custom pixel format, see docs for available values",
     args: {
       suggestions: [
@@ -488,7 +472,6 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--memory",
                   description: "Amount of memory in MB to allocate",
-                  insertValue: "--memory=",
                   args: {
                     name: "sizeInMegabytes",
                   },
@@ -496,7 +479,6 @@ const completionSpec: Fig.Spec = {
                 {
                   name: "--disk",
                   description: "Amount of disk space in MB to allocate",
-                  insertValue: "--disk=",
                   args: {
                     name: "diskInMegabytes",
                   },
@@ -505,7 +487,6 @@ const completionSpec: Fig.Spec = {
                   name: "--architecture",
                   description:
                     "Type of CPU architecture to use for the Lambda function",
-                  insertValue: "--architecture=",
                   args: {
                     name: "architecture",
                     suggestions: [{ name: "x86_64" }, { name: "arm64" }],
@@ -582,7 +563,6 @@ const completionSpec: Fig.Spec = {
                 ...globalLambdaOptions,
                 {
                   name: "--site-name",
-                  insertValue: "--site-name=",
                   args: {
                     name: "How the folder in S3 should be named.",
                   },

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -1,4 +1,125 @@
+const localRenderAndStillOptions: Fig.Option[] = [
+  {
+    name: "--env-file",
+    description: "Specify a location for a dotenv file",
+    args: {
+      template: "filepaths",
+    },
+  },
+  {
+    name: "--overwrite",
+    description: "Overwrite if file exists, default true",
+  },
+  {
+    name: "--browser-executable",
+    description: "Custom path for browser executable",
+    args: {
+      template: "filepaths",
+    },
+  },
+  {
+    name: "--ffmpeg-executable",
+    description: "Custom path for FFMPEG executable",
+    args: {
+      template: "filepaths",
+    },
+  },
+  {
+    name: "--bundle-cache",
+    description: "Cache webpack bundle, boolean, default true",
+  },
+  {
+    name: "--port",
+    description: "Custom port to use for the HTTP server",
+    args: {
+      name: "port",
+      default: "3333",
+    },
+  },
+  {
+    name: "--disable-headless",
+    description: "Run Chrome in normal mode rather than headless",
+  },
+  {
+    name: "--config",
+    description: "Custom location for a Remotion config file",
+    args: {
+      template: "filepaths",
+    },
+  },
+];
+
+const lambdaRenderAndStillOptions: Fig.Option[] = [
+  {
+    name: "--max-retries",
+    insertValue: "--max-retries=",
+    description:
+      "How many times a chunk can be retried before the render times out",
+    args: {
+      name: "numberOfRetries",
+    },
+  },
+  {
+    name: "--privacy",
+    insertValue: "--privacy=",
+    args: {
+      name: "privacy",
+      default: "public",
+      suggestions: ["public", "private"],
+    },
+  },
+  {
+    name: "--frames-per-lambda",
+    insertValue: "--frames-per-lambda=",
+    description: "How many frames should be rendered per chunk",
+    args: {
+      name: "framesPerLambda",
+    },
+  },
+];
+
+const localRenderOptions: Fig.Option[] = [
+  {
+    name: "--sequence",
+    description: "Output as an image sequence",
+  },
+  {
+    name: "--concurrency",
+    description: "How many frames to render in parallel",
+  },
+];
+
+const stillOptions: Fig.Option[] = [
+  {
+    name: "--frame",
+    description: "Which frame to render (default 0)",
+    args: { name: "frame", default: "0" },
+  },
+];
+
 const renderOptions: Fig.Option[] = [
+  {
+    name: "--gl",
+    insertValue: "--gl=",
+    description: "Which OpenGL renderer to use",
+    args: {
+      suggestions: ["angle", "egl", "swiftshader", "swangle"],
+    },
+  },
+  {
+    name: "--timeout",
+    insertValue: "--timeout=",
+    description:
+      "The time in milisecond that a delayRender() may take before it times out",
+  },
+  {
+    name: "--ignore-certificate-errors",
+    description: "Ignore SSL errors",
+  },
+  {
+    name: "--disable-web-security",
+    description: "Disable CORS and other web security features",
+  },
   {
     name: "--props",
     insertValue: "--props=",
@@ -20,6 +141,17 @@ const renderOptions: Fig.Option[] = [
     args: {
       default: "80",
       suggestions: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map((e) => ({
+        name: e.toString(),
+      })),
+    },
+  },
+  {
+    name: "--scale",
+    insertValue: "--scale=",
+    description: "Upscale or downscale or the dimensions of the video",
+    args: {
+      default: "1",
+      suggestions: [0.25, 0.5, 1, 1.5, 2, 4].map((e) => ({
         name: e.toString(),
       })),
     },
@@ -73,7 +205,7 @@ const renderOptions: Fig.Option[] = [
     },
   },
   {
-    name: "prores-profile",
+    name: "--prores-profile",
     insertValue: "--prores-profile=",
     description: "ProRes profile, need --codec=prores to be set",
     args: {
@@ -201,57 +333,141 @@ const completionSpec: Fig.Spec = {
   description: "Create videos programmatically in React",
   subcommands: [
     {
+      name: "versions",
+      description: "Prints and validates versions of all Remotion packages",
+    },
+    {
+      name: "compositions",
+      description: "Prints the list of available compositions",
+      args: {
+        name: "entry",
+        description: "The entry point of your Remotion app",
+        template: ["filepaths"],
+      },
+    },
+    {
       name: "lambda",
       description: "Access functionality of @remotion/lambda",
       subcommands: [
         {
+          name: "policies",
+          description: "Manage AWS policies",
+          subcommands: [
+            {
+              name: "role",
+              description: "Print policy to be added to the AWS role",
+            },
+            {
+              name: "user",
+              description: "Print policy to be added to the AWS user",
+            },
+            {
+              name: "validate",
+              description: "Validate the user policy was configured correctly",
+            },
+          ],
+        },
+        {
+          name: "quotas",
+          description: "Show current AWS quota",
+          options: globalLambdaOptions,
+          subcommands: [
+            {
+              name: "increase",
+              description:
+                "Send a request to AWS to increase concurrency quotas",
+              options: globalLambdaOptions,
+            },
+          ],
+        },
+        {
+          name: "regions",
+          description: "Prints list of supported regions",
+        },
+        {
           name: "render",
           description: "Render media on Lambda",
-
           args: [
             {
               name: "serve-url",
               description: "URL or name of the site",
+              suggestions: [
+                {
+                  type: "arg",
+                  displayName: "[serve-url]",
+                },
+              ],
             },
             {
               name: "composition-id",
               description: "Name of the composition",
+              suggestions: [
+                {
+                  type: "arg",
+                  displayName: "[serve-url]",
+                },
+              ],
+            },
+            {
+              name: "out-name",
+              description:
+                "Where the output should be downloaded. No download it omitted",
+              suggestions: [
+                {
+                  type: "arg",
+                  displayName: "[out-name]",
+                },
+              ],
+
+              isOptional: true,
+            },
+          ],
+          options: [
+            ...lambdaRenderAndStillOptions,
+            ...renderOptions,
+            ...globalLambdaOptions,
+          ],
+        },
+        {
+          name: "still",
+          description: "Render a still on Lambda",
+          args: [
+            {
+              name: "serve-url",
+              description: "URL or name of the site",
+              suggestions: [
+                {
+                  type: "arg",
+                  displayName: "[serve-url]",
+                },
+              ],
+            },
+            {
+              name: "composition-id",
+              description: "Name of the composition",
+              suggestions: [
+                {
+                  type: "arg",
+                  displayName: "[composition-id]",
+                },
+              ],
             },
             {
               name: "out-name",
               description:
                 "Where the output should be downloaded. No download it omitted",
               isOptional: true,
+              suggestions: [
+                {
+                  type: "arg",
+                  displayName: "[out-name]",
+                },
+              ],
             },
           ],
           options: [
-            {
-              name: "--max-retries",
-              insertValue: "--max-retries=",
-              description:
-                "How many times a chunk can be retried before the render times out",
-              args: {
-                name: "numberOfRetries",
-              },
-            },
-            {
-              name: "--privacy",
-              insertValue: "--privacy=",
-              args: {
-                name: "privacy",
-                default: "public",
-                suggestions: ["public", "private"],
-              },
-            },
-            {
-              name: "--frames-per-lambda",
-              insertValue: "--frames-per-lambda=",
-              description: "How many frames should be rendered per chunk",
-              args: {
-                name: "framesPerLambda",
-              },
-            },
-            ...renderOptions,
+            ...lambdaRenderAndStillOptions,
+            ...stillOptions,
             ...globalLambdaOptions,
           ],
         },
@@ -375,6 +591,12 @@ const completionSpec: Fig.Spec = {
               args: {
                 name: "entry",
                 template: ["filepaths"],
+                suggestions: [
+                  {
+                    type: "arg",
+                    displayName: "[entry-point]",
+                  },
+                ],
               },
             },
           ],
@@ -412,52 +634,9 @@ const completionSpec: Fig.Spec = {
         },
       ],
       options: [
-        {
-          name: "--concurrency",
-          description: "How many frames to render in parallel",
-        },
-        {
-          name: "--config",
-          description: "Custom location for a Remotion config file",
-          args: {
-            template: "filepaths",
-          },
-        },
         ...renderOptions,
-        {
-          name: "--overwrite",
-          description: "Overwrite if file exists, default true",
-        },
-        {
-          name: "--sequence",
-          description: "Output as an image sequence",
-        },
-        {
-          name: "--browser-executable",
-          description: "Custom path for browser executable",
-          args: {
-            template: "filepaths",
-          },
-        },
-        {
-          name: "--bundle-cache",
-          description: "Cache webpack bundle, boolean, default true",
-        },
-        {
-          name: "--port",
-          description: "Custom port to use for the HTTP server",
-          args: {
-            name: "port",
-            default: "3333",
-          },
-        },
-        {
-          name: "--env-file",
-          description: "Specify a location for a dotenv file",
-          args: {
-            template: "filepaths",
-          },
-        },
+        ...localRenderOptions,
+        ...localRenderAndStillOptions,
       ],
     },
     {
@@ -486,88 +665,7 @@ const completionSpec: Fig.Spec = {
           suggestions: ["out.mp4"],
         },
       ],
-      options: [
-        {
-          name: "--frame",
-          description: "Which frame to render (default 0)",
-          args: { name: "frame", default: "0" },
-        },
-        {
-          name: "--image-format",
-          description: 'Format to render the frames in, "jpeg" or "png"',
-          args: {
-            template: ["filepaths"],
-          },
-        },
-        {
-          name: "--props",
-          description: "Pass input props as filename or as JSON",
-          args: {
-            template: ["filepaths"],
-            suggestions: [
-              {
-                type: "arg",
-                displayName: "[json string]",
-              },
-            ],
-          },
-        },
-        {
-          name: "--config",
-          description: "Custom location for a Remotion config file",
-          args: {
-            template: "filepaths",
-          },
-        },
-        {
-          name: "--quality",
-          description: "Quality for rendered frames, JPEG only, 0-100",
-          args: {
-            default: "80",
-          },
-        },
-        {
-          name: "--overwrite",
-          description: "Overwrite if file exists, default true",
-        },
-        {
-          name: "--browser-executable",
-          description: "Custom path for browser executable",
-          args: {
-            template: "filepaths",
-          },
-        },
-        {
-          name: "--bundle-cache",
-          description: "Cache webpack bundle, boolean, default true",
-        },
-        {
-          name: "--log",
-          description:
-            'Log level, "error", "warning", "verbose", "info" (default)',
-          args: {
-            default: "info",
-            suggestions: [
-              { name: "error" },
-              { name: "warning" },
-              { name: "verbose" },
-              { name: "info" },
-            ],
-          },
-        },
-        {
-          name: "--port",
-          description: "Custom port to use for the HTTP server",
-          args: {
-            name: "port",
-            default: "3333",
-          },
-        },
-        {
-          name: "--env-file",
-          description: "Specify a location for a dotenv file",
-        },
-      ],
+      options: [...stillOptions, ...localRenderAndStillOptions],
     },
     {
       name: "preview",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Update Remotion completions with new commands, flags and Remotion Lambda feature

**What is the current behavior? (You can also link to an open issue here)**

Represents the capability of Remotion 2.0 while 3.0 is out now

**What is the new behavior (if this is a feature change)?**

Represents 3.0 functionality

**Additional info:**