### PR TITLE
feat(npx): add `pod-install` to suggestions

### DIFF
--- a/src/npx.ts
+++ b/src/npx.ts
@@ -110,6 +110,9 @@ const suggestions: Fig.Suggestion[] = [
     name: "mikro-orm",
     icon: "https://raw.githubusercontent.com/mikro-orm/mikro-orm/master/docs/static/img/favicon.ico",
   },
+  {
+    name: "pod-install",
+  },
 ];
 
 const completionSpec: Fig.Spec = {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds pod-install command to npx command (https://github.com/expo/expo-cli/tree/main/packages/pod-install)

**What is the current behavior? (You can also link to an open issue here)**
npx pod-install is not suggested
