### PR TITLE
feat(gh): add browse core command

### DIFF
--- a/src/gh.ts
+++ b/src/gh.ts
@@ -372,6 +372,49 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
+      name: "browse",
+      description: "Open the repository in the browser",
+      options: [ghOptions.help],
+      subcommands: [
+        {
+          name: ["-b", "--branch"],
+          description: "Select another branch by passing in the branch name",
+          args: {
+            name: "branch",
+            generators: ghGenerators.remoteBranches,
+          },
+        },
+        {
+          name: ["-c", "--commit"],
+          description: "Select another branch by passing in the branch name",
+        },
+        {
+          name: ["-n", "--no-browser"],
+          description: "Print destination URL instead of opening the browser",
+        },
+        {
+          name: ["-p", "--projects"],
+          description: "Open repository projects",
+        },
+        {
+          name: ["-R", "--repo"],
+          description:
+            "Select another repository using the [HOST/]OWNER/REPO format",
+          args: {
+            name: "[HOST/]OWNER/REPO",
+          },
+        },
+        {
+          name: ["-s", "--settings"],
+          description: "Open repository settings",
+        },
+        {
+          name: ["-w", "--wiki"],
+          description: "Open repository wiki",
+        },
+      ],
+    },
+    {
       name: "completion",
       description: "Generate shell completion scripts",
       options: [

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -374,8 +374,12 @@ const completionSpec: Fig.Spec = {
     {
       name: "browse",
       description: "Open the repository in the browser",
-      options: [ghOptions.help],
-      subcommands: [
+      args: {
+        name: "[pr | issue | path[:line]",
+        generators: ghGenerators.listPR,
+      },
+      options: [
+        ghOptions.help,
         {
           name: ["-b", "--branch"],
           description: "Select another branch by passing in the branch name",
@@ -386,7 +390,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: ["-c", "--commit"],
-          description: "Select another branch by passing in the branch name",
+          description: "Open the last commit",
         },
         {
           name: ["-n", "--no-browser"],

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -377,6 +377,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "[pr | issue | path[:line]",
         generators: ghGenerators.listPR,
+        suggestCurrentToken: true,
       },
       options: [
         ghOptions.help,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature

**What is the current behavior? (You can also link to an open issue here)**
`gh` command `browse` is not supported with autocomplete

**What is the new behavior (if this is a feature change)?**
`gh` command `browse` will be an option

**Additional info:**
`gh browse` documentation https://cli.github.com/manual/gh_browse