### PR TITLE
feat(vim): remove suggestCurrentToken

### DIFF
--- a/src/nvim.ts
+++ b/src/nvim.ts
@@ -3,7 +3,7 @@ const completionSpec: Fig.Spec = {
   description: "Hyperextensible Vim-based text editor",
   args: {
     template: ["filepaths", "folders"],
-    suggestCurrentToken: true,
+    // suggestCurrentToken: true,
   },
   parserDirectives: {
     flagsArePosixNoncompliant: true,

--- a/src/vim.ts
+++ b/src/vim.ts
@@ -4,7 +4,7 @@ const completionSpec: Fig.Spec = {
     "Vi[m] is an one of two powerhouse text editors in the Unix world, the other being EMACS",
   args: {
     template: "filepaths",
-    suggestCurrentToken: true,
+    // suggestCurrentToken: true,
   },
   options: [
     {

--- a/src/vim.ts
+++ b/src/vim.ts
@@ -1,7 +1,6 @@
 const completionSpec: Fig.Spec = {
   name: "vim",
-  description:
-    "Vi[m] is an one of two powerhouse text editors in the Unix world, the other being EMACS",
+  description: "Vi IMproved, a programmer's text editor",
   args: {
     template: "filepaths",
     // suggestCurrentToken: true,


### PR DESCRIPTION
`suggestCurrentToken` for {n,}vim args was added because someone asked for it, but it's actually _much_ more annoying this way. This PR removes it.

Maybe we should have a way to indicate preference for `suggestCurrentToken` in editor args?

```
fig settings spec.vim.suggestCurrentToken true
fig settings spec.nvim.suggestCurrentToken true
```
And in the args:

```
{
  suggestCurrentToken: "spec.nvim.suggestCurrentToken",
}
```