### PR TITLE
Fix(git): autocomplete branch name in git-reset

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -4800,7 +4800,11 @@ const completionSpec: Fig.Spec = {
         isOptional: true,
         isVariadic: true,
         suggestions: headSuggestions,
-        generators: [gitGenerators.treeish, gitGenerators.commits],
+        generators: [
+          gitGenerators.treeish,
+          gitGenerators.commits,
+          gitGenerators.remoteLocalBranches,
+        ],
       },
     },
     {


### PR DESCRIPTION


Fixes: #1216 

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix and autocomplete branch name in `git-reset` commit object.

**What is the current behavior? (You can also link to an open issue here)**

`git-reset` is only autocompleted commit hash and `HEAD`.

**What is the new behavior (if this is a feature change)?**

`git-reset` is autocompletedd commit hash and `HEAD` and local/remote branches.

**Additional info:**

According to spec, `git-reset` can get `<commit>` https://git-scm.com/docs/git-reset, and `<commit>` indicates git commit object (FYI: https://git-scm.com/docs/git#Documentation/git.txt-ltcommitgt), and branch is just a pointer to the git commit object, so `git-reset` should be autocompleted also with branch names. 

> A branch in Git is simply a lightweight movable pointer to one of these commits

https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell

(I think there are many point to fix in the same way...)