### PR TITLE
feat: add `glow` completions

### DIFF
--- a/src/glow.ts
+++ b/src/glow.ts
@@ -5,6 +5,7 @@ const completionSpec: Fig.Spec = {
   description: "Render markdown on the CLI, with pizzazz!",
   args: {
     name: "source|dir",
+    isOptional: true,
     generators: filepaths({
       extensions: ["md"],
       suggestFolders: "always",

--- a/src/glow.ts
+++ b/src/glow.ts
@@ -84,6 +84,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-m", "--memo"],
           description: "Memo/note for stashing",
+          args: { name: "note" },
         },
       ],
     },

--- a/src/glow.ts
+++ b/src/glow.ts
@@ -6,6 +6,7 @@ const completionSpec: Fig.Spec = {
   args: {
     name: "source|dir",
     isOptional: true,
+    isVariadic: true,
     generators: filepaths({
       extensions: ["md"],
       suggestFolders: "always",
@@ -86,6 +87,7 @@ const completionSpec: Fig.Spec = {
           name: ["-m", "--memo"],
           description: "Memo/note for stashing",
           args: { name: "note" },
+          insertValue: "--memo '{cursor}'",
         },
       ],
     },

--- a/src/glow.ts
+++ b/src/glow.ts
@@ -1,0 +1,93 @@
+import { filepaths } from "@fig/autocomplete-generators";
+
+const completionSpec: Fig.Spec = {
+  name: "glow",
+  description: "Render markdown on the CLI, with pizzazz!",
+  args: {
+    name: "source|dir",
+    generators: filepaths({
+      extensions: ["md"],
+      suggestFolders: "always",
+      editFileSuggestions: { priority: 52 },
+      editFolderSuggestions: { priority: 51 },
+    }),
+  },
+  options: [
+    {
+      name: ["-a", "--all"],
+      description: "Show system files and directories (TUI-mode only)",
+    },
+    {
+      name: "--config",
+      args: { name: "path", template: "filepaths" },
+      description: "Config file",
+      isPersistent: true,
+    },
+    {
+      name: ["-h", "--help"],
+      description: "Help for glow",
+      isPersistent: true,
+    },
+    {
+      name: ["-l", "--local"],
+      description: "Show local files only; no network (TUI-mode only)",
+    },
+    {
+      name: ["-p", "--pager"],
+      description: "Display with pager",
+    },
+    {
+      name: ["-s", "--style"],
+      description: "Style name or JSON path (default 'auto')",
+      args: {
+        name: "name",
+        suggestions: ["auto", "light", "dark", "notty"],
+        template: "filepaths",
+      },
+    },
+    {
+      name: ["-v", "--version"],
+      description: "Version for glow",
+    },
+    {
+      name: ["-w", "--width"],
+      args: { name: "column" },
+      description: "Word-wrap at width",
+    },
+  ],
+  subcommands: [
+    {
+      name: "config",
+      description: "Edit the glow config file",
+    },
+    {
+      name: "help",
+      description: "Help about any command",
+      args: {
+        name: "command",
+        template: "help",
+        isOptional: true,
+      },
+    },
+    {
+      name: "stash",
+      description: "Manage your stash of markdown files",
+      args: {
+        name: "path",
+        isOptional: true,
+        generators: filepaths({
+          extensions: ["md"],
+          suggestFolders: "always",
+        }),
+      },
+      options: [
+        {
+          name: ["-m", "--memo"],
+          description: "Memo/note for stashing",
+        },
+      ],
+    },
+  ],
+};
+
+export default completionSpec;


### PR DESCRIPTION
1. I wanted to add the 'wrapwidth' option to neovim. The suggestion has been open for _**six years**_ nobody has added the option to soft wrap at a set column number.
2. To do that, I had to read the documentation on how to build it.
3. To read the documentation, I wanted to use `glow`.
4. In the documentation was a link that was wrapping over two lines, so I couldn't click it.
5. I wanted to see if there was a flag for glow to use the proper escape codes to make the link clickable.
6. There were no fig completions for glow.

So here we are... I _was_ going to add an option to neovim...