### PR TITLE
fix(ruby): update a description to be grammatically correct

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -40,7 +40,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "-S",
       description:
-        "Makes Ruby use the PATH environment variable to search for script, unless if its name begins with a slash. This is used to emulate #! on machines that don't support it, in the following manner: #! /usr/local/bin/ruby # This line makes the next one a comment in Ruby \\ exec /usr/local/bin/ruby -S $0 $*",
+        "Makes Ruby use the PATH environment variable to search for script, unless its name begins with a slash. This is used to emulate #! on machines that don't support it, in the following manner: #! /usr/local/bin/ruby # This line makes the next one a comment in Ruby \\ exec /usr/local/bin/ruby -S $0 $*",
     },
     {
       name: "-T",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This PR is just a grammatical error fix.

**What is the current behavior? (You can also link to an open issue here)**

No issues created yet because this seems a very tiny thing.

**What is the new behavior (if this is a feature change)?**

You can see like below that this is correct description.

![スクリーンショット 2022-07-12 22 09 56](https://user-images.githubusercontent.com/130989/178497577-0a26856b-3f26-43ca-807c-5f8c22105809.jpg)

**Additional info:**

For your information, the Ruby man says like below.

https://github.com/ruby/ruby/blob/067a5f1a0024ebd270f363cd440147da9dc176b5/man/ruby.1#L212-L213
