### PR TITLE
feat(railway): update options and subcommands

### DIFF
--- a/src/railway.ts
+++ b/src/railway.ts
@@ -130,6 +130,11 @@ const completionSpec: Fig.Spec = {
           description: "Environment to run in",
           args: {},
         },
+        {
+          name: ["-s", "--service"],
+          description: "Define specific service",
+          args: { name: "Service name" },
+        },
       ],
     },
     {
@@ -152,6 +157,11 @@ const completionSpec: Fig.Spec = {
       options: [
         { name: ["-d", "--detach"], description: "Detach from build logs" },
         { name: ["-e", "--environment"], description: "Environment to run in" },
+        {
+          name: ["-s", "--service"],
+          description: "Deploy app to specific service",
+          args: { name: "Service name" },
+        },
       ],
     },
     {
@@ -189,7 +199,14 @@ const completionSpec: Fig.Spec = {
           ],
         },
       ],
-      options: [{ name: ["-e", "--environment"], description: "Environment" }],
+      options: [
+        { name: ["-e", "--environment"], description: "Environment" },
+        {
+          name: ["-s", "--service"],
+          description: "Deploy app to specific service",
+          args: { name: "Service name" },
+        },
+      ],
     },
     {
       name: "version",

--- a/src/railway.ts
+++ b/src/railway.ts
@@ -39,6 +39,17 @@ const completionSpec: Fig.Spec = {
       description: "Open Railway Documentation in default browser",
     },
     {
+      name: "down",
+      description: "Remove the most recent deployment",
+      options: [
+        {
+          name: ["-e", "--environment"],
+          description: "Environment to delete from",
+          args: {},
+        },
+      ],
+    },
+    {
       name: "environment",
       description: "Change your environment",
       args: {
@@ -133,6 +144,17 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-s", "--service"],
           description: "Define specific service",
+          args: { name: "Service name" },
+        },
+      ],
+    },
+    {
+      name: "shell",
+      description: "Open a subshell with Railway variables available",
+      options: [
+        {
+          name: ["-s", "--service"],
+          description: "Deploy app to specific service",
           args: { name: "Service name" },
         },
       ],


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Update options for some commands, and add `down` and `shell` completion.

**What is the current behavior? (You can also link to an open issue here)**
No completion for `down` and `shell` commands, and `-s` or `--service` options.

**What is the new behavior (if this is a feature change)?**
Completion for `down` and `shell` commands, and `-s` or `--service` options.

**Additional info:**
