### PR TITLE
fix(git): autocomplete branch name in git-diff

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -4725,6 +4725,7 @@ const completionSpec: Fig.Spec = {
         suggestions: headSuggestions,
         generators: [
           gitGenerators.commits,
+          gitGenerators.remoteLocalBranches,
           gitGenerators.getChangedTrackedFiles,
         ],
       },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Rel: #1392 

autocomplete branch name in `git-diff` commit object.

**What is the current behavior? (You can also link to an open issue here)**

`git-diff` is only autocompleted commit hash and HEAD.

**What is the new behavior (if this is a feature change)?**

`git-diff` is autocompletedd commit hash and HEAD and local/remote branches.

**Additional info:**

I found out in #1392 that according to the specification `<commit>` includes git branch because git branch is just a pointer of git’s commit object. So fig can autocomplete git’s branch name with a part of `git-` command  same as #1392 `git-reset`. Of course, I do not think fig should autocomplete git’s branch name with all of `git-` command which get `<commit>` as a argument, but it is good to make fig autocomplete git’s branch name if it is useful and correct.