### PR TITLE
feat(`basename`,`dirname`): add completion

### DIFF
--- a/src/basename.ts
+++ b/src/basename.ts
@@ -1,0 +1,24 @@
+const completionSpec: Fig.Spec = {
+  name: "basename",
+  description: "Return filename portion of pathname",
+  options: [
+    {
+      name: "-a",
+      description: "Treat every argument as a string",
+    },
+    {
+      name: "-s",
+      description: "Suffix to remove from string",
+      args: {
+        name: "suffix",
+      },
+    },
+  ],
+  args: {
+    name: "string",
+    description: "String to operate on (typically filenames)",
+    isVariadic: true,
+    template: "filepaths",
+  },
+};
+export default completionSpec;

--- a/src/dirname.ts
+++ b/src/dirname.ts
@@ -1,0 +1,11 @@
+const completionSpec: Fig.Spec = {
+  name: "dirname",
+  description: "Return directory portion of pathname",
+  args: {
+    name: "string",
+    description: "String to operate on (typically filenames)",
+    isVariadic: true,
+    template: "filepaths",
+  },
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

New completions

**What is the current behavior? (You can also link to an open issue here)**

There is no completion for `basename` and `dirname`

**What is the new behavior (if this is a feature change)?**

There will be completion for `basename` and `dirname`

**Additional info:**

`man basename`