### PR TITLE
feat(ssh): suggest hosts from `Include`d config files

### DIFF
--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -1,9 +1,5 @@
 const knownHostRegex = /(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9]+/; // will match numerical IPs as well as domains/subdomains
 
-type ExecuteShellCommandFunction = (
-  commandToExecute: string
-) => Promise<string>;
-
 const resolveAbsolutePath = (path: string, basePath: string): string => {
   if (path.startsWith("/") || path.startsWith("~/") || path === "~") {
     return path;
@@ -14,7 +10,7 @@ const resolveAbsolutePath = (path: string, basePath: string): string => {
 
 const getConfigLines = async (
   file: string,
-  executeShellCommand: ExecuteShellCommandFunction,
+  executeShellCommand: Fig.ExecuteShellCommandFunction,
   basePath
 ) => {
   const absolutePath = resolveAbsolutePath(file, basePath);

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -25,7 +25,10 @@ export const configHosts: Fig.Generator = {
   postProcess: function (out) {
     return out
       .split("\n")
-      .filter((line) => line.trim().startsWith("Host ") && !line.includes("*"))
+      .filter(
+        (line) =>
+          line.trim().toLowerCase().startsWith("host ") && !line.includes("*")
+      )
       .map((host) => ({
         name: host.split(" ")[1],
         description: "SSH host",

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -5,7 +5,7 @@ const resolveAbsolutePath = (path: string, basePath: string): string => {
     return path;
   }
 
-  return basePath.replace(/\/$/, "") + "/" + path;
+  return basePath + (basePath.endsWith("/") ? "" : "/") + path;
 };
 
 const getConfigLines = async (


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Spec update for `ssh`

**What is the current behavior? (You can also link to an open issue here)**
If `~/.ssh/config` file includes `Include` statement - fig doesn't provide suggestion from the included file [Bug: closes #1187]

**What is the new behavior (if this is a feature change)?**
The `ssh` spec now suggests hosts that are defined in config file included from the `~/.ssh/config` file

**Additional info:**
Solves this case (`customer-main-site` will be suggested as a host for `ssh ` command

`~/.ssh/config`:
```
Host my-personal-site
     HostName 172.0.0.1
     User siteuser

Include config.d/*
```

`~/.ssh/config.d/customer`:

```
Host customer-main-site
   HostName ...
   User blabla
```

     

This PR also resolves #1450 issue with the suggestions when `~/.ssh/config` contains lowercase `Host` configurations
