### PR TITLE
feat(create-next-app): add `use-pnpm` and `version` options

### DIFF
--- a/src/create-next-app.ts
+++ b/src/create-next-app.ts
@@ -5,12 +5,20 @@ const completionSpec: Fig.Spec = {
   icon: "https://nextjs.org/static/favicon/favicon-16x16.png",
   options: [
     {
+      name: ["-V", "--version"],
+      description: "Output the version number",
+    },
+    {
       name: ["--ts", "--typescript"],
       description: "Initialize as a TypeScript project",
     },
     {
       name: "--use-npm",
       description: "Explicitly tell the CLI to bootstrap the app using npm",
+    },
+    {
+      name: "--use-pnpm",
+      description: "Explicitly tell the CLI to bootstrap the app using pnpm",
     },
     {
       name: ["-e", "--example"],


### PR DESCRIPTION
Latest `create-next-app` includes these options:

```
Usage: create-next-app <project-directory> [options]

Options:
  -V, --version                      output the version number
  --ts, --typescript

    Initialize as a TypeScript project.

  --use-npm

    Explicitly tell the CLI to bootstrap the app using npm

  --use-pnpm

    Explicitly tell the CLI to bootstrap the app using pnpm

  -e, --example [name]|[github-url]

    An example to bootstrap the app with. You can use an example name
    from the official Next.js repo or a GitHub URL. The URL can use
    any branch and/or subdirectory

  --example-path <path-to-example>

    In a rare case, your GitHub URL might contain a branch name with
    a slash (e.g. bug/fix-1) and the path to the example (e.g. foo/bar).
    In this case, you must specify the path to the example separately:
    --example-path foo/bar

  -h, --help                         output usage information
```