### PR TITLE
feat: add capacitor completion spec

### DIFF
--- a/src/cap.ts
+++ b/src/cap.ts
@@ -1,0 +1,8 @@
+import capacitor from "./capacitor";
+
+const completionSpec: Fig.Spec = {
+  ...capacitor,
+  name: "cap",
+};
+
+export default completionSpec;

--- a/src/capacitor.ts
+++ b/src/capacitor.ts
@@ -1,0 +1,135 @@
+const platforms: Fig.Suggestion[] = [
+  { name: "android", icon: "fig://icon?type=android" },
+  { name: "ios", icon: "fig://icon?type=apple" },
+];
+
+const helpOption: Fig.Option = {
+  name: ["--help", "-h"],
+  description:
+    "Output usage information. Can be used with individual commands too",
+};
+
+const completionSpec: Fig.Spec = {
+  name: "capacitor",
+  description:
+    "The Capacitor command-line interface (CLI) tool is used to develop Capacitor apps",
+  icon: "https://capacitorjs.com/docs/img/meta/favicon.png",
+  subcommands: [
+    {
+      name: "add",
+      description: "Add a native platform project to your app",
+      args: {
+        name: "platform",
+        suggestions: platforms,
+      },
+      options: [helpOption],
+    },
+    {
+      name: "copy",
+      description:
+        "Copy the web app build and Capacitor configuration file into the native platform project. Run this each time you make changes to your web app or change a configuration value",
+      priority: 51,
+      args: {
+        name: "platform",
+        suggestions: platforms,
+        isOptional: true,
+      },
+      options: [helpOption],
+    },
+    {
+      name: "ls",
+      description: "List all installed Cordova and Capacitor plugins",
+      args: {
+        name: "platform",
+        suggestions: platforms,
+        isOptional: true,
+      },
+      options: [helpOption],
+    },
+    {
+      name: "open",
+      description:
+        "Opens the native project workspace in the specified native IDE (Xcode for iOS, Android Studio for Android)",
+      priority: 51,
+      args: {
+        name: "platform",
+        suggestions: platforms,
+      },
+      options: [helpOption],
+    },
+    {
+      name: "run",
+      description:
+        "Opens the native project workspace in the specified native IDE (Xcode for iOS, Android Studio for Android)",
+      priority: 51,
+      args: {
+        name: "platform",
+        suggestions: platforms,
+      },
+
+      options: [
+        {
+          name: "--list",
+          description:
+            "Print a list of target devices available to the given platform",
+        },
+        {
+          name: "--target",
+          description: "Run on a specific target device",
+          args: {
+            name: "target",
+          },
+        },
+        helpOption,
+      ],
+    },
+    {
+      name: "sync",
+      description: "This command runs copy and then update",
+      args: {
+        name: "platform",
+        suggestions: platforms,
+        isOptional: true,
+      },
+      options: [
+        {
+          name: "--deployment",
+          description:
+            "Podfile.lock won't be deleted and pod install will use --deployment option",
+        },
+        {
+          name: "--inline",
+          description:
+            "After syncing, all JS source maps will be inlined allowing for debugging an Android Web View in Chromium based browsers",
+        },
+        helpOption,
+      ],
+    },
+    {
+      name: "update",
+      description:
+        "Updates the native plugins and dependencies referenced in package.json",
+      args: {
+        name: "platform",
+        suggestions: platforms,
+        isOptional: true,
+      },
+      options: [
+        {
+          name: "--deployment",
+          description:
+            "Podfile.lock won't be deleted and pod install will use --deployment option",
+        },
+        helpOption,
+      ],
+    },
+  ],
+  options: [
+    helpOption,
+    {
+      name: ["--version", "-V"],
+      description: "Output the version number",
+    },
+  ],
+};
+export default completionSpec;

--- a/src/capacitor.ts
+++ b/src/capacitor.ts
@@ -3,12 +3,6 @@ const platforms: Fig.Suggestion[] = [
   { name: "ios", icon: "fig://icon?type=apple" },
 ];
 
-const helpOption: Fig.Option = {
-  name: ["--help", "-h"],
-  description:
-    "Output usage information. Can be used with individual commands too",
-};
-
 const completionSpec: Fig.Spec = {
   name: "capacitor",
   description:
@@ -22,7 +16,6 @@ const completionSpec: Fig.Spec = {
         name: "platform",
         suggestions: platforms,
       },
-      options: [helpOption],
     },
     {
       name: "copy",
@@ -34,7 +27,6 @@ const completionSpec: Fig.Spec = {
         suggestions: platforms,
         isOptional: true,
       },
-      options: [helpOption],
     },
     {
       name: "ls",
@@ -44,7 +36,6 @@ const completionSpec: Fig.Spec = {
         suggestions: platforms,
         isOptional: true,
       },
-      options: [helpOption],
     },
     {
       name: "open",
@@ -55,7 +46,6 @@ const completionSpec: Fig.Spec = {
         name: "platform",
         suggestions: platforms,
       },
-      options: [helpOption],
     },
     {
       name: "run",
@@ -80,7 +70,6 @@ const completionSpec: Fig.Spec = {
             name: "target",
           },
         },
-        helpOption,
       ],
     },
     {
@@ -102,7 +91,6 @@ const completionSpec: Fig.Spec = {
           description:
             "After syncing, all JS source maps will be inlined allowing for debugging an Android Web View in Chromium based browsers",
         },
-        helpOption,
       ],
     },
     {
@@ -120,12 +108,16 @@ const completionSpec: Fig.Spec = {
           description:
             "Podfile.lock won't be deleted and pod install will use --deployment option",
         },
-        helpOption,
       ],
     },
   ],
   options: [
-    helpOption,
+    {
+      name: ["--help", "-h"],
+      description:
+        "Output usage information. Can be used with individual commands too",
+      isPersistent: true,
+    },
     {
       name: ["--version", "-V"],
       description: "Output the version number",

--- a/src/npx.ts
+++ b/src/npx.ts
@@ -117,6 +117,14 @@ const suggestions: Fig.Suggestion[] = [
   {
     name: "pod-install",
   },
+  {
+    name: "capacitor",
+    icon: "https://capacitorjs.com/docs/img/meta/favicon.png",
+  },
+  {
+    name: "cap",
+    icon: "https://capacitorjs.com/docs/img/meta/favicon.png",
+  },
 ];
 
 const completionSpec: Fig.Spec = {

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -32,6 +32,8 @@ export const nodeClis = [
   "@redwoodjs/core",
   "create-completion-spec",
   "@fig/publish-spec-to-team",
+  "capacitor",
+  "cap",
 ];
 
 type SearchResult = {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature

**What is the current behavior? (You can also link to an open issue here)**
n/a

**What is the new behavior (if this is a feature change)?**
Adds a new spec for [capacitor](https://capacitorjs.com/docs/cli)

**Additional info:**
I also added a `cap.ts` spec file because the capacitor CLI can be used either with `capacitor` or `cap` ([Reference](https://github.com/ionic-team/capacitor/blob/22c2fb505ee80dfce335c05f841ffafd21b7842c/cli/package.json#L34)). I was not sure if this is ok or if there is a better way of doing this. If you prefer not to have the second spec I can remove it again. 

