### PR TITLE
feat(trivy): add additional `--format` suggestions

### DIFF
--- a/src/trivy.ts
+++ b/src/trivy.ts
@@ -166,6 +166,27 @@ const formatOptions: Fig.Option = {
   },
 };
 
+const fsFormatOptions: Fig.Option = {
+  name: ["--format", "-f"],
+  description:
+    'Format (table, json, sarif, template) (default: "table") [$TRIVY_FORMAT]',
+  args: {
+    name: "format",
+    suggestions: [
+      "table",
+      "json",
+      "sarif",
+      "template",
+      "cyclonedx",
+      "spdx",
+      "spdx-json",
+      "github",
+      "cosign-vuln",
+    ],
+    default: "table",
+  },
+};
+
 const exitCodeOption: Fig.Option = {
   name: "--exit-code",
   description:
@@ -350,6 +371,7 @@ const completionSpec: Fig.Spec = {
         "Scan local filesystem for language-specific dependencies and config files",
       subcommands: [
         ...scanOptions,
+        fsFormatOptions,
         skipPolicyUpdateOption,
         ignoreUnfixedOption,
         ...regoPolicyOptions,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
The spec for trivy seems a bit broken in regards of `sbom` scans. Since i'm not too familiar with the trivy cli i only added the additional `--format`'s for the `trivy fs` command.

**What is the current behavior? (You can also link to an open issue here)**
`trivy fs --format` is missing some formats.

**What is the new behavior (if this is a feature change)?**
`trivy fs --format` now includes additional formats.

**Additional info:**
The spec for `trivy sbom` seems to need changes as well.