### PR TITLE
docs: fix typo (MacOS -> macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Fig uses the Accessibility API on Mac to position the window, and integrates wit
 
 #### Does Fig work on Windows or Linux?
 
-Not yet, Fig is only available on MacOS for now. [Windows](https://github.com/withfig/fig/issues/35) and [Linux](https://github.com/withfig/fig/issues/34) support is in progress!
+Not yet, Fig is only available on macOS for now. [Windows](https://github.com/withfig/fig/issues/35) and [Linux](https://github.com/withfig/fig/issues/34) support is in progress!
 
 #### How can I download Fig?
 


### PR DESCRIPTION
Fix the text from "MacOS" to "macOS".

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Spell fix: "macOS"

**What is the current behavior? (You can also link to an open issue here)**
The text in the question, "Does Fig work on Windows or Linux?", is "macOS".

**What is the new behavior (if this is a feature change)?**
Change to "macOS".

**Additional info:**
None