### PR TITLE
[z] Added generated path based on navigation history

### DIFF
--- a/src/z.ts
+++ b/src/z.ts
@@ -3,10 +3,29 @@ const completionSpec: Fig.Spec = {
   name: "z",
   description: "CLI tool to jump around directories",
   args: {
-    template: ["folders"],
     name: "regex",
     isVariadic: true,
     isOptional: true,
+    // Generate a completion for the given argument, via zoxide CLI.
+    generators: {
+        script: context => {
+          const query = context[context.length - 1]
+          return `zoxide query -l ${query}`
+        },
+        postProcess: out => {
+          return out.split("\n").map(fullPath => {
+            const homeRegex = /\/users\/\w+/i
+
+            const shortPath = fullPath.replace(homeRegex, '~') // .split('/').slice(3).join('/')
+
+            return {
+              name: shortPath,
+              description: fullPath,
+              displayName: shortPath
+            };
+          });
+        }
+      }
   },
   options: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
Autocomplete on 'z' is shown using the current path.

**What is the new behavior (if this is a feature change)?**
It uses navigation history to autocomplete the path (it makes more sense since `z` is used for jumping into recent directories without the need of writing the full path)

**Additional info:**
<img width="505" alt="CleanShot 2022-07-07 at 00 36 02@2x" src="https://user-images.githubusercontent.com/16429579/177654874-99cce3c9-3948-4097-9a94-71b7d0c1c34c.png">
