### PR TITLE
feat: add `xcodes` completion spec

### DIFF
--- a/src/xcodes.ts
+++ b/src/xcodes.ts
@@ -1,0 +1,270 @@
+const completionSpec: Fig.Spec = {
+  name: "xcodes",
+  description: "Manage the Xcode versions installed on your Mac",
+  subcommands: [
+    {
+      name: "help",
+      args: {
+        name: "command",
+        template: "help",
+        isOptional: true,
+      },
+    },
+    {
+      name: "download",
+      description: "Download a specific version of Xcode",
+      options: [
+        {
+          name: "--latest",
+          description:
+            "Update and then install the latest non-prerelease version available",
+        },
+
+        {
+          name: "--latest-prerelease",
+          description:
+            "Update and then install the latest prerelease version available, including GM seeds and GMs",
+        },
+        {
+          name: "--aria2",
+          description:
+            "The path to an aria2 executable. Searches $PATH by default",
+          args: { name: "aria2", template: "filepaths" },
+        },
+        {
+          name: "--no-aria2",
+          description:
+            "Don't use aria2 to download Xcode, even if it's available",
+        },
+        {
+          name: "--directory",
+          description:
+            "The directory where your Xcodes are installed. Defaults to /Applications",
+          args: { name: "directory", template: "folders" },
+        },
+        {
+          name: "--data-source",
+          description:
+            "The data source for available Xcode versions. (default: xcodereleases)",
+          args: { name: "dataSource", suggestions: ["xcodereleases", "apple"] },
+        },
+        { name: "--color", description: "Color the output" },
+        { name: "--no-color", description: "Do not color the output" },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information",
+        },
+      ],
+      args: {
+        name: "version",
+        description: "The version to install",
+        isOptional: true,
+      },
+    },
+    {
+      name: "install",
+      description: "Download and install a specific version of Xcode",
+      options: [
+        {
+          name: "--path",
+          description: "Local path to Xcode.xip",
+          args: { name: "path", template: "filepaths" },
+        },
+        {
+          name: "--latest",
+          description:
+            "Update and then install the latest non-prerelease version available",
+        },
+
+        {
+          name: "--latest-prerelease",
+          description:
+            "Update and then install the latest prerelease version available, including GM seeds and GMs",
+        },
+        {
+          name: "--aria2",
+          description:
+            "The path to an aria2 executable. Searches $PATH by default",
+          args: { name: "aria2", template: "filepaths" },
+        },
+        {
+          name: "--no-aria2",
+          description:
+            "Don't use aria2 to download Xcode, even if it's available",
+        },
+        {
+          name: "--experimental-unxip",
+          description:
+            "Use the experimental unxip functionality. May speed up unarchiving by up to 2-3x",
+        },
+        {
+          name: "--directory",
+          description:
+            "The directory where your Xcodes are installed. Defaults to /Applications",
+          args: { name: "directory", template: "folders" },
+        },
+        {
+          name: "--data-source",
+          description:
+            "The data source for available Xcode versions. (default: xcodereleases)",
+          args: { name: "dataSource", suggestions: ["xcodereleases", "apple"] },
+        },
+        { name: "--color", description: "Color the output" },
+        { name: "--no-color", description: "Do not color the output" },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information",
+        },
+      ],
+      args: {
+        name: "version",
+        description: "The version to install",
+        isOptional: true,
+      },
+    },
+    {
+      name: "installed",
+      description: "List the versions of Xcode that are installed",
+      options: [
+        {
+          name: "--directory",
+          description:
+            "The directory where your Xcodes are installed. Defaults to /Applications",
+          args: { name: "directory", template: "folders" },
+        },
+        { name: "--color", description: "Color the output" },
+        { name: "--no-color", description: "Do not color the output" },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information",
+        },
+      ],
+    },
+    {
+      name: "list",
+      description: "List all versions of Xcode available to install",
+      options: [
+        {
+          name: "--directory",
+          description:
+            "The directory where your Xcodes are installed. Defaults to /Applications",
+          args: { name: "directory", template: "folders" },
+        },
+        {
+          name: "--data-source",
+          description:
+            "The data source for available Xcode versions. (default: xcodereleases)",
+          args: { name: "dataSource", suggestions: ["xcodereleases", "apple"] },
+        },
+        { name: "--color", description: "Color the output" },
+        { name: "--no-color", description: "Do not color the output" },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information",
+        },
+      ],
+    },
+    {
+      name: "select",
+      description: "Change the selected Xcode",
+      options: [
+        {
+          name: ["-p", "--print-path"],
+          description: "Print the path of the selected Xcode",
+        },
+        {
+          name: "--directory",
+          description:
+            "The directory where your Xcodes are installed. Defaults to /Applications",
+          args: { name: "directory", template: "folders" },
+        },
+        { name: "--color", description: "Color the output" },
+        { name: "--no-color", description: "Do not color the output" },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information",
+        },
+      ],
+      args: {
+        name: "version-or-path",
+        description: "Version or path of Xcode to select",
+        template: "filepaths",
+        isOptional: true,
+      },
+    },
+    {
+      name: "uninstall",
+      description: "Uninstall a version of Xcode",
+      args: { name: "version", isOptional: true },
+      options: [
+        {
+          name: "--directory",
+          description:
+            "The directory where your Xcodes are installed. Defaults to /Applications",
+          args: { name: "directory", template: "folders" },
+        },
+        { name: "--color", description: "Color the output" },
+        { name: "--no-color", description: "Do not color the output" },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information",
+        },
+      ],
+    },
+    {
+      name: "update",
+      description: "Update the list of available versions of Xcode",
+      options: [
+        {
+          name: "--directory",
+          description:
+            "The directory where your Xcodes are installed. Defaults to /Applications",
+          args: { name: "directory", template: "folders" },
+        },
+        {
+          name: "--data-source",
+          description:
+            "The data source for available Xcode versions. (default: xcodereleases)",
+          args: { name: "dataSource", suggestions: ["xcodereleases", "apple"] },
+        },
+        { name: "--color", description: "Color the output" },
+        { name: "--no-color", description: "Do not color the output" },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information",
+        },
+      ],
+    },
+    {
+      name: "version",
+      description: "Print the version number of xcodes itself",
+      options: [
+        { name: "--color", description: "Color the output" },
+        { name: "--no-color", description: "Do not color the output" },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information",
+        },
+      ],
+    },
+    {
+      name: "signout",
+      description: "Clears the stored username and password",
+      options: [
+        { name: "--color", description: "Color the output" },
+        { name: "--no-color", description: "Do not color the output" },
+        {
+          name: ["--help", "-h"],
+          description: "Show help information",
+        },
+      ],
+    },
+  ],
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help information",
+    },
+  ],
+};
+export default completionSpec;

--- a/src/xcodes.ts
+++ b/src/xcodes.ts
@@ -1,9 +1,36 @@
+const processXcodeList = (out: string, tokens: string[]) =>
+  out
+    .split("\n")
+    .reverse()
+    .map((line) => ({
+      name: line.slice(0, line.indexOf(" (")),
+      icon: line.includes("Selected")
+        ? "⭐️"
+        : line.includes("Installed")
+        ? "🔨"
+        : tokens.includes("select") || tokens.includes("uninstall")
+        ? "🔨"
+        : "⬇️",
+      description: line.slice(line.indexOf("(")).replaceAll(/[\(\)]/g, ""),
+    }));
+
+const allXcodes: Fig.Generator = {
+  script: "xcodes list",
+  postProcess: processXcodeList,
+};
+
+const installedXcodes: Fig.Generator = {
+  script: "xcodes installed",
+  postProcess: processXcodeList,
+};
+
 const completionSpec: Fig.Spec = {
   name: "xcodes",
   description: "Manage the Xcode versions installed on your Mac",
   subcommands: [
     {
       name: "help",
+      icon: "ℹ️",
       args: {
         name: "command",
         template: "help",
@@ -13,6 +40,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "download",
       description: "Download a specific version of Xcode",
+      icon: "⬇️",
       options: [
         {
           name: "--latest",
@@ -50,20 +78,18 @@ const completionSpec: Fig.Spec = {
         },
         { name: "--color", description: "Color the output" },
         { name: "--no-color", description: "Do not color the output" },
-        {
-          name: ["--help", "-h"],
-          description: "Show help information",
-        },
       ],
       args: {
         name: "version",
         description: "The version to install",
         isOptional: true,
+        generators: allXcodes,
       },
     },
     {
       name: "install",
       description: "Download and install a specific version of Xcode",
+      icon: "⬇️",
       options: [
         {
           name: "--path",
@@ -111,20 +137,18 @@ const completionSpec: Fig.Spec = {
         },
         { name: "--color", description: "Color the output" },
         { name: "--no-color", description: "Do not color the output" },
-        {
-          name: ["--help", "-h"],
-          description: "Show help information",
-        },
       ],
       args: {
         name: "version",
         description: "The version to install",
         isOptional: true,
+        generators: allXcodes,
       },
     },
     {
       name: "installed",
       description: "List the versions of Xcode that are installed",
+      icon: "🔨",
       options: [
         {
           name: "--directory",
@@ -134,15 +158,12 @@ const completionSpec: Fig.Spec = {
         },
         { name: "--color", description: "Color the output" },
         { name: "--no-color", description: "Do not color the output" },
-        {
-          name: ["--help", "-h"],
-          description: "Show help information",
-        },
       ],
     },
     {
       name: "list",
       description: "List all versions of Xcode available to install",
+      icon: "🔍",
       options: [
         {
           name: "--directory",
@@ -158,15 +179,12 @@ const completionSpec: Fig.Spec = {
         },
         { name: "--color", description: "Color the output" },
         { name: "--no-color", description: "Do not color the output" },
-        {
-          name: ["--help", "-h"],
-          description: "Show help information",
-        },
       ],
     },
     {
       name: "select",
       description: "Change the selected Xcode",
+      icon: "☑️",
       options: [
         {
           name: ["-p", "--print-path"],
@@ -180,22 +198,25 @@ const completionSpec: Fig.Spec = {
         },
         { name: "--color", description: "Color the output" },
         { name: "--no-color", description: "Do not color the output" },
-        {
-          name: ["--help", "-h"],
-          description: "Show help information",
-        },
       ],
       args: {
         name: "version-or-path",
         description: "Version or path of Xcode to select",
-        template: "filepaths",
         isOptional: true,
+        generators: installedXcodes,
       },
     },
     {
       name: "uninstall",
       description: "Uninstall a version of Xcode",
-      args: { name: "version", isOptional: true },
+      icon: "❌",
+      isDangerous: true,
+      args: {
+        name: "version",
+        isOptional: true,
+        generators: installedXcodes,
+        isDangerous: true,
+      },
       options: [
         {
           name: "--directory",
@@ -205,15 +226,12 @@ const completionSpec: Fig.Spec = {
         },
         { name: "--color", description: "Color the output" },
         { name: "--no-color", description: "Do not color the output" },
-        {
-          name: ["--help", "-h"],
-          description: "Show help information",
-        },
       ],
     },
     {
       name: "update",
       description: "Update the list of available versions of Xcode",
+      icon: "🔄",
       options: [
         {
           name: "--directory",
@@ -229,10 +247,6 @@ const completionSpec: Fig.Spec = {
         },
         { name: "--color", description: "Color the output" },
         { name: "--no-color", description: "Do not color the output" },
-        {
-          name: ["--help", "-h"],
-          description: "Show help information",
-        },
       ],
     },
     {
@@ -253,10 +267,6 @@ const completionSpec: Fig.Spec = {
       options: [
         { name: "--color", description: "Color the output" },
         { name: "--no-color", description: "Do not color the output" },
-        {
-          name: ["--help", "-h"],
-          description: "Show help information",
-        },
       ],
     },
   ],
@@ -264,6 +274,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["--help", "-h"],
       description: "Show help information",
+      isPersistent: true,
     },
   ],
 };


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds completion spec for [xcodes](https://github.com/RobotsAndPencils/xcodes) CLI.

**What is the current behavior? (You can also link to an open issue here)**

n/a

**What is the new behavior (if this is a feature change)?**

Fig will show completions for `xcodes` CLI 

**Additional info:**

n/a