### PR TITLE
feat(tac): add completion

### DIFF
--- a/src/tac.ts
+++ b/src/tac.ts
@@ -1,0 +1,34 @@
+const completionSpec: Fig.Spec = {
+  name: "tac",
+  description: "Concatenate and print files in reverse",
+  options: [
+    {
+      name: "--help",
+      description: "Display this help and exit",
+    },
+    {
+      name: ["--before", "-b"],
+      description: "Attach the separator before instead of after",
+    },
+    {
+      name: ["--regex", "-r"],
+      description: "Interpret the separator as a regular expression",
+    },
+    {
+      name: ["--separator", "-s"],
+      description: "Use STRING as the separator instead of newline",
+      args: {
+        name: "STRING",
+      },
+    },
+    {
+      name: "--version",
+      description: "Output version information and exit",
+    },
+  ],
+  args: {
+    name: "FILE",
+    template: "filepaths",
+  },
+};
+export default completionSpec;

--- a/src/tac.ts
+++ b/src/tac.ts
@@ -1,6 +1,9 @@
 const completionSpec: Fig.Spec = {
   name: "tac",
   description: "Concatenate and print files in reverse",
+  parserDirectives: {
+    optionsMustPrecedeArguments: true,
+  },
   options: [
     {
       name: "--help",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

New completion

**What is the current behavior? (You can also link to an open issue here)**

There is no completion for `tac`

**What is the new behavior (if this is a feature change)?**

There will be completion for `tac`

**Additional info:**

```bash
 tac --help
Usage: tac [OPTION]... [FILE]...
Write each FILE to standard output, last line first.

With no FILE, or when FILE is -, read standard input.

Mandatory arguments to long options are mandatory for short options too.
  -b, --before             attach the separator before instead of after
  -r, --regex              interpret the separator as a regular expression
  -s, --separator=STRING   use STRING as the separator instead of newline
      --help        display this help and exit
      --version     output version information and exit

GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
Full documentation <https://www.gnu.org/software/coreutils/tac>
or available locally via: info '(coreutils) tac invocation'
```