### PR TITLE
feat(remotion): update autocomplete for 3.1

### DIFF
--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -176,6 +176,22 @@ const renderOptions: Fig.Option[] = [
     },
   },
   {
+    name: "--every-nth-frame",
+    description: "Render only every nth frame (only for GIFs)",
+    args: {
+      default: "1",
+      suggestions: [{ name: "2" }, { name: "3" }, { name: "4" }, { name: "5" }],
+    },
+  },
+  {
+    name: "--loop",
+    description: "How many times a GIF should loop. 0 = No loop",
+    args: {
+      default: "1",
+      suggestions: [{ name: "0" }, { name: "1" }, { name: "2" }, { name: "3" }],
+    },
+  },
+  {
     name: "--crf",
     description: "FFMPEG CRF value, controls quality, see docs for info",
   },

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -336,6 +336,17 @@ const completionSpec: Fig.Spec = {
         description: "The entry point of your Remotion app",
         template: ["filepaths"],
       },
+      options: [
+        {
+          name: "--quiet",
+          description: "Print less output",
+        },
+        {
+          name: "-q",
+          hidden: true,
+          description: "Print less output",
+        },
+      ],
     },
     {
       name: "lambda",

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -73,6 +73,13 @@ const lambdaRenderAndStillOptions: Fig.Option[] = [
       name: "framesPerLambda",
     },
   },
+  {
+    name: "--concurrency-per-lambda",
+    description: "Concurrency with which each Lambda function should render",
+    args: {
+      name: "concurrencyPerLambda",
+    },
+  },
 ];
 
 const localRenderOptions: Fig.Option[] = [

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -680,7 +680,8 @@ const completionSpec: Fig.Spec = {
         {
           name: "output",
           template: ["filepaths"],
-          suggestions: ["out.mp4"],
+          suggestions: ["out.png"],
+          isOptional: true,
         },
       ],
       options: [...stillOptions, ...localRenderAndStillOptions],

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -184,7 +184,7 @@ const renderOptions: Fig.Option[] = [
     },
   },
   {
-    name: "--loop",
+    name: "--number-of-gif-loops",
     description: "How many times a GIF should loop. 0 = No loop",
     args: {
       default: "1",

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -437,7 +437,6 @@ const completionSpec: Fig.Spec = {
                   displayName: "[out-name]",
                 },
               ],
-
               isOptional: true,
             },
           ],
@@ -649,6 +648,7 @@ const completionSpec: Fig.Spec = {
 
           template: ["filepaths"],
           suggestions: ["out.mp4"],
+          isOptional: true,
         },
       ],
       options: [


### PR DESCRIPTION
For Remotion CLI, adding flags that we recently introduced:

- `--concurrency-per-lambda` flag
- `--quiet` flag
- `--number-of-gif-loops` and `--every-nth-frame` flag
- The output name parameter is now optional.

My plan is to always batch together a few changes and send them from time to time!