### PR TITLE
feat(ansible-lint): add completion

### DIFF
--- a/src/ansible-lint.ts
+++ b/src/ansible-lint.ts
@@ -1,0 +1,192 @@
+const shortFormatArg: Fig.Arg = {
+  name: "-f",
+  suggestions: ["rich", "plain", "md"],
+  default: "rich",
+};
+
+const fullFormatArg: Fig.Arg = {
+  name: "-f",
+  suggestions: [
+    "rich",
+    "plain",
+    "md",
+    "json",
+    "codeclimate",
+    "quiet",
+    "pep8",
+    "sarif",
+  ],
+  default: "rich",
+};
+
+const completionSpec: Fig.Spec = {
+  name: "ansible-lint",
+  description: "Ansible static code analysis",
+  subcommands: [
+    {
+      name: ["--list-rules", "-L"],
+      description: "List all the rules",
+      options: [
+        {
+          name: ["--format", "-f"],
+          displayName: "Format",
+          description: "Stdout formatting",
+          args: shortFormatArg,
+          icon: "fig://icon?type=characters",
+        },
+      ],
+    },
+    {
+      name: ["--list-tags", "-T"],
+      description: "List all the tags and the rules they cover",
+      options: [
+        {
+          name: ["--format", "-f"],
+          displayName: "Format",
+          description: "Stdout formatting",
+          args: fullFormatArg,
+          icon: "fig://icon?type=characters",
+        },
+      ],
+    },
+  ],
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for ansible-lint",
+    },
+    {
+      name: ["--format", "-f"],
+      displayName: "Format",
+      description: "Stdout formatting",
+      args: fullFormatArg,
+      icon: "fig://icon?type=characters",
+    },
+    {
+      name: "-q",
+      description: "Quieter, reduce verbosity, can be specified twice",
+      isRepeatable: 2,
+    },
+    {
+      name: "-p",
+      description: "Parseable output, same as '-f pep8'",
+    },
+    {
+      name: "--progressive",
+      description:
+        "Return success if it detects a reduction in number of violations compared with previous git commit. This feature works only in git repositories",
+    },
+    {
+      name: "--project-dir",
+      description:
+        "Location of project/repository, autodetected based on location of configuration file",
+      args: {
+        name: "PROJECT_DIR",
+        template: "folders",
+      },
+    },
+    {
+      name: ["--rules-dir", "-r"],
+      description: "Specify custom rule directories",
+      args: {
+        name: "RULESDIR",
+        template: "folders",
+      },
+    },
+    {
+      name: "-R",
+      description: "Keep using embedded rules when using '-r'",
+    },
+    {
+      name: "--write",
+      description:
+        "Allow ansible-lint to reformat YAML files and run rule transforms",
+      args: {
+        name: "WRITE_LIST",
+        description:
+          "Limit the effective rule transforms by passing a keywords 'all' or 'none' or a comma separated list of rule ids or rule tags",
+        suggestions: ["all", "none", "rule1,rule2,..."],
+        default: "all",
+      },
+    },
+    {
+      name: "--show-relpath",
+      description: "Display path relative to CWD",
+    },
+    {
+      name: ["--tags", "-t"],
+      description: "Only check rules whose id/tags match these values",
+    },
+    {
+      name: "-v",
+      description: "Increase verbosity level (-vv for more)",
+      isRepeatable: 2,
+    },
+    {
+      name: ["--skip-list", "-x"],
+      description: "Only check rules whose id/tags do not match these values",
+      args: {
+        name: "SKIP_LIST",
+      },
+    },
+    {
+      name: ["--warn-list", "-w"],
+      description:
+        "Only warn about these rules, unless overridden in config file defaults to 'experimental'",
+      args: {
+        name: "WARN_LIST",
+      },
+    },
+    {
+      name: "--enable-list",
+      description: "Activate optional rules by their tag name",
+      args: {
+        name: "ENABLE_LIST",
+      },
+    },
+    {
+      name: "--nocolor",
+      description: "Disable colored output, same as NO_COLOR=1",
+    },
+    {
+      name: "--force-color",
+      description: "Force colored output, same as FORCE_COLOR=1",
+    },
+    {
+      name: "--exclude-paths",
+      description:
+        "Path to directories or files to skip. This option is repeatable",
+      args: {
+        name: "EXCLUDE_PATHS",
+        isVariadic: true,
+        template: "folders",
+      },
+    },
+    {
+      name: "--config-file",
+      description:
+        "Specify configuration file to use. By default it will look for '.ansible-lint' or '.config/ansible-lint.yml'",
+      args: {
+        name: "CONFIG_FILE",
+        template: "filepaths",
+      },
+    },
+    {
+      name: "--offline",
+      description: "Disable installation of requirements.yml",
+    },
+    {
+      name: "--version",
+      description: "Show version of ansible-lint",
+    },
+  ],
+  args: {
+    name: "lintables",
+    description: "Files to lint",
+    isOptional: true,
+    isVariadic: true,
+    template: "filepaths",
+  },
+};
+
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

New completion

**What is the current behavior? (You can also link to an open issue here)**

There is no completion for `ansible-lint`

**What is the new behavior (if this is a feature change)?**

There will be completion for `ansible-lint`

**Additional info:**

```bash
 ansible-lint -h
WARNING: PATH altered to include /Users/mark/.pyenv/versions/3.9.9/bin
usage: ansible-lint [-h] [-L | -T]
                    [-f {rich,plain,md,json,codeclimate,quiet,pep8,sarif}]
                    [-q] [-p] [--progressive]
                    [--project-dir PROJECT_DIR] [-r RULESDIR] [-R]
                    [--write [WRITE_LIST]] [--show-relpath] [-t TAGS]
                    [-v] [-x SKIP_LIST] [-w WARN_LIST]
                    [--enable-list ENABLE_LIST] [--nocolor]
                    [--force-color] [--exclude EXCLUDE_PATHS]
                    [-c CONFIG_FILE] [--offline] [--version]
                    [lintables ...]

positional arguments:
  lintables             One or more files or paths. When missing it
                        will enable auto-detection mode.

optional arguments:
  -h, --help            show this help message and exit
  -L, --list-rules      List all the rules. For listing rules only the
                        following formats for argument -f are
                        supported: {plain, rich, md}
  -T, --list-tags       List all the tags and the rules they cover.
                        Increase the verbosity level with `-v` to
                        include 'opt-in' tag and its rules.
  -f {rich,plain,md,json,codeclimate,quiet,pep8,sarif}, --format {rich,plain,md,json,codeclimate,quiet,pep8,sarif}
                        stdout formatting, json being an alias for
                        codeclimate. (default: rich)
  -q                    quieter, reduce verbosity, can be specified
                        twice.
  -p, --parseable       parseable output, same as '-f pep8'
  --progressive         Return success if it detects a reduction in
                        number of violations compared with previous git
                        commit. This feature works only in git
                        repositories.
  --project-dir PROJECT_DIR
                        Location of project/repository, autodetected
                        based on location of configuration file.
  -r RULESDIR, --rules-dir RULESDIR
                        Specify custom rule directories. Add -R to keep
                        using embedded rules from
                        /Users/mark/.local/lib/python3.9/site-
                        packages/ansiblelint/rules
  -R                    Keep default rules when using -r
  --write [WRITE_LIST]  Allow ansible-lint to reformat YAML files and
                        run rule transforms (Reformatting YAML files
                        standardizes spacing, quotes, etc. A rule
                        transform can fix or simplify fixing issues
                        identified by that rule). You can limit the
                        effective rule transforms (the 'write_list') by
                        passing a keywords 'all' or 'none' or a comma
                        separated list of rule ids or rule tags. YAML
                        reformatting happens whenever '--write' or '--
                        write=' is used. '--write' and '--write=all'
                        are equivalent: they allow all transforms to
                        run. The effective list of transforms comes
                        from 'write_list' in the config file, followed
                        whatever '--write' args are provided on the
                        commandline. '--write=none' resets the list of
                        transforms to allow reformatting YAML without
                        running any of the transforms (ie '--
                        write=none,rule-id' will ignore write_list in
                        the config file and only run the rule-id
                        transform).
  --show-relpath        Display path relative to CWD
  -t TAGS, --tags TAGS  only check rules whose id/tags match these
                        values
  -v                    Increase verbosity level (-vv for more)
  -x SKIP_LIST, --skip-list SKIP_LIST
                        only check rules whose id/tags do not match
                        these values
  -w WARN_LIST, --warn-list WARN_LIST
                        only warn about these rules, unless overridden
                        in config file defaults to 'experimental'
  --enable-list ENABLE_LIST
                        activate optional rules by their tag name
  --nocolor             disable colored output, same as NO_COLOR=1
  --force-color         Force colored output, same as FORCE_COLOR=1
  --exclude EXCLUDE_PATHS
                        path to directories or files to skip. This
                        option is repeatable.
  -c CONFIG_FILE, --config-file CONFIG_FILE
                        Specify configuration file to use. By default
                        it will look for '.ansible-lint' or
                        '.config/ansible-lint.yml'
  --offline             Disable installation of requirements.yml
  --version
```