### PR TITLE
Fix `rule-enforcement` typo

### DIFF
--- a/src/st2.ts
+++ b/src/st2.ts
@@ -2052,7 +2052,7 @@ const triggerInstanceSubcommand: Fig.Subcommand = {
 };
 
 const ruleEnforcementSubcommand: Fig.Subcommand = {
-  name: "rule-enforcemnt",
+  name: "rule-enforcement",
   description: "Models that represent enforcement of rules",
   subcommands: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bugfix; fixes #1361.

**What is the current behavior? (You can also link to an open issue here)**

The `rule-enforcemnt` subcommand is misspelled.

**What is the new behavior (if this is a feature change)?**

The `rule-enforcement` subcommand will not be misspelled.

**Additional info:**

N/A