### PR TITLE
fix(youtube-dl): correct option name

### DIFF
--- a/src/youtube-dl.ts
+++ b/src/youtube-dl.ts
@@ -1041,7 +1041,7 @@ const completionSpec: Fig.Spec = {
         "Embed subtitles in the video (only for mp4, webm and mkv videos)",
     },
     {
-      name: "--embed-thumbnails",
+      name: "--embed-thumbnail",
       description: "Embed thumbnail in the audio as cover art",
     },
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
bug fix
**What is the current behavior? (You can also link to an open issue here)**
The argument of youtube-dl "--embed-thumbnails" is incorrect.
It should be changed to "--embed-thumbnail".

**What is the new behavior (if this is a feature change)?**
youtube-dl now prompts "--embed-thumbnail" correctly.

**Additional info:**
<img width="960" alt="Screen Shot 2022-06-03 at 13 03 26" src="https://user-images.githubusercontent.com/43875433/171789736-2e179dc2-ad10-46c6-93b9-34cd54a268bf.png">