### PR TITLE
feat(nextflow): Add runname generator for log subcommand

### DIFF
--- a/src/nextflow.ts
+++ b/src/nextflow.ts
@@ -539,6 +539,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "log",
       description: "Print executions log and runtime info",
+      args: {
+        name: "run name",
+        generators: runname,
+      },
       options: [
         {
           name: "-after",


### PR DESCRIPTION


**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix

**What is the current behavior? (You can also link to an open issue here)**
Fig won't help the user when s/he wants to use `nextflow log` to a run name
without specifying one of the options: -but/-before/-after

**What is the new behavior (if this is a feature change)?**
Both the log subcommand and its options -but/-before/-after
accept a run name as argument. If the user provides a run name
both for the log subcommand and its other options, it's fine,
nextflow knows what to do.

Signed-off-by: Marcel Ribeiro-Dantas <mribeirodantas@seqera.io>

