### PR TITLE
Make args optional for `watson restart`

### DIFF
--- a/src/watson.ts
+++ b/src/watson.ts
@@ -570,6 +570,7 @@ const completionSpec: Fig.Spec = {
       description: "Restart monitoring time for a previously stopped project",
       args: {
         name: "FRAME",
+        isOptional: true,
         generators: listFrames,
       },
       options: [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix/tiny feature correction: args for `watson restart` should be optional.

**What is the current behavior? (You can also link to an open issue here)**

Typing `watson restart` and enter adds a space and brings up autocomplete with a list of frames.

**What is the new behavior (if this is a feature change)?**

Typing `watson restart` and enter runs the command. This restarts the last frame.

Typing `watson restart` followed by a space brings up autocomplete with the list of frames.

**Additional info:**