### PR TITLE
fix(vercel): Update env spec suggestions (#1430)

### DIFF
--- a/src/vercel.ts
+++ b/src/vercel.ts
@@ -186,10 +186,6 @@ const completionSpec: Fig.Spec = {
           description: "Add an environment variable",
           args: [
             {
-              name: "type",
-              description: "Type of env variable to add",
-            },
-            {
               name: "name",
               description: "Name of the env variable to add",
             },

--- a/src/vercel.ts
+++ b/src/vercel.ts
@@ -198,15 +198,15 @@ const completionSpec: Fig.Spec = {
               description: "Environment to add the variable to",
               suggestions: [
                 {
-                  name: "Production",
+                  name: "production",
                   icon: "🔵",
                 },
                 {
-                  name: "Preview",
+                  name: "preview",
                   icon: "🟠",
                 },
                 {
-                  name: "Development",
+                  name: "development",
                   icon: "🟡",
                 },
               ],
@@ -227,15 +227,15 @@ const completionSpec: Fig.Spec = {
               description: "Environment to remove from",
               suggestions: [
                 {
-                  name: "Production",
+                  name: "production",
                   icon: "🔵",
                 },
                 {
-                  name: "Preview",
+                  name: "preview",
                   icon: "🟠",
                 },
                 {
-                  name: "Development",
+                  name: "development",
                   icon: "🟡",
                 },
               ],


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
#1430

**What is the new behavior (if this is a feature change)?**
- removes deprecated 'type' arg in `vercel env rm`
- lowercases environment suggestions in `vercel env add` and `vercel env rm`

**Additional info:**
See #1430 for detailed screenshots and relevant vercel blobs