### PR TITLE
feat(basenc,base32,base64): add completion

### DIFF
--- a/src/base32.ts
+++ b/src/base32.ts
@@ -1,6 +1,9 @@
 const completionSpec: Fig.Spec = {
   name: "base32",
   description: "Base32 encode/decode data and print to standard output",
+  parserDirectives: {
+    optionsMustPrecedeArguments: true,
+  },
   options: [
     {
       name: ["--help", "-h"],

--- a/src/base32.ts
+++ b/src/base32.ts
@@ -1,0 +1,38 @@
+const completionSpec: Fig.Spec = {
+  name: "base32",
+  description: "Base32 encode/decode data and print to standard output",
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Display this help and exit",
+    },
+    {
+      name: ["--decode", "-d"],
+      description: "Decode data",
+    },
+    {
+      name: ["--ignore-garbage", "-i"],
+      description: "When decoding, ignore non-alphabet characters",
+    },
+    {
+      name: ["--wrap", "-w"],
+      description:
+        "Wrap encoded lines after COLS character (default 76).  Use 0 to disable line wrapping",
+      args: {
+        name: "COLS",
+        suggestions: ["76", "78", "80", "100", "120", "160", "0"],
+        default: "76",
+      },
+    },
+    {
+      name: "--version",
+      description: "Output version information and exit",
+    },
+  ],
+  args: {
+    name: "FILE",
+    description: "File to base32 encode/decode",
+    template: "filepaths",
+  },
+};
+export default completionSpec;

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -1,6 +1,9 @@
 const completionSpec: Fig.Spec = {
   name: "base64",
   description: "Encode and decode using Base64 representation",
+  parserDirectives: {
+    optionsMustPrecedeArguments: true,
+  },
   options: [
     {
       name: ["--help", "-h"],

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -1,0 +1,47 @@
+const completionSpec: Fig.Spec = {
+  name: "base64",
+  description: "Encode and decode using Base64 representation",
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Display this help and exit",
+    },
+    {
+      name: ["--break", "-b"],
+      description:
+        "Insert line breaks every count characters.  Default is 0, which generates an unbroken stream",
+      args: {
+        name: "count",
+        suggestions: ["0"],
+        default: "0",
+      },
+    },
+    {
+      name: ["--decode", "-d", "-D"],
+      description: "Decode incoming Base64 stream into binary data",
+    },
+    {
+      name: ["--input", "-i"],
+      description:
+        "Read input from input_file.  Default is stdin; passing - also represents stdin",
+      args: {
+        name: "input_file",
+        suggestions: ["stdin", "-"],
+        default: "stdin",
+        template: "filepaths",
+      },
+    },
+    {
+      name: ["--output", "-o"],
+      description:
+        "Write output to output_file.  Default is stdout; passing - also represents stdout",
+      args: {
+        name: "output_file",
+        suggestions: ["stdout", "-"],
+        default: "stdout",
+        template: "filepaths",
+      },
+    },
+  ],
+};
+export default completionSpec;

--- a/src/basenc.ts
+++ b/src/basenc.ts
@@ -1,6 +1,9 @@
 const completionSpec: Fig.Spec = {
   name: "basenc",
   description: "Encode/decode data and print to standard output",
+  parserDirectives: {
+    optionsMustPrecedeArguments: true,
+  },
   options: [
     {
       name: ["--help", "-h"],

--- a/src/basenc.ts
+++ b/src/basenc.ts
@@ -1,0 +1,71 @@
+const completionSpec: Fig.Spec = {
+  name: "basenc",
+  description: "Encode/decode data and print to standard output",
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Display this help and exit",
+    },
+    {
+      name: "--base64",
+      description: "Same as 'base64' program (RFC4648 section 4)",
+    },
+    {
+      name: "--base64url",
+      description: "File- and url-safe base64 (RFC4648 section 5)",
+    },
+    {
+      name: "--base32",
+      description: "Same as 'base32' program (RFC4648 section 6)",
+    },
+    {
+      name: "--base32hex",
+      description: "Extended hex alphabet base32 (RFC4648 section 7)",
+    },
+    {
+      name: "--base16",
+      description: "Hex encoding (RFC4648 section 8)",
+    },
+    {
+      name: "--base2msbf",
+      description: "Bit string with most significant bit (msb) first",
+    },
+    {
+      name: "--base2lsbf",
+      description: "Bit string with least significant bit (lsb) first",
+    },
+    {
+      name: ["--decode", "-d"],
+      description: "Decode data",
+    },
+    {
+      name: ["--ignore-garbage", "-i"],
+      description: "When decoding, ignore non-alphabet characters",
+    },
+    {
+      name: ["--wrap", "-w"],
+      description:
+        "Wrap encoded lines after COLS character (default 76).  Use 0 to disable line wrapping",
+      args: {
+        name: "COLS",
+        suggestions: ["76", "78", "80", "100", "120", "160", "0"],
+        default: "76",
+      },
+    },
+    {
+      name: "--z85",
+      description:
+        "Ascii85-like encoding (ZeroMQ spec:32/Z85); when encoding, input length must be a multiple of 4; when decoding, input length must be a multiple of 5",
+    },
+    {
+      name: "--version",
+      description: "Output version information and exit",
+    },
+  ],
+  args: {
+    name: "FILE",
+    description: "File(s) to encode/decode",
+    template: "filepaths",
+  },
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

New completions

**What is the current behavior? (You can also link to an open issue here)**

There is no completion for `basenc`, `base32`, and `base64`

**What is the new behavior (if this is a feature change)?**

There will be completion for `basenc`, `base32`, and `base64`

**Additional info:**

`man basenc`, `man base32`, and `man base64`