### PR TITLE
fix(nx): app generator returning no apps

### DIFF
--- a/src/nx.ts
+++ b/src/nx.ts
@@ -4,12 +4,10 @@ interface NxProject {
   projectType: string;
 }
 
+type NxArray = [string, NxProject];
+
 type PostProcessWorkspaceFn = (
-  filterFn: (
-    projectEntry: [string, NxProject],
-    index: number,
-    array: [string, NxProject][]
-  ) => boolean
+  filterFn: (projectEntry: NxArray, index: number, array: NxArray[]) => boolean
 ) => PostProcessFn;
 
 interface NxGenerators {
@@ -26,7 +24,15 @@ const processWorkspaceJson: PostProcessWorkspaceFn = (filterFn) => (out) => {
   try {
     const workspace = JSON.parse(out);
     return Object.entries<NxProject>(workspace.projects)
-      .filter(filterFn)
+      .filter((el, ind, arr) => {
+        function filterFn(el, ind, arr) {
+          if (el == null || ind == null || arr == null) {
+            return false;
+          }
+          return true;
+        }
+        return filterFn(el, ind, arr);
+      })
       .map(([projectName]) => projectName)
       .map((suggestion) => ({
         name: suggestion,

--- a/src/nx.ts
+++ b/src/nx.ts
@@ -35,11 +35,9 @@ const processWorkspaceJson: PostProcessWorkspaceFn = (filterFn) => (out) => {
         type: "option",
       }));
 
-    if (oldWorkspaceMap.length > 0) {
-      return oldWorkspaceMap;
-    }
+    if (oldWorkspaceMap.length > 0) return oldWorkspaceMap;
 
-    Object.entries<string>(workspace.projects)
+    return Object.entries<string>(workspace.projects)
       .filter((proj) => proj[1].split("/")[0] === "apps")
       .map(([projectName]) => projectName)
       .map((suggestion) => ({

--- a/src/nx.ts
+++ b/src/nx.ts
@@ -6,7 +6,7 @@ interface NxProject {
 
 type PostProcessWorkspaceFn = (
   filterFn: (
-    projectEntry: [string, NxProject],
+    projectEntry: [string, NxProject | string],
     index: number,
     array: [string, NxProject][]
   ) => boolean
@@ -38,7 +38,9 @@ const processWorkspaceJson: PostProcessWorkspaceFn = (filterFn) => (out) => {
     if (oldWorkspaceMap.length > 0) return oldWorkspaceMap;
 
     return Object.entries<string>(workspace.projects)
-      .filter((proj) => proj[1].split("/")[0] === "apps")
+      .filter((proj) =>
+        proj[1].startsWith("apps") || proj[1].startsWith("e2e") ? true : false
+      )
       .map(([projectName]) => projectName)
       .map((suggestion) => ({
         name: suggestion,
@@ -68,16 +70,16 @@ const nxGenerators: NxGenerators = {
   apps: {
     script: "cat workspace.json",
     postProcess: processWorkspaceJson(([projectName, project], _, projects) =>
-      project.projectType == null
-        ? !projectName.endsWith("-e2e")
+      typeof project === "string"
+        ? !project.startsWith("e2e") && !project.endsWith("e2e")
         : project.projectType === "application" && !projectName.endsWith("-e2e")
     ),
   },
   e2eApps: {
     script: "cat workspace.json",
     postProcess: processWorkspaceJson(([projectName, project], _, projects) =>
-      project.projectType == null
-        ? projectName.endsWith("-e2e")
+      typeof project === "string"
+        ? project.startsWith("e2e") || project.endsWith("e2e")
         : project.projectType === "application" && projectName.endsWith("-e2e")
     ),
   },

--- a/src/nx.ts
+++ b/src/nx.ts
@@ -4,10 +4,12 @@ interface NxProject {
   projectType: string;
 }
 
-type NxArray = [string, NxProject];
-
 type PostProcessWorkspaceFn = (
-  filterFn: (projectEntry: NxArray, index: number, array: NxArray[]) => boolean
+  filterFn: (
+    projectEntry: [string, NxProject],
+    index: number,
+    array: [string, NxProject][]
+  ) => boolean
 ) => PostProcessFn;
 
 interface NxGenerators {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixed issue where the NX App generator wasn't detecting any apps from the workspace.json.

**What is the current behavior? (You can also link to an open issue here)**
In the current version, there is a filter that wasn't functioning properly and always returning false.

**What is the new behavior (if this is a feature change)?**
I replaced it with a directly specified null check since the types are already being checked with typescript. My updated code now returns all the apps correctly.