### PR TITLE
fix: add description to hosts for fig access

### DIFF
--- a/src/fig/shared.ts
+++ b/src/fig/shared.ts
@@ -369,13 +369,18 @@ export const sshHostsGenerator: Fig.Generator = {
     strategy: "stale-while-revalidate",
   },
   postProcess: (out) => {
-    return (JSON.parse(out) as { nickName: string; namespace: string }[]).map(
-      (host) => ({
-        insertValue: `'@${host.namespace}/${host.nickName}'`,
-        displayName: `${host.nickName} (${host.namespace})`,
-        name: [host.namespace, host.nickName],
-      })
-    );
+    return (
+      JSON.parse(out) as {
+        nickName: string;
+        namespace: string;
+        description: string;
+      }[]
+    ).map((host) => ({
+      insertValue: `'@${host.namespace}/${host.nickName}'`,
+      displayName: `${host.nickName} (${host.namespace})`,
+      name: [host.namespace, host.nickName],
+      description: host.description,
+    }));
   },
 };
 


### PR DESCRIPTION
- Adds descriptions to hosts for `fig ssh`