### PR TITLE
feat: add specs for c++ compilers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withfig/autocomplete",
-  "version": "2.364.0",
+  "version": "2.365.0",
   "description": "Fig Autocomplete Specs",
   "schemaVersion": "v7",
   "main": "./build/index",

--- a/src/c++.ts
+++ b/src/c++.ts
@@ -1,0 +1,6 @@
+const completionSpec: Fig.Spec = {
+  name: "c++",
+  description: "C++ compiler",
+  loadSpec: "clang++",
+};
+export default completionSpec;

--- a/src/c++.ts
+++ b/src/c++.ts
@@ -1,6 +1,6 @@
-import clang from "./clang++";
+import clangpp from "./clang++";
 const completionSpec: Fig.Spec = {
-  ...clang,
+  ...clangpp,
   name: "c++",
   description: "C++ compiler",
 };

--- a/src/c++.ts
+++ b/src/c++.ts
@@ -1,6 +1,7 @@
+import clang from "./clang++";
 const completionSpec: Fig.Spec = {
+  ...clang,
   name: "c++",
   description: "C++ compiler",
-  loadSpec: "clang++",
 };
 export default completionSpec;

--- a/src/clang++.ts
+++ b/src/clang++.ts
@@ -1,0 +1,6 @@
+const completionSpec: Fig.Spec = {
+  name: "clang++",
+  description: "Clang LLVM compiler for C++",
+  loadSpec: "clang",
+};
+export default completionSpec;

--- a/src/clang++.ts
+++ b/src/clang++.ts
@@ -1,6 +1,7 @@
+import clang from "./clang";
 const completionSpec: Fig.Spec = {
+  ...clang,
   name: "clang++",
   description: "Clang LLVM compiler for C++",
-  loadSpec: "clang",
 };
 export default completionSpec;

--- a/src/clang++.ts
+++ b/src/clang++.ts
@@ -1,31 +1,33 @@
-import clang from "./clang";
+import {
+  clangBase,
+  stdCPPSuggestions,
+  stdOpenCLCPPSuggestions,
+  stdHLSLSuggestions,
+} from "./clang";
+
 const completionSpec: Fig.Spec = {
-  ...clang,
+  ...clangBase,
   name: "clang++",
   description: "Clang LLVM compiler for C++",
   options: [
-    ...(clang as Fig.Subcommand).options,
+    ...(clangBase as Fig.Subcommand).options,
     {
       name: "-std",
       description: "Language standard to compile for",
       args: {
         name: "value",
         suggestions: [
-          "c++98",
-          "c++03",
-          "c++11",
-          "c++14",
-          "c++17",
-          "c++20",
-          "c++2b",
-
-          "gnu++98",
-          "gnu++03",
-          "gnu++11",
-          "gnu++14",
-          "gnu++17",
-          "gnu++20",
-          "gnu++2b",
+          ...stdCPPSuggestions,
+          ...stdOpenCLCPPSuggestions,
+          {
+            name: "cuda",
+            description: "NVIDIA CUDA(tm)",
+          },
+          {
+            name: "hip",
+            description: "HIP",
+          },
+          ...stdHLSLSuggestions,
         ],
       },
       requiresSeparator: true,

--- a/src/clang++.ts
+++ b/src/clang++.ts
@@ -3,5 +3,33 @@ const completionSpec: Fig.Spec = {
   ...clang,
   name: "clang++",
   description: "Clang LLVM compiler for C++",
+  options: [
+    ...(clang as Fig.Subcommand).options,
+    {
+      name: "-std",
+      description: "Language standard to compile for",
+      args: {
+        name: "value",
+        suggestions: [
+          "c++98",
+          "c++03",
+          "c++11",
+          "c++14",
+          "c++17",
+          "c++20",
+          "c++2b",
+
+          "gnu++98",
+          "gnu++03",
+          "gnu++11",
+          "gnu++14",
+          "gnu++17",
+          "gnu++20",
+          "gnu++2b",
+        ],
+      },
+      requiresSeparator: true,
+    },
+  ],
 };
 export default completionSpec;

--- a/src/clang.ts
+++ b/src/clang.ts
@@ -1,4 +1,191 @@
-const completionSpec: Fig.Spec = {
+export const stdCSuggestions: Fig.Suggestion[] = [
+  {
+    name: ["c89", "c90", "iso9899:1990"],
+    description: "ISO C 1990",
+  },
+  {
+    name: "iso9899:199409",
+    description: "ISO C 1990 with amendment 1",
+  },
+  {
+    name: ["gnu89", "gnu90"],
+    description: "ISO C 1990 with GNU extensions",
+  },
+  {
+    name: ["c99", "iso9899:1999"],
+    description: "ISO C 1999",
+  },
+  {
+    name: "gnu99",
+    description: "ISO C 1999 with GNU extensions",
+  },
+  {
+    name: ["c11", "iso9899:2011"],
+    description: "ISO C 2011",
+  },
+  {
+    name: "gnu11",
+    description: "ISO C 2011 with GNU extensions",
+  },
+  {
+    name: ["c17", "iso9899:2017", "c18", "iso9899:2018"],
+    description: "ISO C 2017",
+  },
+  {
+    name: ["gnu17", "gnu18"],
+    description: "ISO C 2017 with GNU extensions",
+  },
+  {
+    name: "c2x",
+    description: "Working Draft for ISO C2x",
+  },
+  {
+    name: "gnu2x",
+    description: "Working Draft for ISO C2x with GNU extensions",
+  },
+];
+
+export const stdCPPSuggestions: Fig.Suggestion[] = [
+  {
+    name: ["c++98", "c++03"],
+    description: "ISO C++ 1998 with amendments",
+  },
+  {
+    name: ["gnu++98", "gnu++03"],
+    description: "ISO C++ 1998 with amendments and GNU extensions",
+  },
+  {
+    name: "c++11",
+    description: "ISO C++ 2011 with amendments",
+  },
+  {
+    name: "gnu++11",
+    description: "ISO C++ 2011 with amendments and GNU extensions",
+  },
+  {
+    name: "c++14",
+    description: "ISO C++ 2014 with amendments",
+  },
+  {
+    name: "gnu++14",
+    description: "ISO C++ 2014 with amendments and GNU extensions",
+  },
+  {
+    name: "c++17",
+    description: "ISO C++ 2017 with amendments",
+  },
+  {
+    name: "gnu++17",
+    description: "ISO C++ 2017 with amendments and GNU extensions",
+  },
+  {
+    name: "c++20",
+    description: "ISO C++ 2020 DIS",
+  },
+  {
+    name: "gnu++20",
+    description: "ISO C++ 2020 DIS with GNU extensions",
+  },
+  {
+    name: "c++2b",
+    description: "Working draft for ISO C++ 2023 DIS",
+  },
+  {
+    name: "gnu++2b",
+    description: "Working draft for ISO C++ 2023 DIS with GNU extensions",
+  },
+];
+
+export const stdOpenCLSuggestions: Fig.Suggestion[] = [
+  {
+    name: "cl1.0",
+    description: "OpenCL 1.0",
+  },
+  {
+    name: "cl1.1",
+    description: "OpenCL 1.1",
+  },
+  {
+    name: "cl1.2",
+    description: "OpenCL 1.2",
+  },
+  {
+    name: "cl2.0",
+    description: "OpenCL 2.0",
+  },
+  {
+    name: "cl3.0",
+    description: "OpenCL 3.0",
+  },
+];
+
+export const stdOpenCLCPPSuggestions: Fig.Suggestion[] = [
+  {
+    name: ["clc++", "clc++1.0"],
+    description: "C++ for OpenCL 1.0",
+  },
+  {
+    name: "clc++2021",
+    description: "C++ for OpenCL 2021",
+  },
+];
+
+export const stdHLSLSuggestions: Fig.Suggestion[] = [
+  {
+    name: "hlsl",
+    description: "High Level Shader Language",
+  },
+  {
+    name: "hlsl2015",
+    description: "High Level Shader Language 2015",
+  },
+  {
+    name: "hlsl2016",
+    description: "High Level Shader Language 2016",
+  },
+  {
+    name: "hlsl2017",
+    description: "High Level Shader Language 2017",
+  },
+  {
+    name: "hlsl2018",
+    description: "High Level Shader Language 2018",
+  },
+  {
+    name: "hlsl2021",
+    description: "High Level Shader Language 2021",
+  },
+  {
+    name: "hlsl202x",
+    description: "High Level Shader Language 202x",
+  },
+];
+
+export const stdOption: Fig.Option = {
+  name: "-std",
+  description: "Language standard to compile for",
+  args: {
+    name: "value",
+    suggestions: [
+      ...stdCSuggestions,
+      ...stdCPPSuggestions,
+      ...stdOpenCLSuggestions,
+      ...stdOpenCLCPPSuggestions,
+      {
+        name: "cuda",
+        description: "NVIDIA CUDA(tm)",
+      },
+      {
+        name: "hip",
+        description: "HIP",
+      },
+      ...stdHLSLSuggestions,
+    ],
+  },
+  requiresSeparator: true,
+};
+
+export const clangBase: Fig.Spec = {
   name: "clang",
   description: "Clang LLVM compiler",
   args: {
@@ -4404,14 +4591,6 @@ const completionSpec: Fig.Spec = {
       description: "Use the static host OpenMP runtime while linking",
     },
     {
-      name: "-std",
-      description: "Language standard to compile for",
-      args: {
-        name: "value",
-      },
-      requiresSeparator: true,
-    },
-    {
       name: "-stdlib++-isystem",
       description: "Use directory as the C++ standard library include path",
       args: {
@@ -4680,4 +4859,8 @@ const completionSpec: Fig.Spec = {
   ],
 };
 
+const completionSpec: Fig.Spec = {
+  ...clangBase,
+  options: [...clangBase.options, stdOption],
+};
 export default completionSpec;

--- a/src/g++.ts
+++ b/src/g++.ts
@@ -1,7 +1,35 @@
-import gcc from "./gcc"
+import gcc from "./gcc";
 const completionSpec: Fig.Spec = {
   ...gcc,
   name: "g++",
   description: "The default C++ compiler for most linux distributions",
+  options: [
+    ...(gcc as Fig.Subcommand).options,
+    {
+      name: "-std",
+      description: "Language standard to compile for",
+      args: {
+        name: "value",
+        suggestions: [
+          "c++98",
+          "c++03",
+          "c++11",
+          "c++14",
+          "c++17",
+          "c++20",
+          "c++2b",
+
+          "gnu++98",
+          "gnu++03",
+          "gnu++11",
+          "gnu++14",
+          "gnu++17",
+          "gnu++20",
+          "gnu++2b",
+        ],
+      },
+      requiresSeparator: true,
+    },
+  ],
 };
 export default completionSpec;

--- a/src/g++.ts
+++ b/src/g++.ts
@@ -1,0 +1,6 @@
+const completionSpec: Fig.Spec = {
+  name: "g++",
+  description: "The default C++ compiler for most linux distributions",
+  loadSpec: "gcc",
+};
+export default completionSpec;

--- a/src/g++.ts
+++ b/src/g++.ts
@@ -1,32 +1,18 @@
-import gcc from "./gcc";
+import { gccBase } from "./gcc";
+import { stdCPPSuggestions } from "./clang";
+
 const completionSpec: Fig.Spec = {
-  ...gcc,
+  ...gccBase,
   name: "g++",
   description: "The default C++ compiler for most linux distributions",
   options: [
-    ...(gcc as Fig.Subcommand).options,
+    ...(gccBase as Fig.Subcommand).options,
     {
       name: "-std",
       description: "Language standard to compile for",
       args: {
         name: "value",
-        suggestions: [
-          "c++98",
-          "c++03",
-          "c++11",
-          "c++14",
-          "c++17",
-          "c++20",
-          "c++2b",
-
-          "gnu++98",
-          "gnu++03",
-          "gnu++11",
-          "gnu++14",
-          "gnu++17",
-          "gnu++20",
-          "gnu++2b",
-        ],
+        suggestions: [...stdCPPSuggestions],
       },
       requiresSeparator: true,
     },

--- a/src/gcc.ts
+++ b/src/gcc.ts
@@ -1,4 +1,16 @@
-const completionSpec: Fig.Spec = {
+import { stdCSuggestions, stdCPPSuggestions } from "./clang";
+
+export const stdOption: Fig.Option = {
+  name: "-std",
+  description: "Language standard to compile for",
+  args: {
+    name: "value",
+    suggestions: [...stdCSuggestions, ...stdCPPSuggestions],
+  },
+  requiresSeparator: true,
+};
+
+export const gccBase: Fig.Spec = {
   name: "gcc",
   description: "The default compiler for most linux distributions",
   options: [
@@ -3159,11 +3171,6 @@ const completionSpec: Fig.Spec = {
       description: "Use the static host OpenMP runtime while linking",
     },
     {
-      name: "-std",
-      description: "Language standard to compile for",
-      args: { name: "value", description: "Value" },
-    },
-    {
       name: "-stdlib++-isystem",
       description: "Use directory as the C++ standard library include path",
       args: {
@@ -3323,4 +3330,8 @@ const completionSpec: Fig.Spec = {
   ],
 };
 
+const completionSpec: Fig.Spec = {
+  ...gccBase,
+  options: [...gccBase.options, stdOption],
+};
 export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the new behavior (if this is a feature change)?**
Completion for `clang++`, `c++` (same as `clang`) and `g++` (same as `gcc`) 