### PR TITLE
feat(nl): add completion

### DIFF
--- a/src/nl.ts
+++ b/src/nl.ts
@@ -1,0 +1,140 @@
+const completionSpec: Fig.Spec = {
+  name: "nl",
+  description: "Line numbering filter",
+  options: [
+    {
+      name: "--help",
+      description: "Show help for nl",
+    },
+    {
+      name: "-b",
+      description: `Specify the logical page body lines to be numbered
+        'a' number all lines, 't' number only non-empty lines,
+        'n' no line numbering, 'pexpr' number only those lines that
+        contain the basic regular expression specified by 'expr'`,
+      args: {
+        name: "type",
+        suggestions: ["a", "t", "n", "pexpr"],
+        default: "t",
+      },
+    },
+    {
+      name: "-d",
+      description: `Specify the delimiter characters used to indicate the
+        start of a logical page section in the input file.  At
+        most two characters may be specified; if only one
+        character is specified, the first character is
+        replaced and the second character remains unchanged.
+        The default delim characters are "\\:".`,
+      args: {
+        name: "delim",
+        suggestions: ["\\:"],
+        default: "\\:",
+      },
+    },
+    {
+      name: "-f",
+      description: `Specify the same as -b type except for logical page
+        footer lines.  The default type for logical page
+        footer lines is n.`,
+      args: {
+        name: "type",
+        suggestions: ["n"],
+        default: "n",
+      },
+    },
+    {
+      name: "-h",
+      description: `Specify the same as -b type except for logical page
+        header lines.  The default type for logical page
+        header lines is n.`,
+      args: {
+        name: "type",
+        suggestions: ["n"],
+        default: "n",
+      },
+    },
+    {
+      name: "-i",
+      description: `Specify the increment value used to number logical
+        page lines.  The default incr value is 1.`,
+      args: {
+        name: "incr",
+        suggestions: ["1"],
+        default: "1",
+      },
+    },
+    {
+      name: "-l",
+      description: `If numbering of all lines is specified for the current
+        logical section using the corresponding -b a, -f a or
+        -h a option, specify the number of adjacent blank
+        lines to be considered as one.  For example, -l 2
+        results in only the second adjacent blank line being
+        numbered.  The default num value is 1.`,
+      args: {
+        name: "num",
+        suggestions: ["1"],
+        default: "1",
+      },
+    },
+    {
+      name: "-n",
+      description: `Specify the line numbering output format.
+        Recognized format arguments are:
+        'ln' Left justified,
+        'rn' Right justified (leading zeros suppressed),
+        'rz' Right justified (leading zeros kept).`,
+      args: {
+        name: "format",
+        suggestions: ["ln", "rn", "rz"],
+        default: "rz",
+      },
+    },
+    {
+      name: "-p",
+      description: `Specify that line numbering should not be restarted at
+        logical page delimiters.`,
+    },
+    {
+      name: "-s",
+      description: `Specify the characters used in separating the line
+        number and the corresponding text line.  The default
+        sep setting is a single tab character.`,
+      args: {
+        name: "sep",
+        suggestions: ["\\t"],
+        default: "\\t",
+      },
+    },
+    {
+      name: "-v",
+      description: `Specify the initial value used to number logical page
+        lines; see also the description of the -p option.  The
+        default startnum value is 1.`,
+      args: {
+        name: "startnum",
+        suggestions: ["1", "2", "3"],
+        default: "1",
+      },
+    },
+    {
+      name: "-w",
+      description: `Specify the number of characters to be occupied by the
+        line number; in case the width is insufficient to hold
+        the line number, it will be truncated to its width
+        least significant digits.  The default width is 6.`,
+      args: {
+        name: "width",
+        suggestions: ["6", "5", "4", "3", "2", "1"],
+        default: "6",
+      },
+    },
+  ],
+  args: {
+    name: "file",
+    description: "File(s) to number",
+    template: "filepaths",
+  },
+};
+export default completionSpec;

--- a/src/nl.ts
+++ b/src/nl.ts
@@ -7,24 +7,33 @@ const completionSpec: Fig.Spec = {
   options: [
     {
       name: "-b",
-      description: `Specify the logical page body lines to be numbered
-        'a' number all lines, 't' number only non-empty lines,
-        'n' no line numbering, 'pexpr' number only those lines that
-        contain the basic regular expression specified by 'expr'`,
+      description: "Specify the logical page body lines to be numbered",
       args: {
         name: "type",
-        suggestions: ["a", "t", "n", "pexpr"],
+        suggestions: [
+          {
+            name: "a",
+            description: "Number all lines",
+          },
+          {
+            name: "t",
+            description: "Number only non-empty lines",
+          },
+          {
+            name: "pexpr",
+            description:
+              "Only those lines that contain the basic regular expression specified by 'expr'",
+          },
+        ],
         default: "t",
       },
     },
     {
       name: "-d",
       description: `Specify the delimiter characters used to indicate the
-        start of a logical page section in the input file.  At
-        most two characters may be specified; if only one
-        character is specified, the first character is
-        replaced and the second character remains unchanged.
-        The default delim characters are "\\:".`,
+      start of a logical page section in the input file. At most two
+      characters may be specified; if only one character is specified,
+      the first character is replaced and the second character remains unchanged`,
       args: {
         name: "delim",
         suggestions: ["\\:"],
@@ -33,9 +42,8 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "-f",
-      description: `Specify the same as -b type except for logical page
-        footer lines.  The default type for logical page
-        footer lines is n.`,
+      description:
+        "Specify the same as -b type except for logical page footer lines",
       args: {
         name: "type",
         suggestions: ["n"],
@@ -44,9 +52,8 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "-h",
-      description: `Specify the same as -b type except for logical page
-        header lines.  The default type for logical page
-        header lines is n.`,
+      description:
+        "Specify the same as -b type except for logical page header lines",
       args: {
         name: "type",
         suggestions: ["n"],
@@ -55,8 +62,8 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "-i",
-      description: `Specify the increment value used to number logical
-        page lines.  The default incr value is 1.`,
+      description:
+        "Specify the increment value used to number logical page lines",
       args: {
         name: "incr",
         suggestions: ["1"],
@@ -66,11 +73,9 @@ const completionSpec: Fig.Spec = {
     {
       name: "-l",
       description: `If numbering of all lines is specified for the current
-        logical section using the corresponding -b a, -f a or
-        -h a option, specify the number of adjacent blank
-        lines to be considered as one.  For example, -l 2
-        results in only the second adjacent blank line being
-        numbered.  The default num value is 1.`,
+      logical section using the corresponding -b a, -f a or -h a option, specify
+      the number of adjacent blank lines to be considered as one. For example,
+      -l 2 results in only the second adjacent blank line being numbered`,
       args: {
         name: "num",
         suggestions: ["1"],
@@ -79,27 +84,36 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "-n",
-      description: `Specify the line numbering output format.
-        Recognized format arguments are:
-        'ln' Left justified,
-        'rn' Right justified (leading zeros suppressed),
-        'rz' Right justified (leading zeros kept).`,
+      description: "Specify the line numbering output format",
       args: {
         name: "format",
-        suggestions: ["ln", "rn", "rz"],
+        suggestions: [
+          {
+            name: "ln",
+            description: "Left justified",
+          },
+          {
+            name: "rn",
+            description: "Right justified (leading zeros suppressed)",
+          },
+          {
+            name: "rz",
+            description: "Right justified (leading zeros kept)",
+          },
+        ],
         default: "rz",
       },
     },
     {
       name: "-p",
-      description: `Specify that line numbering should not be restarted at
-        logical page delimiters.`,
+      description:
+        "Specify that line numbering should not be restarted at logical page delimiters",
     },
     {
       name: "-s",
       description: `Specify the characters used in separating the line
-        number and the corresponding text line.  The default
-        sep setting is a single tab character.`,
+      number and the corresponding text line.  The default
+      sep setting is a single tab character`,
       args: {
         name: "sep",
         suggestions: ["\\t"],
@@ -108,9 +122,8 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "-v",
-      description: `Specify the initial value used to number logical page
-        lines; see also the description of the -p option.  The
-        default startnum value is 1.`,
+      description:
+        "Specify the initial value used to number logical page lines; see also the description of the -p option",
       args: {
         name: "startnum",
         suggestions: ["1", "2", "3"],
@@ -120,9 +133,8 @@ const completionSpec: Fig.Spec = {
     {
       name: "-w",
       description: `Specify the number of characters to be occupied by the
-        line number; in case the width is insufficient to hold
-        the line number, it will be truncated to its width
-        least significant digits.  The default width is 6.`,
+      line number; in case the width is insufficient to hold the line number,
+      it will be truncated to its width least significant digits`,
       args: {
         name: "width",
         suggestions: ["6", "5", "4", "3", "2", "1"],

--- a/src/nl.ts
+++ b/src/nl.ts
@@ -3,10 +3,6 @@ const completionSpec: Fig.Spec = {
   description: "Line numbering filter",
   options: [
     {
-      name: "--help",
-      description: "Show help for nl",
-    },
-    {
       name: "-b",
       description: `Specify the logical page body lines to be numbered
         'a' number all lines, 't' number only non-empty lines,

--- a/src/nl.ts
+++ b/src/nl.ts
@@ -1,6 +1,9 @@
 const completionSpec: Fig.Spec = {
   name: "nl",
   description: "Line numbering filter",
+  parserDirectives: {
+    optionsMustPrecedeArguments: true,
+  },
   options: [
     {
       name: "-b",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

New completion

**What is the current behavior? (You can also link to an open issue here)**

There is no completion for `nl`

**What is the new behavior (if this is a feature change)?**

There will be completion for `nl`

**Additional info:**

`bash
❯ nl --fake-argument
nl: illegal option -- -
usage: nl [-p] [-b type] [-d delim] [-f type] [-h type] [-i incr] [-l num]
          [-n format] [-s sep] [-v startnum] [-w width] [file]
```