### PR TITLE
feat: Add ddev spec for DDEV

### DIFF
--- a/src/ddev.ts
+++ b/src/ddev.ts
@@ -3,40 +3,40 @@ const completionSpec: Fig.Spec = {
   description: "DDEV-Local local development environment",
   subcommands: [
     {
-      name: ["auth"],
+      name: "auth",
       description: "A collection of authentication commands",
       subcommands: [
         {
-          name: ["ssh"],
+          name: "ssh",
           description:
             "Add ssh key authentication to the ddev-ssh-auth container",
           options: [
             {
               name: ["--ssh-key-path", "-d"],
-              description: "full path to ssh key directory",
-              args: [{ name: "ssh-key-path" }],
+              description: "Full path to ssh key directory",
+              args: { name: "ssh-key-path" },
             },
           ],
         },
       ],
     },
     {
-      name: ["clean"],
+      name: "clean",
       description: "Removes items ddev has created",
       options: [
         { name: ["--all", "-a"], description: "Clean all ddev projects" },
         {
-          name: ["--dry-run"],
+          name: "--dry-run",
           description: "Run the clean command without deleting",
         },
       ],
     },
     {
-      name: ["composer"],
+      name: "composer",
       description: "Executes a composer command within the web container",
       subcommands: [
         {
-          name: ["create"],
+          name: "create",
           description:
             "Executes 'composer create-project' within the web container with the arguments and flags provided",
           options: [
@@ -46,445 +46,443 @@ const completionSpec: Fig.Spec = {
             },
           ],
         },
-        { name: ["create-project"], description: "" },
+        { name: "create-project", description: "" },
       ],
     },
     {
-      name: ["config"],
+      name: "config",
       description:
         "Create or modify a ddev project configuration in the current directory",
       subcommands: [
         {
-          name: ["global"],
+          name: "global",
           description: "Change global configuration",
           options: [
             {
-              name: ["--auto-restart-containers"],
+              name: "--auto-restart-containers",
               description:
                 "If true, automatically restart containers after a reboot or docker restart",
             },
             {
-              name: ["--disable-http2"],
+              name: "--disable-http2",
               description:
                 "Optionally disable http2 in ddev-router, 'ddev global --disable-http2' or `ddev global --disable-http2=false'",
             },
             {
-              name: ["--fail-on-hook-fail"],
-              description: "If true, 'ddev start' will fail when a hook fails.",
+              name: "--fail-on-hook-fail",
+              description: "If true, 'ddev start' will fail when a hook fails",
             },
             {
-              name: ["--instrumentation-opt-in"],
-              description: "instrumentation-opt-in=true",
+              name: "--instrumentation-opt-in",
+              description: "Instrumentation-opt-in=true",
             },
             {
-              name: ["--internet-detection-timeout-ms"],
+              name: "--internet-detection-timeout-ms",
               description:
                 "Increase timeout when checking internet timeout, in milliseconds",
-              args: [
-                { name: "internet-detection-timeout-ms", default: "3000" },
-              ],
+              args: { name: "internet-detection-timeout-ms", default: "3000" },
             },
             {
-              name: ["--letsencrypt-email"],
+              name: "--letsencrypt-email",
               description:
                 "Email associated with Let's Encrypt, `ddev global --letsencrypt-email=me@example.com'",
-              args: [{ name: "letsencrypt-email" }],
+              args: { name: "letsencrypt-email" },
             },
             {
-              name: ["--mutagen-enabled"],
+              name: "--mutagen-enabled",
               description:
-                "If true, web container will use mutagen caching/asynchronous updates.",
+                "If true, web container will use mutagen caching/asynchronous updates",
             },
             {
-              name: ["--nfs-mount-enabled"],
+              name: "--nfs-mount-enabled",
               description: "Enable NFS mounting on all projects globally",
             },
             {
-              name: ["--no-bind-mounts"],
+              name: "--no-bind-mounts",
               description:
                 "If true, don't use bind-mounts - useful for environments like remote docker where bind-mounts are impossible",
             },
             {
-              name: ["--omit-containers"],
+              name: "--omit-containers",
               description: "For example, --omit-containers=dba,ddev-ssh-agent",
-              args: [{ name: "omit-containers" }],
+              args: { name: "omit-containers" },
             },
             {
-              name: ["--required-docker-compose-version"],
+              name: "--required-docker-compose-version",
               description: "Override default docker-compose version",
-              args: [{ name: "required-docker-compose-version" }],
+              args: { name: "required-docker-compose-version" },
             },
             {
-              name: ["--router-bind-all-interfaces"],
-              description: "router-bind-all-interfaces=true",
+              name: "--router-bind-all-interfaces",
+              description: "Router-bind-all-interfaces=true",
             },
             {
-              name: ["--simple-formatting"],
+              name: "--simple-formatting",
               description:
                 "If true, use simple formatting and no color for tables",
             },
             {
-              name: ["--table-style"],
+              name: "--table-style",
               description:
                 "Table style for list and describe, see ~/.ddev/global_config.yaml for values",
-              args: [{ name: "table-style" }],
+              args: { name: "table-style" },
             },
             {
-              name: ["--use-docker-compose-from-path"],
+              name: "--use-docker-compose-from-path",
               description:
                 "If true, use docker-compose from path instead of private ~/.ddev/bin/docker-compose",
             },
             {
-              name: ["--use-hardened-images"],
+              name: "--use-hardened-images",
               description:
-                "If true, use more secure 'hardened' images for an actual internet deployment.",
+                "If true, use more secure 'hardened' images for an actual internet deployment",
             },
             {
-              name: ["--use-letsencrypt"],
+              name: "--use-letsencrypt",
               description:
                 "Enables experimental Let's Encrypt integration, 'ddev global --use-letsencrypt' or `ddev global --use-letsencrypt=false'",
             },
             {
-              name: ["--web-environment"],
+              name: "--web-environment",
               description:
                 'Set the environment variables in the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"',
-              args: [{ name: "web-environment" }],
+              args: { name: "web-environment" },
             },
             {
-              name: ["--web-environment-add"],
+              name: "--web-environment-add",
               description:
                 'Append environment variables to the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"',
-              args: [{ name: "web-environment-add" }],
+              args: { name: "web-environment-add" },
             },
           ],
         },
       ],
       options: [
         {
-          name: ["--additional-fqdns"],
+          name: "--additional-fqdns",
           description: "A comma-delimited list of FQDNs for the project",
-          args: [{ name: "additional-fqdns" }],
+          args: { name: "additional-fqdns" },
         },
         {
-          name: ["--additional-hostnames"],
+          name: "--additional-hostnames",
           description: "A comma-delimited list of hostnames for the project",
-          args: [{ name: "additional-hostnames" }],
+          args: { name: "additional-hostnames" },
         },
         {
-          name: ["--apptype"],
+          name: "--apptype",
           description:
-            "Provide the project type (one of backdrop, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress). This is autodetected and this flag is necessary only to override the detection. This is the same as --project-type and is included only for backwards compatibility.",
+            "Provide the project type (one of backdrop, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress). This is autodetected and this flag is necessary only to override the detection. This is the same as --project-type and is included only for backwards compatibility",
           hidden: true,
-          args: [{ name: "apptype" }],
+          args: { name: "apptype" },
         },
         {
-          name: ["--auto"],
-          description: "Automatically run config without prompting.",
+          name: "--auto",
+          description: "Automatically run config without prompting",
         },
         {
-          name: ["--bind-all-interfaces"],
+          name: "--bind-all-interfaces",
           description:
             "Bind host ports on all interfaces, not just on localhost network interface",
         },
         {
-          name: ["--composer-root"],
+          name: "--composer-root",
           description:
             "Overrides the default composer root directory for the web service",
-          args: [{ name: "composer-root" }],
+          args: { name: "composer-root" },
         },
         {
-          name: ["--composer-root-default"],
+          name: "--composer-root-default",
           description: "Unsets a web service composer root directory override",
         },
         {
-          name: ["--composer-version"],
+          name: "--composer-version",
           description:
-            'Specify override for composer version in web container. This may be "", "1", "2", "2.2", "stable", "preview", "snapshot" or a specific version.',
-          args: [{ name: "composer-version" }],
+            'Specify override for composer version in web container. This may be "", "1", "2", "2.2", "stable", "preview", "snapshot" or a specific version',
+          args: { name: "composer-version" },
         },
         {
-          name: ["--create-docroot"],
+          name: "--create-docroot",
           description: "Prompts ddev to create the docroot if it doesn't exist",
         },
         {
-          name: ["--database"],
+          name: "--database",
           description:
             "Specify the database type:version to use. Defaults to mariadb:10.4",
-          args: [{ name: "database" }],
+          args: { name: "database" },
         },
         {
-          name: ["--db-image"],
+          name: "--db-image",
           description: "Sets the db container image",
-          args: [{ name: "db-image" }],
+          args: { name: "db-image" },
         },
         {
-          name: ["--db-image-default"],
+          name: "--db-image-default",
           description:
             "Sets the default db container image for this ddev version",
         },
         {
-          name: ["--db-working-dir"],
+          name: "--db-working-dir",
           description:
             "Overrides the default working directory for the db service",
-          args: [{ name: "db-working-dir" }],
+          args: { name: "db-working-dir" },
         },
         {
-          name: ["--db-working-dir-default"],
+          name: "--db-working-dir-default",
           description: "Unsets a db service working directory override",
         },
         {
-          name: ["--dba-image"],
+          name: "--dba-image",
           description: "Sets the dba container image",
-          args: [{ name: "dba-image" }],
+          args: { name: "dba-image" },
         },
         {
-          name: ["--dba-image-default"],
+          name: "--dba-image-default",
           description:
             "Sets the default dba container image for this ddev version",
         },
         {
-          name: ["--dba-working-dir"],
+          name: "--dba-working-dir",
           description:
             "Overrides the default working directory for the dba service",
-          args: [{ name: "dba-working-dir" }],
+          args: { name: "dba-working-dir" },
         },
         {
-          name: ["--dba-working-dir-default"],
+          name: "--dba-working-dir-default",
           description: "Unsets a dba service working directory override",
         },
         {
-          name: ["--dbimage-extra-packages"],
+          name: "--dbimage-extra-packages",
           description:
             "A comma-delimited list of Debian packages that should be added to db container when the project is started",
-          args: [{ name: "dbimage-extra-packages" }],
+          args: { name: "dbimage-extra-packages" },
         },
         {
-          name: ["--default-container-timeout"],
+          name: "--default-container-timeout",
           description:
-            "default time in seconds that ddev waits for all containers to become ready on start",
-          args: [{ name: "default-container-timeout", default: "120" }],
+            "Default time in seconds that ddev waits for all containers to become ready on start",
+          args: { name: "default-container-timeout", default: "120" },
         },
         {
-          name: ["--disable-settings-management"],
+          name: "--disable-settings-management",
           description:
             "Prevent ddev from creating or updating CMS settings files",
         },
         {
-          name: ["--docroot"],
+          name: "--docroot",
           description:
             "Provide the relative docroot of the project, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory",
-          args: [{ name: "docroot" }],
+          args: { name: "docroot" },
         },
         {
-          name: ["--fail-on-hook-fail"],
+          name: "--fail-on-hook-fail",
           description:
             "Decide whether 'ddev start' should be interrupted by a failing hook",
         },
         {
-          name: ["--host-db-port"],
+          name: "--host-db-port",
           description: "The db container's localhost-bound port",
-          args: [{ name: "host-db-port" }],
+          args: { name: "host-db-port" },
         },
         {
-          name: ["--host-dba-port"],
+          name: "--host-dba-port",
           description:
             "The dba (PHPMyAdmin) container's localhost-bound port, if exposed via bind-all-interfaces",
-          args: [{ name: "host-dba-port" }],
+          args: { name: "host-dba-port" },
         },
         {
-          name: ["--host-https-port"],
+          name: "--host-https-port",
           description: "The web container's localhost-bound https port",
-          args: [{ name: "host-https-port" }],
+          args: { name: "host-https-port" },
         },
         {
-          name: ["--host-webserver-port"],
+          name: "--host-webserver-port",
           description: "The web container's localhost-bound port",
-          args: [{ name: "host-webserver-port" }],
+          args: { name: "host-webserver-port" },
         },
         {
-          name: ["--http-port"],
+          name: "--http-port",
           description: "The router HTTP port for this project",
-          args: [{ name: "http-port" }],
+          args: { name: "http-port" },
         },
         {
-          name: ["--https-port"],
+          name: "--https-port",
           description: "The router HTTPS port for this project",
-          args: [{ name: "https-port" }],
+          args: { name: "https-port" },
         },
         {
-          name: ["--image-defaults"],
+          name: "--image-defaults",
           description: "Sets the default web, db, and dba container images",
         },
         {
-          name: ["--mailhog-https-port"],
+          name: "--mailhog-https-port",
           description: "Router port to be used for mailhog access (https)",
-          args: [{ name: "mailhog-https-port" }],
+          args: { name: "mailhog-https-port" },
         },
         {
-          name: ["--mailhog-port"],
+          name: "--mailhog-port",
           description: "Router port to be used for mailhog access",
-          args: [{ name: "mailhog-port" }],
+          args: { name: "mailhog-port" },
         },
         {
-          name: ["--mutagen-enabled"],
+          name: "--mutagen-enabled",
           description:
-            "enable mutagen asynchronous update of project in web container",
+            "Enable mutagen asynchronous update of project in web container",
         },
         {
-          name: ["--nfs-mount-enabled"],
-          description: "enable NFS mounting of project in container",
+          name: "--nfs-mount-enabled",
+          description: "Enable NFS mounting of project in container",
         },
         {
-          name: ["--ngrok-args"],
+          name: "--ngrok-args",
           description: "Provide extra args to ngrok in ddev share",
-          args: [{ name: "ngrok-args" }],
+          args: { name: "ngrok-args" },
         },
         {
-          name: ["--no-project-mount"],
+          name: "--no-project-mount",
           description:
             "Whether or not to skip mounting project code into the web container",
         },
         {
-          name: ["--nodejs-version"],
+          name: "--nodejs-version",
           description:
             "Specify the nodejs version to use if you don't want the default NodeJS 16",
-          args: [{ name: "nodejs-version" }],
+          args: { name: "nodejs-version" },
         },
         {
-          name: ["--omit-containers"],
+          name: "--omit-containers",
           description:
             "A comma-delimited list of container types that should not be started when the project is started",
-          args: [{ name: "omit-containers" }],
+          args: { name: "omit-containers" },
         },
         {
-          name: ["--php-version"],
+          name: "--php-version",
           description:
             "The version of PHP that will be enabled in the web container",
-          args: [{ name: "php-version" }],
+          args: { name: "php-version" },
         },
         {
-          name: ["--phpmyadmin-https-port"],
+          name: "--phpmyadmin-https-port",
           description:
             "Router port to be used for PHPMyAdmin (dba) container access (https)",
-          args: [{ name: "phpmyadmin-https-port" }],
+          args: { name: "phpmyadmin-https-port" },
         },
         {
-          name: ["--phpmyadmin-port"],
+          name: "--phpmyadmin-port",
           description:
             "Router port to be used for PHPMyAdmin (dba) container access",
-          args: [{ name: "phpmyadmin-port" }],
+          args: { name: "phpmyadmin-port" },
         },
         {
-          name: ["--project-name"],
+          name: "--project-name",
           description:
             "Provide the project name of project to configure (normally the same as the last part of directory name)",
-          args: [{ name: "project-name" }],
+          args: { name: "project-name" },
         },
         {
-          name: ["--project-tld"],
+          name: "--project-tld",
           description:
-            "set the top-level domain to be used for projects, defaults to ddev.site",
-          args: [{ name: "project-tld", default: "ddev.site" }],
+            "Set the top-level domain to be used for projects, defaults to ddev.site",
+          args: { name: "project-tld", default: "ddev.site" },
         },
         {
-          name: ["--project-type"],
+          name: "--project-type",
           description:
-            "Provide the project type (one of backdrop, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress). This is autodetected and this flag is necessary only to override the detection.",
-          args: [{ name: "project-type" }],
+            "Provide the project type (one of backdrop, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress). This is autodetected and this flag is necessary only to override the detection",
+          args: { name: "project-type" },
         },
         {
-          name: ["--projectname"],
+          name: "--projectname",
           description:
             "Provide the project name of project to configure (normally the same as the last part of directory name)",
           hidden: true,
-          args: [{ name: "projectname" }],
+          args: { name: "projectname" },
         },
         {
-          name: ["--projecttype"],
+          name: "--projecttype",
           description:
-            "Provide the project type (one of backdrop, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress). This is autodetected and this flag is necessary only to override the detection.",
+            "Provide the project type (one of backdrop, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress). This is autodetected and this flag is necessary only to override the detection",
           hidden: true,
-          args: [{ name: "projecttype" }],
+          args: { name: "projecttype" },
         },
         {
-          name: ["--show-config-location"],
+          name: "--show-config-location",
           description:
-            "Output the location of the config.yaml file if it exists, or error that it doesn't exist.",
+            "Output the location of the config.yaml file if it exists, or error that it doesn't exist",
         },
         {
-          name: ["--sitename"],
+          name: "--sitename",
           description:
             "Provide the project name of project to configure (normally the same as the last part of directory name) This is the same as project-name and is included only for backwards compatibility",
           hidden: true,
-          args: [{ name: "sitename" }],
+          args: { name: "sitename" },
         },
         {
-          name: ["--timezone"],
+          name: "--timezone",
           description:
             "Specify timezone for containers and php, like Europe/London or America/Denver or GMT or UTC",
-          args: [{ name: "timezone" }],
+          args: { name: "timezone" },
         },
         {
-          name: ["--upload-dir"],
+          name: "--upload-dir",
           description:
-            "Sets the project's upload directory, the destination directory of the import-files command.",
-          args: [{ name: "upload-dir" }],
+            "Sets the project's upload directory, the destination directory of the import-files command",
+          args: { name: "upload-dir" },
         },
         {
-          name: ["--use-dns-when-possible"],
+          name: "--use-dns-when-possible",
           description:
             "Use DNS for hostname resolution instead of /etc/hosts when possible",
         },
         {
-          name: ["--web-environment"],
+          name: "--web-environment",
           description:
             'Set the environment variables in the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"',
-          args: [{ name: "web-environment" }],
+          args: { name: "web-environment" },
         },
         {
-          name: ["--web-environment-add"],
+          name: "--web-environment-add",
           description:
             'Append environment variables to the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"',
-          args: [{ name: "web-environment-add" }],
+          args: { name: "web-environment-add" },
         },
         {
-          name: ["--web-image"],
+          name: "--web-image",
           description: "Sets the web container image",
-          args: [{ name: "web-image" }],
+          args: { name: "web-image" },
         },
         {
-          name: ["--web-image-default"],
+          name: "--web-image-default",
           description:
             "Sets the default web container image for this ddev version",
         },
         {
-          name: ["--web-working-dir"],
+          name: "--web-working-dir",
           description:
             "Overrides the default working directory for the web service",
-          args: [{ name: "web-working-dir" }],
+          args: { name: "web-working-dir" },
         },
         {
-          name: ["--web-working-dir-default"],
+          name: "--web-working-dir-default",
           description: "Unsets a web service working directory override",
         },
         {
-          name: ["--webimage-extra-packages"],
+          name: "--webimage-extra-packages",
           description:
             "A comma-delimited list of Debian packages that should be added to web container when the project is started",
-          args: [{ name: "webimage-extra-packages" }],
+          args: { name: "webimage-extra-packages" },
         },
         {
-          name: ["--webserver-type"],
+          name: "--webserver-type",
           description:
             "Sets the project's desired webserver type: nginx-fpm or apache-fpm",
-          args: [{ name: "webserver-type" }],
+          args: { name: "webserver-type" },
         },
         {
-          name: ["--working-dir-defaults"],
+          name: "--working-dir-defaults",
           description: "Unsets all service working directory overrides",
         },
         {
-          name: ["--xdebug-enabled"],
+          name: "--xdebug-enabled",
           description: "Whether or not XDebug is enabled in the web container",
         },
       ],
@@ -494,83 +492,83 @@ const completionSpec: Fig.Spec = {
       description: "A collection of debugging commands",
       subcommands: [
         {
-          name: ["capabilities"],
+          name: "capabilities",
           description: "Show capabilities of this version of ddev",
         },
         {
-          name: ["check-db-match"],
+          name: "check-db-match",
           description:
             "Verify that the database in the ddev-db server matches the configured type/version",
         },
         {
-          name: ["compose-config"],
+          name: "compose-config",
           description:
             "Prints the docker-compose configuration of the current project",
         },
         {
-          name: ["configyaml"],
+          name: "configyaml",
           description: "Prints the project config.*.yaml usage",
         },
         {
-          name: ["dockercheck"],
+          name: "dockercheck",
           description: "Diagnose DDEV docker/colima setup",
         },
         {
-          name: ["download-images"],
+          name: "download-images",
           description: "Download all images required by ddev",
         },
         {
-          name: ["fix-commands"],
+          name: "fix-commands",
           description:
             "Fix up custom/shell commands without running ddev start",
         },
         {
-          name: ["get-volume-db-version"],
+          name: "get-volume-db-version",
           description:
             "Get the database type/version found in the ddev-dbserver's database volume, which may not be the same as the configured database type/version",
         },
         {
-          name: ["migrate-database"],
+          name: "migrate-database",
           description:
             "Migrate a mysql or mariadb database to a different dbtype:dbversion; works only with mysql and mariadb, not with postgres",
         },
         {
-          name: ["mutagen"],
+          name: "mutagen",
           description: "Allows access to any mutagen command",
         },
         {
-          name: ["nfsmount"],
+          name: "nfsmount",
           description:
             "Checks to see if nfs mounting works for current project",
         },
         {
-          name: ["refresh"],
+          name: "refresh",
           description: "Refreshes docker cache for project",
         },
         {
-          name: ["router-nginx-config"],
+          name: "router-nginx-config",
           description: "Prints the nginx config of the router",
         },
         {
-          name: ["test"],
+          name: "test",
           description:
             "Run diagnostics on ddev using the embedded test_ddev.sh script",
         },
       ],
     },
     {
-      name: ["delete"],
+      name: "delete",
       description:
         "Remove all project information (including database) for an existing project",
       subcommands: [
         {
-          name: ["images"],
+          name: "images",
           description:
             "Deletes drud/ddev-* docker images not in use by current ddev version",
           options: [
             {
               name: ["--all", "-a"],
-              description: "If set, deletes all Docker images created by ddev.",
+              description: "If set, deletes all Docker images created by ddev",
             },
             {
               name: ["--yes", "-y"],
@@ -582,7 +580,7 @@ const completionSpec: Fig.Spec = {
       options: [
         { name: ["--all", "-a"], description: "Delete all projects" },
         {
-          name: ["--clean-containers"],
+          name: "--clean-containers",
           description:
             "Clean up all ddev docker containers which are not required by this version of ddev",
         },
@@ -598,70 +596,70 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["desc", "st", "status", "describe"],
-      description: "Get a detailed description of a running ddev project.",
+      description: "Get a detailed description of a running ddev project",
     },
     {
       name: [".", "exec"],
       description:
-        "Execute a shell command in the container for a service. Uses the web service by default.",
+        "Execute a shell command in the container for a service. Uses the web service by default",
       options: [
         {
           name: ["--dir", "-d"],
           description: "Defines the execution directory within the container",
-          args: [{ name: "dir" }],
+          args: { name: "dir" },
         },
         {
-          name: ["--raw"],
+          name: "--raw",
           description:
             "Use raw exec (do not interpret with bash inside container)",
         },
         {
           name: ["--service", "-s"],
           description: "Defines the service to connect to. [e.g. web, db]",
-          args: [{ name: "service", default: "web" }],
+          args: { name: "service", default: "web" },
         },
       ],
     },
     {
-      name: ["export-db"],
+      name: "export-db",
       description: "Dump a database to a file or to stdout",
       options: [
-        { name: ["--bzip2"], description: "Use bzip2 compression" },
+        { name: "--bzip2", description: "Use bzip2 compression" },
         {
           name: ["--file", "-f"],
           description: "Provide the path to output the dump",
-          args: [{ name: "file" }],
+          args: { name: "file" },
         },
         { name: ["--gzip", "-z"], description: "Use gzip compression" },
         {
           name: ["--target-db", "-d"],
           description: "If provided, target-db is alternate database to export",
-          args: [{ name: "target-db", default: "db" }],
+          args: { name: "target-db", default: "db" },
         },
-        { name: ["--xz"], description: "Use xz compression" },
+        { name: "--xz", description: "Use xz compression" },
       ],
     },
     {
-      name: ["get"],
+      name: "get",
       description: "Get/Download a 3rd party add-on (service, provider, etc.)",
       options: [
         {
-          name: ["--all"],
+          name: "--all",
           description:
             "List unofficial add-ons for 'ddev get' in addition to the official ones",
         },
         {
-          name: ["--list"],
+          name: "--list",
           description: "List available add-ons for 'ddev get'",
         },
       ],
     },
     {
-      name: ["hostname"],
-      description: "Manage your hostfile entries.",
+      name: "hostname",
+      description: "Manage your hostfile entries",
       options: [
         {
-          name: ["--fire-bazooka"],
+          name: "--fire-bazooka",
           description: "Alias of --remove-inactive",
           hidden: true,
         },
@@ -676,17 +674,17 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["import-db"],
-      description: "Import a sql file into the project.",
+      name: "import-db",
+      description: "Import a sql file into the project",
       options: [
         {
-          name: ["--extract-path"],
+          name: "--extract-path",
           description:
-            "If provided asset is an archive, provide the path to extract within the archive.",
-          args: [{ name: "extract-path" }],
+            "If provided asset is an archive, provide the path to extract within the archive",
+          args: { name: "extract-path" },
         },
         {
-          name: ["--no-drop"],
+          name: "--no-drop",
           description: "Set if you do NOT want to drop the db before importing",
         },
         {
@@ -697,32 +695,32 @@ const completionSpec: Fig.Spec = {
           name: ["--src", "-f"],
           description:
             "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format",
-          args: [{ name: "src" }],
+          args: { name: "src" },
         },
         {
           name: ["--target-db", "-d"],
           description:
             "If provided, target-db is alternate database to import into",
-          args: [{ name: "target-db", default: "db" }],
+          args: { name: "target-db", default: "db" },
         },
       ],
     },
     {
-      name: ["import-files"],
+      name: "import-files",
       description:
-        "Pull the uploaded files directory of an existing project to the default public upload directory of your project.",
+        "Pull the uploaded files directory of an existing project to the default public upload directory of your project",
       options: [
         {
-          name: ["--extract-path"],
+          name: "--extract-path",
           description:
-            "If provided asset is an archive, optionally provide the path to extract within the archive.",
-          args: [{ name: "extract-path" }],
+            "If provided asset is an archive, optionally provide the path to extract within the archive",
+          args: { name: "extract-path" },
         },
         {
-          name: ["--src"],
+          name: "--src",
           description:
             "Provide the path to the source directory or tar/tar.gz/tgz/zip archive of files to import",
-          args: [{ name: "src" }],
+          args: { name: "src" },
         },
       ],
     },
@@ -733,53 +731,53 @@ const completionSpec: Fig.Spec = {
         {
           name: ["--active-only", "-A"],
           description:
-            "If set, only currently active projects will be displayed.",
+            "If set, only currently active projects will be displayed",
         },
         {
-          name: ["--continuous"],
+          name: "--continuous",
           description:
-            "If set, project information will be emitted until the command is stopped.",
+            "If set, project information will be emitted until the command is stopped",
         },
         {
           name: ["--continuous-sleep-interval", "-I"],
           description:
-            "Time in seconds between ddev list --continuous output lists.",
-          args: [{ name: "continuous-sleep-interval", default: "1" }],
+            "Time in seconds between ddev list --continuous output lists",
+          args: { name: "continuous-sleep-interval", default: "1" },
         },
         {
           name: ["--wrap-table", "-W"],
-          description: "Display table with wrapped text if required.",
+          description: "Display table with wrapped text if required",
         },
       ],
     },
     {
-      name: ["logs"],
-      description: "Get the logs from your running services.",
+      name: "logs",
+      description: "Get the logs from your running services",
       options: [
         {
           name: ["--follow", "-f"],
-          description: "Follow the logs in real time.",
+          description: "Follow the logs in real time",
         },
         {
           name: ["--service", "-s"],
           description:
             "Defines the service to retrieve logs from. [e.g. web, db]",
-          args: [{ name: "service", default: "web" }],
+          args: { name: "service", default: "web" },
         },
         {
-          name: ["--tail"],
+          name: "--tail",
           description: "How many lines to show",
-          args: [{ name: "tail" }],
+          args: { name: "tail" },
         },
         { name: ["--time", "-t"], description: "Add timestamps to logs" },
       ],
     },
     {
-      name: ["mutagen"],
-      description: "Commands for mutagen status and sync, etc.",
+      name: "mutagen",
+      description: "Commands for mutagen status and sync, etc",
       subcommands: [
-        { name: ["monitor"], description: "Monitor mutagen status" },
-        { name: ["reset"], description: "Reset mutagen for project" },
+        { name: "monitor", description: "Monitor mutagen status" },
+        { name: "reset", description: "Reset mutagen for project" },
         {
           name: ["st", "status"],
           description: "Shows mutagen sync status",
@@ -791,11 +789,11 @@ const completionSpec: Fig.Spec = {
           ],
         },
         {
-          name: ["sync"],
+          name: "sync",
           description: "Explicit sync for mutagen",
           options: [
             {
-              name: ["--verbose"],
+              name: "--verbose",
               description: "Extended/verbose output for mutagen status",
             },
           ],
@@ -805,7 +803,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["sc", "stop-containers", "pause"],
       description:
-        "uses 'docker stop' to pause/stop the containers belonging to a project.",
+        "Uses 'docker stop' to pause/stop the containers belonging to a project",
       options: [
         { name: ["--all", "-a"], description: "Pause all running projects" },
       ],
@@ -815,43 +813,41 @@ const completionSpec: Fig.Spec = {
       description: "Completely stop all projects and containers",
     },
     {
-      name: ["pull"],
-      description:
-        "Pull files and database using a configured provider plugin.",
+      name: "pull",
+      description: "Pull files and database using a configured provider plugin",
     },
     {
-      name: ["push"],
-      description:
-        "push files and database using a configured provider plugin.",
+      name: "push",
+      description: "Push files and database using a configured provider plugin",
     },
     {
-      name: ["restart"],
-      description: "Restart a project or several projects.",
-      options: [{ name: ["--all", "-a"], description: "restart all projects" }],
+      name: "restart",
+      description: "Restart a project or several projects",
+      options: [{ name: ["--all", "-a"], description: "Restart all projects" }],
     },
     {
-      name: ["service"],
+      name: "service",
       description: "Add or remove, enable or disable extra services",
       subcommands: [
-        { name: ["disable"], description: "disable a 3rd party service" },
-        { name: ["enable"], description: "Enable a 3rd party service" },
+        { name: "disable", description: "Disable a 3rd party service" },
+        { name: "enable", description: "Enable a 3rd party service" },
       ],
     },
     {
-      name: ["share"],
-      description: "Share project on the internet via ngrok.",
+      name: "share",
+      description: "Share project on the internet via ngrok",
       options: [
         {
-          name: ["--subdomain"],
+          name: "--subdomain",
           description:
-            'ngrok --subdomain argument, as in "ngrok --subdomain my-subdomain:, requires paid ngrok.com account"',
-          args: [{ name: "subdomain" }],
+            'Ngrok --subdomain argument, as in "ngrok --subdomain my-subdomain:, requires paid ngrok.com account"',
+          args: { name: "subdomain" },
         },
       ],
     },
     {
-      name: ["snapshot"],
-      description: "Create a database snapshot for one or more projects.",
+      name: "snapshot",
+      description: "Create a database snapshot for one or more projects",
       options: [
         {
           name: ["--all", "-a"],
@@ -862,8 +858,8 @@ const completionSpec: Fig.Spec = {
         { name: ["--list", "-l"], description: "List snapshots" },
         {
           name: ["--name", "-n"],
-          description: "provide a name for the snapshot",
-          args: [{ name: "name" }],
+          description: "Provide a name for the snapshot",
+          args: { name: "name" },
         },
         {
           name: ["--yes", "-y"],
@@ -872,25 +868,25 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["ssh"],
+      name: "ssh",
       description:
-        "Starts a shell session in the container for a service. Uses web service by default.",
+        "Starts a shell session in the container for a service. Uses web service by default",
       options: [
         {
           name: ["--dir", "-d"],
           description: "Defines the destination directory within the container",
-          args: [{ name: "dir" }],
+          args: { name: "dir" },
         },
         {
           name: ["--service", "-s"],
           description: "Defines the service to connect to. [e.g. web, db]",
-          args: [{ name: "service", default: "web" }],
+          args: { name: "service", default: "web" },
         },
       ],
     },
     {
       name: ["add", "start"],
-      description: "Start a ddev project.",
+      description: "Start a ddev project",
       options: [
         { name: ["--all", "-a"], description: "Start all projects" },
         {
@@ -906,7 +902,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["remove", "rm", "stop"],
       description:
-        "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data.",
+        "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data",
       options: [
         {
           name: ["--all", "-a"],
@@ -927,7 +923,7 @@ const completionSpec: Fig.Spec = {
         },
         { name: ["--snapshot", "-S"], description: "Create database snapshot" },
         {
-          name: ["--stop-ssh-agent"],
+          name: "--stop-ssh-agent",
           description: "Stop the ddev-ssh-agent container",
         },
         {
@@ -938,43 +934,43 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["version"],
-      description: "print ddev version and component versions",
+      name: "version",
+      description: "Print ddev version and component versions",
     },
     {
-      name: ["help"],
+      name: "help",
       description: "Help about any command",
       subcommands: [
         {
-          name: ["auth"],
+          name: "auth",
           description: "A collection of authentication commands",
           subcommands: [
             {
-              name: ["ssh"],
+              name: "ssh",
               description:
                 "Add ssh key authentication to the ddev-ssh-auth container",
             },
           ],
         },
-        { name: ["clean"], description: "Removes items ddev has created" },
+        { name: "clean", description: "Removes items ddev has created" },
         {
-          name: ["composer"],
+          name: "composer",
           description: "Executes a composer command within the web container",
           subcommands: [
             {
-              name: ["create"],
+              name: "create",
               description:
                 "Executes 'composer create-project' within the web container with the arguments and flags provided",
             },
-            { name: ["create-project"], description: "" },
+            { name: "create-project", description: "" },
           ],
         },
         {
-          name: ["config"],
+          name: "config",
           description:
             "Create or modify a ddev project configuration in the current directory",
           subcommands: [
-            { name: ["global"], description: "Change global configuration" },
+            { name: "global", description: "Change global configuration" },
           ],
         },
         {
@@ -982,77 +978,77 @@ const completionSpec: Fig.Spec = {
           description: "A collection of debugging commands",
           subcommands: [
             {
-              name: ["capabilities"],
+              name: "capabilities",
               description: "Show capabilities of this version of ddev",
             },
             {
-              name: ["check-db-match"],
+              name: "check-db-match",
               description:
                 "Verify that the database in the ddev-db server matches the configured type/version",
             },
             {
-              name: ["compose-config"],
+              name: "compose-config",
               description:
                 "Prints the docker-compose configuration of the current project",
             },
             {
-              name: ["configyaml"],
+              name: "configyaml",
               description: "Prints the project config.*.yaml usage",
             },
             {
-              name: ["dockercheck"],
+              name: "dockercheck",
               description: "Diagnose DDEV docker/colima setup",
             },
             {
-              name: ["download-images"],
+              name: "download-images",
               description: "Download all images required by ddev",
             },
             {
-              name: ["fix-commands"],
+              name: "fix-commands",
               description:
                 "Fix up custom/shell commands without running ddev start",
             },
             {
-              name: ["get-volume-db-version"],
+              name: "get-volume-db-version",
               description:
                 "Get the database type/version found in the ddev-dbserver's database volume, which may not be the same as the configured database type/version",
             },
             {
-              name: ["migrate-database"],
+              name: "migrate-database",
               description:
                 "Migrate a mysql or mariadb database to a different dbtype:dbversion; works only with mysql and mariadb, not with postgres",
             },
             {
-              name: ["mutagen"],
+              name: "mutagen",
               description: "Allows access to any mutagen command",
             },
             {
-              name: ["nfsmount"],
+              name: "nfsmount",
               description:
                 "Checks to see if nfs mounting works for current project",
             },
             {
-              name: ["refresh"],
+              name: "refresh",
               description: "Refreshes docker cache for project",
             },
             {
-              name: ["router-nginx-config"],
+              name: "router-nginx-config",
               description: "Prints the nginx config of the router",
             },
             {
-              name: ["test"],
+              name: "test",
               description:
                 "Run diagnostics on ddev using the embedded test_ddev.sh script",
             },
           ],
         },
         {
-          name: ["delete"],
+          name: "delete",
           description:
             "Remove all project information (including database) for an existing project",
           subcommands: [
             {
-              name: ["images"],
+              name: "images",
               description:
                 "Deletes drud/ddev-* docker images not in use by current ddev version",
             },
@@ -1060,103 +1056,103 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: ["desc", "st", "status", "describe"],
-          description: "Get a detailed description of a running ddev project.",
+          description: "Get a detailed description of a running ddev project",
         },
         {
           name: [".", "exec"],
           description:
-            "Execute a shell command in the container for a service. Uses the web service by default.",
+            "Execute a shell command in the container for a service. Uses the web service by default",
         },
         {
-          name: ["export-db"],
+          name: "export-db",
           description: "Dump a database to a file or to stdout",
         },
         {
-          name: ["get"],
+          name: "get",
           description:
             "Get/Download a 3rd party add-on (service, provider, etc.)",
         },
-        { name: ["hostname"], description: "Manage your hostfile entries." },
+        { name: "hostname", description: "Manage your hostfile entries" },
         {
-          name: ["import-db"],
-          description: "Import a sql file into the project.",
+          name: "import-db",
+          description: "Import a sql file into the project",
         },
         {
-          name: ["import-files"],
+          name: "import-files",
           description:
-            "Pull the uploaded files directory of an existing project to the default public upload directory of your project.",
+            "Pull the uploaded files directory of an existing project to the default public upload directory of your project",
         },
         { name: ["l", "ls", "list"], description: "List projects" },
         {
-          name: ["logs"],
-          description: "Get the logs from your running services.",
+          name: "logs",
+          description: "Get the logs from your running services",
         },
         {
-          name: ["mutagen"],
-          description: "Commands for mutagen status and sync, etc.",
+          name: "mutagen",
+          description: "Commands for mutagen status and sync, etc",
           subcommands: [
-            { name: ["monitor"], description: "Monitor mutagen status" },
-            { name: ["reset"], description: "Reset mutagen for project" },
+            { name: "monitor", description: "Monitor mutagen status" },
+            { name: "reset", description: "Reset mutagen for project" },
             {
               name: ["st", "status"],
               description: "Shows mutagen sync status",
             },
-            { name: ["sync"], description: "Explicit sync for mutagen" },
+            { name: "sync", description: "Explicit sync for mutagen" },
           ],
         },
         {
           name: ["sc", "stop-containers", "pause"],
           description:
-            "uses 'docker stop' to pause/stop the containers belonging to a project.",
+            "Uses 'docker stop' to pause/stop the containers belonging to a project",
         },
         {
           name: ["powerdown", "poweroff"],
           description: "Completely stop all projects and containers",
         },
         {
-          name: ["pull"],
+          name: "pull",
           description:
-            "Pull files and database using a configured provider plugin.",
+            "Pull files and database using a configured provider plugin",
         },
         {
-          name: ["push"],
+          name: "push",
           description:
-            "push files and database using a configured provider plugin.",
+            "Push files and database using a configured provider plugin",
         },
         {
-          name: ["restart"],
-          description: "Restart a project or several projects.",
+          name: "restart",
+          description: "Restart a project or several projects",
         },
         {
-          name: ["service"],
+          name: "service",
           description: "Add or remove, enable or disable extra services",
           subcommands: [
-            { name: ["disable"], description: "disable a 3rd party service" },
-            { name: ["enable"], description: "Enable a 3rd party service" },
+            { name: "disable", description: "Disable a 3rd party service" },
+            { name: "enable", description: "Enable a 3rd party service" },
           ],
         },
         {
-          name: ["share"],
-          description: "Share project on the internet via ngrok.",
+          name: "share",
+          description: "Share project on the internet via ngrok",
         },
         {
-          name: ["snapshot"],
-          description: "Create a database snapshot for one or more projects.",
+          name: "snapshot",
+          description: "Create a database snapshot for one or more projects",
         },
         {
-          name: ["ssh"],
+          name: "ssh",
           description:
-            "Starts a shell session in the container for a service. Uses web service by default.",
+            "Starts a shell session in the container for a service. Uses web service by default",
         },
-        { name: ["add", "start"], description: "Start a ddev project." },
+        { name: ["add", "start"], description: "Start a ddev project" },
         {
           name: ["remove", "rm", "stop"],
           description:
-            "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data.",
+            "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data",
         },
         {
-          name: ["version"],
-          description: "print ddev version and component versions",
+          name: "version",
+          description: "Print ddev version and component versions",
         },
       ],
     },
@@ -1164,7 +1160,7 @@ const completionSpec: Fig.Spec = {
   options: [
     {
       name: ["--json-output", "-j"],
-      description: "If true, user-oriented output will be in JSON format.",
+      description: "If true, user-oriented output will be in JSON format",
       isPersistent: true,
     },
     { name: ["--help", "-h"], description: "Display help", isPersistent: true },

--- a/src/ddev.ts
+++ b/src/ddev.ts
@@ -1,0 +1,1173 @@
+const completionSpec: Fig.Spec = {
+  name: "ddev",
+  description: "DDEV-Local local development environment",
+  subcommands: [
+    {
+      name: ["auth"],
+      description: "A collection of authentication commands",
+      subcommands: [
+        {
+          name: ["ssh"],
+          description:
+            "Add ssh key authentication to the ddev-ssh-auth container",
+          options: [
+            {
+              name: ["--ssh-key-path", "-d"],
+              description: "full path to ssh key directory",
+              args: [{ name: "ssh-key-path" }],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: ["clean"],
+      description: "Removes items ddev has created",
+      options: [
+        { name: ["--all", "-a"], description: "Clean all ddev projects" },
+        {
+          name: ["--dry-run"],
+          description: "Run the clean command without deleting",
+        },
+      ],
+    },
+    {
+      name: ["composer"],
+      description: "Executes a composer command within the web container",
+      subcommands: [
+        {
+          name: ["create"],
+          description:
+            "Executes 'composer create-project' within the web container with the arguments and flags provided",
+          options: [
+            {
+              name: ["--yes", "-y"],
+              description: "Yes - skip confirmation prompt",
+            },
+          ],
+        },
+        { name: ["create-project"], description: "" },
+      ],
+    },
+    {
+      name: ["config"],
+      description:
+        "Create or modify a ddev project configuration in the current directory",
+      subcommands: [
+        {
+          name: ["global"],
+          description: "Change global configuration",
+          options: [
+            {
+              name: ["--auto-restart-containers"],
+              description:
+                "If true, automatically restart containers after a reboot or docker restart",
+            },
+            {
+              name: ["--disable-http2"],
+              description:
+                "Optionally disable http2 in ddev-router, 'ddev global --disable-http2' or `ddev global --disable-http2=false'",
+            },
+            {
+              name: ["--fail-on-hook-fail"],
+              description: "If true, 'ddev start' will fail when a hook fails.",
+            },
+            {
+              name: ["--instrumentation-opt-in"],
+              description: "instrumentation-opt-in=true",
+            },
+            {
+              name: ["--internet-detection-timeout-ms"],
+              description:
+                "Increase timeout when checking internet timeout, in milliseconds",
+              args: [
+                { name: "internet-detection-timeout-ms", default: "3000" },
+              ],
+            },
+            {
+              name: ["--letsencrypt-email"],
+              description:
+                "Email associated with Let's Encrypt, `ddev global --letsencrypt-email=me@example.com'",
+              args: [{ name: "letsencrypt-email" }],
+            },
+            {
+              name: ["--mutagen-enabled"],
+              description:
+                "If true, web container will use mutagen caching/asynchronous updates.",
+            },
+            {
+              name: ["--nfs-mount-enabled"],
+              description: "Enable NFS mounting on all projects globally",
+            },
+            {
+              name: ["--no-bind-mounts"],
+              description:
+                "If true, don't use bind-mounts - useful for environments like remote docker where bind-mounts are impossible",
+            },
+            {
+              name: ["--omit-containers"],
+              description: "For example, --omit-containers=dba,ddev-ssh-agent",
+              args: [{ name: "omit-containers" }],
+            },
+            {
+              name: ["--required-docker-compose-version"],
+              description: "Override default docker-compose version",
+              args: [{ name: "required-docker-compose-version" }],
+            },
+            {
+              name: ["--router-bind-all-interfaces"],
+              description: "router-bind-all-interfaces=true",
+            },
+            {
+              name: ["--simple-formatting"],
+              description:
+                "If true, use simple formatting and no color for tables",
+            },
+            {
+              name: ["--table-style"],
+              description:
+                "Table style for list and describe, see ~/.ddev/global_config.yaml for values",
+              args: [{ name: "table-style" }],
+            },
+            {
+              name: ["--use-docker-compose-from-path"],
+              description:
+                "If true, use docker-compose from path instead of private ~/.ddev/bin/docker-compose",
+            },
+            {
+              name: ["--use-hardened-images"],
+              description:
+                "If true, use more secure 'hardened' images for an actual internet deployment.",
+            },
+            {
+              name: ["--use-letsencrypt"],
+              description:
+                "Enables experimental Let's Encrypt integration, 'ddev global --use-letsencrypt' or `ddev global --use-letsencrypt=false'",
+            },
+            {
+              name: ["--web-environment"],
+              description:
+                'Set the environment variables in the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"',
+              args: [{ name: "web-environment" }],
+            },
+            {
+              name: ["--web-environment-add"],
+              description:
+                'Append environment variables to the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"',
+              args: [{ name: "web-environment-add" }],
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          name: ["--additional-fqdns"],
+          description: "A comma-delimited list of FQDNs for the project",
+          args: [{ name: "additional-fqdns" }],
+        },
+        {
+          name: ["--additional-hostnames"],
+          description: "A comma-delimited list of hostnames for the project",
+          args: [{ name: "additional-hostnames" }],
+        },
+        {
+          name: ["--apptype"],
+          description:
+            "Provide the project type (one of backdrop, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress). This is autodetected and this flag is necessary only to override the detection. This is the same as --project-type and is included only for backwards compatibility.",
+          hidden: true,
+          args: [{ name: "apptype" }],
+        },
+        {
+          name: ["--auto"],
+          description: "Automatically run config without prompting.",
+        },
+        {
+          name: ["--bind-all-interfaces"],
+          description:
+            "Bind host ports on all interfaces, not just on localhost network interface",
+        },
+        {
+          name: ["--composer-root"],
+          description:
+            "Overrides the default composer root directory for the web service",
+          args: [{ name: "composer-root" }],
+        },
+        {
+          name: ["--composer-root-default"],
+          description: "Unsets a web service composer root directory override",
+        },
+        {
+          name: ["--composer-version"],
+          description:
+            'Specify override for composer version in web container. This may be "", "1", "2", "2.2", "stable", "preview", "snapshot" or a specific version.',
+          args: [{ name: "composer-version" }],
+        },
+        {
+          name: ["--create-docroot"],
+          description: "Prompts ddev to create the docroot if it doesn't exist",
+        },
+        {
+          name: ["--database"],
+          description:
+            "Specify the database type:version to use. Defaults to mariadb:10.4",
+          args: [{ name: "database" }],
+        },
+        {
+          name: ["--db-image"],
+          description: "Sets the db container image",
+          args: [{ name: "db-image" }],
+        },
+        {
+          name: ["--db-image-default"],
+          description:
+            "Sets the default db container image for this ddev version",
+        },
+        {
+          name: ["--db-working-dir"],
+          description:
+            "Overrides the default working directory for the db service",
+          args: [{ name: "db-working-dir" }],
+        },
+        {
+          name: ["--db-working-dir-default"],
+          description: "Unsets a db service working directory override",
+        },
+        {
+          name: ["--dba-image"],
+          description: "Sets the dba container image",
+          args: [{ name: "dba-image" }],
+        },
+        {
+          name: ["--dba-image-default"],
+          description:
+            "Sets the default dba container image for this ddev version",
+        },
+        {
+          name: ["--dba-working-dir"],
+          description:
+            "Overrides the default working directory for the dba service",
+          args: [{ name: "dba-working-dir" }],
+        },
+        {
+          name: ["--dba-working-dir-default"],
+          description: "Unsets a dba service working directory override",
+        },
+        {
+          name: ["--dbimage-extra-packages"],
+          description:
+            "A comma-delimited list of Debian packages that should be added to db container when the project is started",
+          args: [{ name: "dbimage-extra-packages" }],
+        },
+        {
+          name: ["--default-container-timeout"],
+          description:
+            "default time in seconds that ddev waits for all containers to become ready on start",
+          args: [{ name: "default-container-timeout", default: "120" }],
+        },
+        {
+          name: ["--disable-settings-management"],
+          description:
+            "Prevent ddev from creating or updating CMS settings files",
+        },
+        {
+          name: ["--docroot"],
+          description:
+            "Provide the relative docroot of the project, like 'docroot' or 'htdocs' or 'web', defaults to empty, the current directory",
+          args: [{ name: "docroot" }],
+        },
+        {
+          name: ["--fail-on-hook-fail"],
+          description:
+            "Decide whether 'ddev start' should be interrupted by a failing hook",
+        },
+        {
+          name: ["--host-db-port"],
+          description: "The db container's localhost-bound port",
+          args: [{ name: "host-db-port" }],
+        },
+        {
+          name: ["--host-dba-port"],
+          description:
+            "The dba (PHPMyAdmin) container's localhost-bound port, if exposed via bind-all-interfaces",
+          args: [{ name: "host-dba-port" }],
+        },
+        {
+          name: ["--host-https-port"],
+          description: "The web container's localhost-bound https port",
+          args: [{ name: "host-https-port" }],
+        },
+        {
+          name: ["--host-webserver-port"],
+          description: "The web container's localhost-bound port",
+          args: [{ name: "host-webserver-port" }],
+        },
+        {
+          name: ["--http-port"],
+          description: "The router HTTP port for this project",
+          args: [{ name: "http-port" }],
+        },
+        {
+          name: ["--https-port"],
+          description: "The router HTTPS port for this project",
+          args: [{ name: "https-port" }],
+        },
+        {
+          name: ["--image-defaults"],
+          description: "Sets the default web, db, and dba container images",
+        },
+        {
+          name: ["--mailhog-https-port"],
+          description: "Router port to be used for mailhog access (https)",
+          args: [{ name: "mailhog-https-port" }],
+        },
+        {
+          name: ["--mailhog-port"],
+          description: "Router port to be used for mailhog access",
+          args: [{ name: "mailhog-port" }],
+        },
+        {
+          name: ["--mutagen-enabled"],
+          description:
+            "enable mutagen asynchronous update of project in web container",
+        },
+        {
+          name: ["--nfs-mount-enabled"],
+          description: "enable NFS mounting of project in container",
+        },
+        {
+          name: ["--ngrok-args"],
+          description: "Provide extra args to ngrok in ddev share",
+          args: [{ name: "ngrok-args" }],
+        },
+        {
+          name: ["--no-project-mount"],
+          description:
+            "Whether or not to skip mounting project code into the web container",
+        },
+        {
+          name: ["--nodejs-version"],
+          description:
+            "Specify the nodejs version to use if you don't want the default NodeJS 16",
+          args: [{ name: "nodejs-version" }],
+        },
+        {
+          name: ["--omit-containers"],
+          description:
+            "A comma-delimited list of container types that should not be started when the project is started",
+          args: [{ name: "omit-containers" }],
+        },
+        {
+          name: ["--php-version"],
+          description:
+            "The version of PHP that will be enabled in the web container",
+          args: [{ name: "php-version" }],
+        },
+        {
+          name: ["--phpmyadmin-https-port"],
+          description:
+            "Router port to be used for PHPMyAdmin (dba) container access (https)",
+          args: [{ name: "phpmyadmin-https-port" }],
+        },
+        {
+          name: ["--phpmyadmin-port"],
+          description:
+            "Router port to be used for PHPMyAdmin (dba) container access",
+          args: [{ name: "phpmyadmin-port" }],
+        },
+        {
+          name: ["--project-name"],
+          description:
+            "Provide the project name of project to configure (normally the same as the last part of directory name)",
+          args: [{ name: "project-name" }],
+        },
+        {
+          name: ["--project-tld"],
+          description:
+            "set the top-level domain to be used for projects, defaults to ddev.site",
+          args: [{ name: "project-tld", default: "ddev.site" }],
+        },
+        {
+          name: ["--project-type"],
+          description:
+            "Provide the project type (one of backdrop, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress). This is autodetected and this flag is necessary only to override the detection.",
+          args: [{ name: "project-type" }],
+        },
+        {
+          name: ["--projectname"],
+          description:
+            "Provide the project name of project to configure (normally the same as the last part of directory name)",
+          hidden: true,
+          args: [{ name: "projectname" }],
+        },
+        {
+          name: ["--projecttype"],
+          description:
+            "Provide the project type (one of backdrop, drupal10, drupal6, drupal7, drupal8, drupal9, laravel, magento, magento2, php, shopware6, typo3, wordpress). This is autodetected and this flag is necessary only to override the detection.",
+          hidden: true,
+          args: [{ name: "projecttype" }],
+        },
+        {
+          name: ["--show-config-location"],
+          description:
+            "Output the location of the config.yaml file if it exists, or error that it doesn't exist.",
+        },
+        {
+          name: ["--sitename"],
+          description:
+            "Provide the project name of project to configure (normally the same as the last part of directory name) This is the same as project-name and is included only for backwards compatibility",
+          hidden: true,
+          args: [{ name: "sitename" }],
+        },
+        {
+          name: ["--timezone"],
+          description:
+            "Specify timezone for containers and php, like Europe/London or America/Denver or GMT or UTC",
+          args: [{ name: "timezone" }],
+        },
+        {
+          name: ["--upload-dir"],
+          description:
+            "Sets the project's upload directory, the destination directory of the import-files command.",
+          args: [{ name: "upload-dir" }],
+        },
+        {
+          name: ["--use-dns-when-possible"],
+          description:
+            "Use DNS for hostname resolution instead of /etc/hosts when possible",
+        },
+        {
+          name: ["--web-environment"],
+          description:
+            'Set the environment variables in the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"',
+          args: [{ name: "web-environment" }],
+        },
+        {
+          name: ["--web-environment-add"],
+          description:
+            'Append environment variables to the web container: --web-environment="TYPO3_CONTEXT=Development,SOMEENV=someval"',
+          args: [{ name: "web-environment-add" }],
+        },
+        {
+          name: ["--web-image"],
+          description: "Sets the web container image",
+          args: [{ name: "web-image" }],
+        },
+        {
+          name: ["--web-image-default"],
+          description:
+            "Sets the default web container image for this ddev version",
+        },
+        {
+          name: ["--web-working-dir"],
+          description:
+            "Overrides the default working directory for the web service",
+          args: [{ name: "web-working-dir" }],
+        },
+        {
+          name: ["--web-working-dir-default"],
+          description: "Unsets a web service working directory override",
+        },
+        {
+          name: ["--webimage-extra-packages"],
+          description:
+            "A comma-delimited list of Debian packages that should be added to web container when the project is started",
+          args: [{ name: "webimage-extra-packages" }],
+        },
+        {
+          name: ["--webserver-type"],
+          description:
+            "Sets the project's desired webserver type: nginx-fpm or apache-fpm",
+          args: [{ name: "webserver-type" }],
+        },
+        {
+          name: ["--working-dir-defaults"],
+          description: "Unsets all service working directory overrides",
+        },
+        {
+          name: ["--xdebug-enabled"],
+          description: "Whether or not XDebug is enabled in the web container",
+        },
+      ],
+    },
+    {
+      name: ["d", "dbg", "debug"],
+      description: "A collection of debugging commands",
+      subcommands: [
+        {
+          name: ["capabilities"],
+          description: "Show capabilities of this version of ddev",
+        },
+        {
+          name: ["check-db-match"],
+          description:
+            "Verify that the database in the ddev-db server matches the configured type/version",
+        },
+        {
+          name: ["compose-config"],
+          description:
+            "Prints the docker-compose configuration of the current project",
+        },
+        {
+          name: ["configyaml"],
+          description: "Prints the project config.*.yaml usage",
+        },
+        {
+          name: ["dockercheck"],
+          description: "Diagnose DDEV docker/colima setup",
+        },
+        {
+          name: ["download-images"],
+          description: "Download all images required by ddev",
+        },
+        {
+          name: ["fix-commands"],
+          description:
+            "Fix up custom/shell commands without running ddev start",
+        },
+        {
+          name: ["get-volume-db-version"],
+          description:
+            "Get the database type/version found in the ddev-dbserver's database volume, which may not be the same as the configured database type/version",
+        },
+        {
+          name: ["migrate-database"],
+          description:
+            "Migrate a mysql or mariadb database to a different dbtype:dbversion; works only with mysql and mariadb, not with postgres",
+        },
+        {
+          name: ["mutagen"],
+          description: "Allows access to any mutagen command",
+        },
+        {
+          name: ["nfsmount"],
+          description:
+            "Checks to see if nfs mounting works for current project",
+        },
+        {
+          name: ["refresh"],
+          description: "Refreshes docker cache for project",
+        },
+        {
+          name: ["router-nginx-config"],
+          description: "Prints the nginx config of the router",
+        },
+        {
+          name: ["test"],
+          description:
+            "Run diagnostics on ddev using the embedded test_ddev.sh script",
+        },
+      ],
+    },
+    {
+      name: ["delete"],
+      description:
+        "Remove all project information (including database) for an existing project",
+      subcommands: [
+        {
+          name: ["images"],
+          description:
+            "Deletes drud/ddev-* docker images not in use by current ddev version",
+          options: [
+            {
+              name: ["--all", "-a"],
+              description: "If set, deletes all Docker images created by ddev.",
+            },
+            {
+              name: ["--yes", "-y"],
+              description: "Yes - skip confirmation prompt",
+            },
+          ],
+        },
+      ],
+      options: [
+        { name: ["--all", "-a"], description: "Delete all projects" },
+        {
+          name: ["--clean-containers"],
+          description:
+            "Clean up all ddev docker containers which are not required by this version of ddev",
+        },
+        {
+          name: ["--omit-snapshot", "-O"],
+          description: "Omit/skip database snapshot",
+        },
+        {
+          name: ["--yes", "-y"],
+          description: "Yes - skip confirmation prompt",
+        },
+      ],
+    },
+    {
+      name: ["desc", "st", "status", "describe"],
+      description: "Get a detailed description of a running ddev project.",
+    },
+    {
+      name: [".", "exec"],
+      description:
+        "Execute a shell command in the container for a service. Uses the web service by default.",
+      options: [
+        {
+          name: ["--dir", "-d"],
+          description: "Defines the execution directory within the container",
+          args: [{ name: "dir" }],
+        },
+        {
+          name: ["--raw"],
+          description:
+            "Use raw exec (do not interpret with bash inside container)",
+        },
+        {
+          name: ["--service", "-s"],
+          description: "Defines the service to connect to. [e.g. web, db]",
+          args: [{ name: "service", default: "web" }],
+        },
+      ],
+    },
+    {
+      name: ["export-db"],
+      description: "Dump a database to a file or to stdout",
+      options: [
+        { name: ["--bzip2"], description: "Use bzip2 compression" },
+        {
+          name: ["--file", "-f"],
+          description: "Provide the path to output the dump",
+          args: [{ name: "file" }],
+        },
+        { name: ["--gzip", "-z"], description: "Use gzip compression" },
+        {
+          name: ["--target-db", "-d"],
+          description: "If provided, target-db is alternate database to export",
+          args: [{ name: "target-db", default: "db" }],
+        },
+        { name: ["--xz"], description: "Use xz compression" },
+      ],
+    },
+    {
+      name: ["get"],
+      description: "Get/Download a 3rd party add-on (service, provider, etc.)",
+      options: [
+        {
+          name: ["--all"],
+          description:
+            "List unofficial add-ons for 'ddev get' in addition to the official ones",
+        },
+        {
+          name: ["--list"],
+          description: "List available add-ons for 'ddev get'",
+        },
+      ],
+    },
+    {
+      name: ["hostname"],
+      description: "Manage your hostfile entries.",
+      options: [
+        {
+          name: ["--fire-bazooka"],
+          description: "Alias of --remove-inactive",
+          hidden: true,
+        },
+        {
+          name: ["--remove", "-r"],
+          description: "Remove the provided host name - ip correlation",
+        },
+        {
+          name: ["--remove-inactive", "-R"],
+          description: "Remove host names of inactive projects",
+        },
+      ],
+    },
+    {
+      name: ["import-db"],
+      description: "Import a sql file into the project.",
+      options: [
+        {
+          name: ["--extract-path"],
+          description:
+            "If provided asset is an archive, provide the path to extract within the archive.",
+          args: [{ name: "extract-path" }],
+        },
+        {
+          name: ["--no-drop"],
+          description: "Set if you do NOT want to drop the db before importing",
+        },
+        {
+          name: ["--progress", "-p"],
+          description: "Display a progress bar during import",
+        },
+        {
+          name: ["--src", "-f"],
+          description:
+            "Provide the path to a sql dump in .sql or tar/tar.gz/tgz/zip format",
+          args: [{ name: "src" }],
+        },
+        {
+          name: ["--target-db", "-d"],
+          description:
+            "If provided, target-db is alternate database to import into",
+          args: [{ name: "target-db", default: "db" }],
+        },
+      ],
+    },
+    {
+      name: ["import-files"],
+      description:
+        "Pull the uploaded files directory of an existing project to the default public upload directory of your project.",
+      options: [
+        {
+          name: ["--extract-path"],
+          description:
+            "If provided asset is an archive, optionally provide the path to extract within the archive.",
+          args: [{ name: "extract-path" }],
+        },
+        {
+          name: ["--src"],
+          description:
+            "Provide the path to the source directory or tar/tar.gz/tgz/zip archive of files to import",
+          args: [{ name: "src" }],
+        },
+      ],
+    },
+    {
+      name: ["l", "ls", "list"],
+      description: "List projects",
+      options: [
+        {
+          name: ["--active-only", "-A"],
+          description:
+            "If set, only currently active projects will be displayed.",
+        },
+        {
+          name: ["--continuous"],
+          description:
+            "If set, project information will be emitted until the command is stopped.",
+        },
+        {
+          name: ["--continuous-sleep-interval", "-I"],
+          description:
+            "Time in seconds between ddev list --continuous output lists.",
+          args: [{ name: "continuous-sleep-interval", default: "1" }],
+        },
+        {
+          name: ["--wrap-table", "-W"],
+          description: "Display table with wrapped text if required.",
+        },
+      ],
+    },
+    {
+      name: ["logs"],
+      description: "Get the logs from your running services.",
+      options: [
+        {
+          name: ["--follow", "-f"],
+          description: "Follow the logs in real time.",
+        },
+        {
+          name: ["--service", "-s"],
+          description:
+            "Defines the service to retrieve logs from. [e.g. web, db]",
+          args: [{ name: "service", default: "web" }],
+        },
+        {
+          name: ["--tail"],
+          description: "How many lines to show",
+          args: [{ name: "tail" }],
+        },
+        { name: ["--time", "-t"], description: "Add timestamps to logs" },
+      ],
+    },
+    {
+      name: ["mutagen"],
+      description: "Commands for mutagen status and sync, etc.",
+      subcommands: [
+        { name: ["monitor"], description: "Monitor mutagen status" },
+        { name: ["reset"], description: "Reset mutagen for project" },
+        {
+          name: ["st", "status"],
+          description: "Shows mutagen sync status",
+          options: [
+            {
+              name: ["--verbose", "-l"],
+              description: "Extended/verbose output for mutagen status",
+            },
+          ],
+        },
+        {
+          name: ["sync"],
+          description: "Explicit sync for mutagen",
+          options: [
+            {
+              name: ["--verbose"],
+              description: "Extended/verbose output for mutagen status",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: ["sc", "stop-containers", "pause"],
+      description:
+        "uses 'docker stop' to pause/stop the containers belonging to a project.",
+      options: [
+        { name: ["--all", "-a"], description: "Pause all running projects" },
+      ],
+    },
+    {
+      name: ["powerdown", "poweroff"],
+      description: "Completely stop all projects and containers",
+    },
+    {
+      name: ["pull"],
+      description:
+        "Pull files and database using a configured provider plugin.",
+    },
+    {
+      name: ["push"],
+      description:
+        "push files and database using a configured provider plugin.",
+    },
+    {
+      name: ["restart"],
+      description: "Restart a project or several projects.",
+      options: [{ name: ["--all", "-a"], description: "restart all projects" }],
+    },
+    {
+      name: ["service"],
+      description: "Add or remove, enable or disable extra services",
+      subcommands: [
+        { name: ["disable"], description: "disable a 3rd party service" },
+        { name: ["enable"], description: "Enable a 3rd party service" },
+      ],
+    },
+    {
+      name: ["share"],
+      description: "Share project on the internet via ngrok.",
+      options: [
+        {
+          name: ["--subdomain"],
+          description:
+            'ngrok --subdomain argument, as in "ngrok --subdomain my-subdomain:, requires paid ngrok.com account"',
+          args: [{ name: "subdomain" }],
+        },
+      ],
+    },
+    {
+      name: ["snapshot"],
+      description: "Create a database snapshot for one or more projects.",
+      options: [
+        {
+          name: ["--all", "-a"],
+          description:
+            "Snapshot all projects. Will start the project if it is stopped or paused",
+        },
+        { name: ["--cleanup", "-C"], description: "Cleanup snapshots" },
+        { name: ["--list", "-l"], description: "List snapshots" },
+        {
+          name: ["--name", "-n"],
+          description: "provide a name for the snapshot",
+          args: [{ name: "name" }],
+        },
+        {
+          name: ["--yes", "-y"],
+          description: "Yes - skip confirmation prompt",
+        },
+      ],
+    },
+    {
+      name: ["ssh"],
+      description:
+        "Starts a shell session in the container for a service. Uses web service by default.",
+      options: [
+        {
+          name: ["--dir", "-d"],
+          description: "Defines the destination directory within the container",
+          args: [{ name: "dir" }],
+        },
+        {
+          name: ["--service", "-s"],
+          description: "Defines the service to connect to. [e.g. web, db]",
+          args: [{ name: "service", default: "web" }],
+        },
+      ],
+    },
+    {
+      name: ["add", "start"],
+      description: "Start a ddev project.",
+      options: [
+        { name: ["--all", "-a"], description: "Start all projects" },
+        {
+          name: ["--select", "-s"],
+          description: "Interactively select a project to start",
+        },
+        {
+          name: ["--skip-confirmation", "-y"],
+          description: "Skip any confirmation steps",
+        },
+      ],
+    },
+    {
+      name: ["remove", "rm", "stop"],
+      description:
+        "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data.",
+      options: [
+        {
+          name: ["--all", "-a"],
+          description:
+            "Stop and remove all running or container-stopped projects and remove from global projects list",
+        },
+        {
+          name: ["--omit-snapshot", "-O"],
+          description: "Omit/skip database snapshot",
+        },
+        {
+          name: ["--remove-data", "-R"],
+          description: "Remove stored project data (MySQL, logs, etc.)",
+        },
+        {
+          name: ["--select", "-s"],
+          description: "Interactively select a project to stop",
+        },
+        { name: ["--snapshot", "-S"], description: "Create database snapshot" },
+        {
+          name: ["--stop-ssh-agent"],
+          description: "Stop the ddev-ssh-agent container",
+        },
+        {
+          name: ["--unlist", "-U"],
+          description:
+            "Remove the project from global project list, it won't show in ddev list until started again",
+        },
+      ],
+    },
+    {
+      name: ["version"],
+      description: "print ddev version and component versions",
+    },
+    {
+      name: ["help"],
+      description: "Help about any command",
+      subcommands: [
+        {
+          name: ["auth"],
+          description: "A collection of authentication commands",
+          subcommands: [
+            {
+              name: ["ssh"],
+              description:
+                "Add ssh key authentication to the ddev-ssh-auth container",
+            },
+          ],
+        },
+        { name: ["clean"], description: "Removes items ddev has created" },
+        {
+          name: ["composer"],
+          description: "Executes a composer command within the web container",
+          subcommands: [
+            {
+              name: ["create"],
+              description:
+                "Executes 'composer create-project' within the web container with the arguments and flags provided",
+            },
+            { name: ["create-project"], description: "" },
+          ],
+        },
+        {
+          name: ["config"],
+          description:
+            "Create or modify a ddev project configuration in the current directory",
+          subcommands: [
+            { name: ["global"], description: "Change global configuration" },
+          ],
+        },
+        {
+          name: ["d", "dbg", "debug"],
+          description: "A collection of debugging commands",
+          subcommands: [
+            {
+              name: ["capabilities"],
+              description: "Show capabilities of this version of ddev",
+            },
+            {
+              name: ["check-db-match"],
+              description:
+                "Verify that the database in the ddev-db server matches the configured type/version",
+            },
+            {
+              name: ["compose-config"],
+              description:
+                "Prints the docker-compose configuration of the current project",
+            },
+            {
+              name: ["configyaml"],
+              description: "Prints the project config.*.yaml usage",
+            },
+            {
+              name: ["dockercheck"],
+              description: "Diagnose DDEV docker/colima setup",
+            },
+            {
+              name: ["download-images"],
+              description: "Download all images required by ddev",
+            },
+            {
+              name: ["fix-commands"],
+              description:
+                "Fix up custom/shell commands without running ddev start",
+            },
+            {
+              name: ["get-volume-db-version"],
+              description:
+                "Get the database type/version found in the ddev-dbserver's database volume, which may not be the same as the configured database type/version",
+            },
+            {
+              name: ["migrate-database"],
+              description:
+                "Migrate a mysql or mariadb database to a different dbtype:dbversion; works only with mysql and mariadb, not with postgres",
+            },
+            {
+              name: ["mutagen"],
+              description: "Allows access to any mutagen command",
+            },
+            {
+              name: ["nfsmount"],
+              description:
+                "Checks to see if nfs mounting works for current project",
+            },
+            {
+              name: ["refresh"],
+              description: "Refreshes docker cache for project",
+            },
+            {
+              name: ["router-nginx-config"],
+              description: "Prints the nginx config of the router",
+            },
+            {
+              name: ["test"],
+              description:
+                "Run diagnostics on ddev using the embedded test_ddev.sh script",
+            },
+          ],
+        },
+        {
+          name: ["delete"],
+          description:
+            "Remove all project information (including database) for an existing project",
+          subcommands: [
+            {
+              name: ["images"],
+              description:
+                "Deletes drud/ddev-* docker images not in use by current ddev version",
+            },
+          ],
+        },
+        {
+          name: ["desc", "st", "status", "describe"],
+          description: "Get a detailed description of a running ddev project.",
+        },
+        {
+          name: [".", "exec"],
+          description:
+            "Execute a shell command in the container for a service. Uses the web service by default.",
+        },
+        {
+          name: ["export-db"],
+          description: "Dump a database to a file or to stdout",
+        },
+        {
+          name: ["get"],
+          description:
+            "Get/Download a 3rd party add-on (service, provider, etc.)",
+        },
+        { name: ["hostname"], description: "Manage your hostfile entries." },
+        {
+          name: ["import-db"],
+          description: "Import a sql file into the project.",
+        },
+        {
+          name: ["import-files"],
+          description:
+            "Pull the uploaded files directory of an existing project to the default public upload directory of your project.",
+        },
+        { name: ["l", "ls", "list"], description: "List projects" },
+        {
+          name: ["logs"],
+          description: "Get the logs from your running services.",
+        },
+        {
+          name: ["mutagen"],
+          description: "Commands for mutagen status and sync, etc.",
+          subcommands: [
+            { name: ["monitor"], description: "Monitor mutagen status" },
+            { name: ["reset"], description: "Reset mutagen for project" },
+            {
+              name: ["st", "status"],
+              description: "Shows mutagen sync status",
+            },
+            { name: ["sync"], description: "Explicit sync for mutagen" },
+          ],
+        },
+        {
+          name: ["sc", "stop-containers", "pause"],
+          description:
+            "uses 'docker stop' to pause/stop the containers belonging to a project.",
+        },
+        {
+          name: ["powerdown", "poweroff"],
+          description: "Completely stop all projects and containers",
+        },
+        {
+          name: ["pull"],
+          description:
+            "Pull files and database using a configured provider plugin.",
+        },
+        {
+          name: ["push"],
+          description:
+            "push files and database using a configured provider plugin.",
+        },
+        {
+          name: ["restart"],
+          description: "Restart a project or several projects.",
+        },
+        {
+          name: ["service"],
+          description: "Add or remove, enable or disable extra services",
+          subcommands: [
+            { name: ["disable"], description: "disable a 3rd party service" },
+            { name: ["enable"], description: "Enable a 3rd party service" },
+          ],
+        },
+        {
+          name: ["share"],
+          description: "Share project on the internet via ngrok.",
+        },
+        {
+          name: ["snapshot"],
+          description: "Create a database snapshot for one or more projects.",
+        },
+        {
+          name: ["ssh"],
+          description:
+            "Starts a shell session in the container for a service. Uses web service by default.",
+        },
+        { name: ["add", "start"], description: "Start a ddev project." },
+        {
+          name: ["remove", "rm", "stop"],
+          description:
+            "Stop and remove the containers of a project. Does not lose or harm anything unless you add --remove-data.",
+        },
+        {
+          name: ["version"],
+          description: "print ddev version and component versions",
+        },
+      ],
+    },
+  ],
+  options: [
+    {
+      name: ["--json-output", "-j"],
+      description: "If true, user-oriented output will be in JSON format.",
+      isPersistent: true,
+    },
+    { name: ["--help", "-h"], description: "Display help", isPersistent: true },
+  ],
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Spec addition: `ddev` for the [DDEV](https://ddev.com/) local development environment

**What is the current behavior? (You can also link to an open issue here)**

Currently `ddev` is not available

**What is the new behavior (if this is a feature change)?**

Adds the `ddev` spec

**Additional info:**

Leverages the Fig-provided Cobra module for generating the spec directly from the `ddev` command: https://github.com/drud/ddev/pull/4216