### PR TITLE
feat: add wifi-password completion spec

### DIFF
--- a/src/wifi-password.ts
+++ b/src/wifi-password.ts
@@ -1,0 +1,29 @@
+const completionSpec: Fig.Spec = {
+  name: "wifi-password",
+  args: {
+    name: "SSID",
+    description: "The name for a Wi-Fi network",
+  },
+  description:
+    "People ask you for the Wi-Fi password. Answer quickly. macOS only",
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for wifi-password",
+    },
+    {
+      name: ["--quiet", "-q"],
+      description: "Only output the password",
+      args: {
+        name: "SSID",
+        description: "The name for a Wi-Fi network",
+      },
+    },
+    {
+      name: ["--version", "-V"],
+      description: "Output version",
+    },
+  ],
+};
+
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
wifi-password commands are not currently supported

**What is the new behavior (if this is a feature change)?**
Autocompletion support for wifi-password

**Additional info:**
You can find wifi-password here : https://github.com/rauchg/wifi-password
wifi-password is mac only utility