### PR TITLE
chore: clarify semver as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@types/glob": "^7.2.0",
     "fs": "^0.0.1-security",
     "strip-json-comments": "^4.0.0",
-    "yaml": "^1.10.2"
+    "yaml": "^1.10.2",
+    "semver": "^7.3.7"
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This fixes a bug with the `infracost` spec.
**What is the current behavior? (You can also link to an open issue here)**
Currently, the spec imports the `semver` package, but it is not listed as a dependency. This causes errors when using pnpm.
**What is the new behavior (if this is a feature change)?**
`semver` is added as a dependency in `package.json`.
**Additional info:**
Fixes #1516 