### PR TITLE
Auto install peer dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=true


### PR DESCRIPTION
Small change but quite helpful. When I am installing dependencies via `pnpm i`, it fails and says there are unmet peer dependencies.
<details>
<summary>Full error</summary>
<br>

```
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

.
├─┬ @typescript-eslint/eslint-plugin
│ └── ✕ missing peer @typescript-eslint/parser@^5.0.0
└─┬ danger
  └─┬ @octokit/rest
    └─┬ @octokit/plugin-request-log
      └── ✕ missing peer @octokit/core@>=3
Peer dependencies that should be installed:
  @octokit/core@>=3                 @typescript-eslint/parser@^5.0.0  

hint: If you want peer dependencies to be automatically installed, add "auto-install-peers=true" to an .npmrc file at the root of your project.
hint: If you don't want pnpm to fail on peer dependency issues, add "strict-peer-dependencies=false" to an .npmrc file at the root of your project.
```
</details>

If you clicked that drop-down and saw that "hint", you might be able to guess what this PR does. I've told it to install those automatically, therefore fixing my problem and hopefully the same problem for others. Hopefully. I think so.