### PR TITLE
feat(z): provide folders autocomplete

### DIFF
--- a/src/z.ts
+++ b/src/z.ts
@@ -3,6 +3,7 @@ const completionSpec: Fig.Spec = {
   name: "z",
   description: "CLI tool to jump around directories",
   args: {
+    template: ["folders"],
     name: "regex",
     isVariadic: true,
     isOptional: true,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes #1328

**What is the current behavior? (You can also link to an open issue here)**
`zoxide` users usually have `z` aliased as `cd`. It currently autocomplete only optional flags.

**What is the new behavior (if this is a feature change)?**
Added folders autocomplete.

**Additional info:**
