### PR TITLE
bugfix(ansible-config): Remove `-v` stacking

### DIFF
--- a/src/ansible-config.ts
+++ b/src/ansible-config.ts
@@ -12,16 +12,13 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--verbose",
-          description:
-            "Verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+          description: "Verbose mode",
           exclusiveOn: ["-v"],
         },
         {
           name: "-v",
-          description:
-            "Verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+          description: "Verbose mode",
           exclusiveOn: ["--verbose"],
-          isRepeatable: 4,
         },
         {
           name: ["--config", "-c"],
@@ -77,16 +74,13 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--verbose",
-          description:
-            "Verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+          description: "Verbose mode",
           exclusiveOn: ["-v"],
         },
         {
           name: "-v",
-          description:
-            "Verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+          description: "Verbose mode",
           exclusiveOn: ["--verbose"],
-          isRepeatable: 4,
         },
         {
           name: ["--only-changed", "--changed-only"],
@@ -146,16 +140,13 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--verbose",
-          description:
-            "Verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+          description: "Verbose mode",
           exclusiveOn: ["-v"],
         },
         {
           name: "-v",
-          description:
-            "Verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+          description: "Verbose mode",
           exclusiveOn: ["--verbose"],
-          isRepeatable: 4,
         },
         {
           name: ["--config", "-c"],
@@ -210,16 +201,13 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--verbose",
-          description:
-            "Verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+          description: "Verbose mode",
           exclusiveOn: ["-v"],
         },
         {
           name: "-v",
-          description:
-            "Verbose mode (-vvv for more, -vvvv to enable connection debugging)",
+          description: "Verbose mode",
           exclusiveOn: ["--verbose"],
-          isRepeatable: 4,
         },
         {
           name: "--disabled",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bugfix `-v` stacking of `ansible-config` completion (it doesn't support it)

**What is the current behavior? (You can also link to an open issue here)**

The `ansible-config` completion supports repeating `-v`

**What is the new behavior (if this is a feature change)?**

The `ansible-config` completion will not support repeating `-v`

**Additional info:**

Related to #1238 
