### PR TITLE
feat: add tsx completion spec

### DIFF
--- a/src/tsx.ts
+++ b/src/tsx.ts
@@ -37,7 +37,7 @@ const completionSpec: Fig.Spec = {
       description: "Disable clearing the screen on rerun",
       isPersistent: true,
       insertValue: "--clear-screen=false",
-      dependsOn: ["watch", "tsx"],
+      dependsOn: ["watch"],
       args: scriptPathArgs,
     },
 

--- a/src/tsx.ts
+++ b/src/tsx.ts
@@ -1,0 +1,64 @@
+import { filepaths } from "@fig/autocomplete-generators";
+
+const scriptPathArgs: Fig.Arg = {
+  name: "script path",
+  isScript: true,
+  generators: filepaths({
+    extensions: ["ts"],
+    editFileSuggestions: { priority: 76 },
+    editFolderSuggestions: { priority: 70 },
+  }),
+};
+
+const completionSpec: Fig.Spec = {
+  name: "tsx",
+  description: "Run TypeScript file using tsx",
+  subcommands: [
+    {
+      name: "watch",
+      description: "Run the script and watch for changes",
+      args: scriptPathArgs,
+    },
+  ],
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for tsx",
+      isPersistent: true,
+    },
+    {
+      name: "--no-cache",
+      description: "Disable caching",
+      isPersistent: true,
+    },
+
+    {
+      name: "--clear-screen",
+      description: "Disable clearing the screen on rerun",
+      isPersistent: true,
+      insertValue: "--clear-screen=false",
+      dependsOn: ["watch", "tsx"],
+      args: scriptPathArgs,
+    },
+
+    {
+      name: ["-v", "--version"],
+      description: "Show version",
+    },
+    {
+      name: "--tsconfig",
+      description: "Custom tsconfig.json path",
+      args: {
+        name: "tsconfig.json path",
+        generators: filepaths({
+          extensions: ["json"],
+          editFileSuggestions: { priority: 76 },
+          editFolderSuggestions: { priority: 70 },
+        }),
+      },
+    },
+  ],
+
+  args: scriptPathArgs,
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature: adds spec for [`tsx`](https://github.com/esbuild-kit/tsx)

**What is the current behavior? (You can also link to an open issue here)**
There is no autocomplete tool, that I am aware of, for the `tsx` CLI.

**What is the new behavior (if this is a feature change)?**
This pull request adds autocompletion for all command line options that `tsx` accepts.

**Additional info:**