### PR TITLE
feat(yarn): bump priority of scripts

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -5382,7 +5382,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "stash",
-      insertValue: "stash{cursor}", 
+      insertValue: "stash{cursor}",
       description: "Temporarily stores all the modified tracked files",
       subcommands: [
         {

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -184,6 +184,7 @@ export const npmScriptsGenerator: Fig.Generator = {
             name: scriptName,
             icon,
             description: scriptContents as string,
+            priority: 51,
             /**
              * If there are custom definitions for the scripts
              * we want to override the default values


### PR DESCRIPTION
This does not affect `npm` since the scripts are only visible with `npm run`, but it improves the usability of `yarn` because the scripts are at the top