### PR TITLE
feat(sqlfluff): Add spec for sqlfluff

### DIFF
--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -37,6 +37,7 @@ const completionSpec: Fig.Spec = {
           name: ["--verbose", "-v"],
           description:
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+          isRepeatable: 5,
         },
         {
           name: ["--exclude-rules", "-e"],
@@ -211,6 +212,7 @@ const completionSpec: Fig.Spec = {
           name: ["--verbose", "-v"],
           description:
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+          isRepeatable: 5,
         },
         {
           name: ["--exclude-rules", "-e"],
@@ -375,6 +377,7 @@ const completionSpec: Fig.Spec = {
           name: ["--verbose", "-v"],
           description:
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+          isRepeatable: 5,
         },
         {
           name: ["--exclude-rules", "-e"],
@@ -525,6 +528,7 @@ const completionSpec: Fig.Spec = {
           name: ["--verbose", "-v"],
           description:
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+          isRepeatable: 5,
         },
       ],
     },
@@ -540,6 +544,7 @@ const completionSpec: Fig.Spec = {
           name: ["--verbose", "-v"],
           description:
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+          isRepeatable: 5,
         },
       ],
     },
@@ -555,6 +560,7 @@ const completionSpec: Fig.Spec = {
           name: ["--verbose", "-v"],
           description:
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+          isRepeatable: 5,
         },
       ],
     },

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -5,12 +5,12 @@ const completionSpec: Fig.Spec = {
     {
       name: "--version",
       description: "Show the version and exit",
-      persistent: true,
+      isPersistent: true,
     },
     {
       name: ["--help", "-h"],
       description: "Show help for sqlfluff",
-      persistent: true,
+      isPersistent: true,
     },
   ],
   subcommands: [

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -1,6 +1,18 @@
 const completionSpec: Fig.Spec = {
   name: "sqlfluff",
   description: "A dialect-flexible and configurable SQL linter",
+  options: [
+    {
+      name: "--version",
+      description: "Show the version and exit",
+      persistent: true,
+    },
+    {
+      name: ["--help", "-h"],
+      description: "Show help for sqlfluff",
+      persistent: true,
+    },
+  ],
   subcommands: [
     {
       name: "lint",
@@ -8,6 +20,7 @@ const completionSpec: Fig.Spec = {
       args: {
         template: "filepaths",
         isOptional: true,
+        isVariadic: true,
       },
       options: [
         {
@@ -18,6 +31,7 @@ const completionSpec: Fig.Spec = {
           name: ["--ignore", "-i"],
           description:
             "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally",
+          args: { name: "error" },
         },
         {
           name: ["--verbose", "-v"],
@@ -25,17 +39,28 @@ const completionSpec: Fig.Spec = {
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
         },
         {
-          name: ["--exclude_rules", "-e"],
+          name: ["--exclude-rules", "-e"],
           description:
             "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist",
+          args: {
+            name: "exclude_rules",
+          },
         },
         {
           name: ["--rules", "-r"],
           description: "Narrow the search to only specific rules",
+          args: {
+            name: "rules",
+          },
         },
         {
           name: ["--templater", "-t"],
           description: "The templater to use (default=jinja)",
+          args: {
+            name: "templater",
+            description: "Name of templater to use, eg. raw",
+            suggestions: ["raw", "jinja", "python", "placeholders"],
+          },
         },
         {
           name: ["--dialect", "-d"],
@@ -64,15 +89,24 @@ const completionSpec: Fig.Spec = {
           name: ["--format", "-f"],
           description:
             "What format to return the lint result in (default=human)",
+          args: {
+            name: "format",
+            suggestions: [
+              "human",
+              "json",
+              "yaml",
+              "github-annotation",
+              "github-annotation-native",
+            ],
+          },
         },
         {
           name: ["--processes", "-p"],
           description:
             "The number of parallel processes to run. Positive numbers work as expected. Zero and negative numbers will work as number_of_cpus - number. e.g -1 means all cpus except one. 0 means all cpus",
-        },
-        {
-          name: "--version",
-          description: "Show the version and exit",
+          args: {
+            name: "processes",
+          },
         },
         {
           name: "--disable-noqa",
@@ -95,6 +129,9 @@ const completionSpec: Fig.Spec = {
           name: "--encoding",
           description:
             "Specify encoding to use when reading and writing files. Defaults to autodetect",
+          args: {
+            name: "encoding",
+          },
         },
         {
           name: "--ignore-local-config",
@@ -105,11 +142,19 @@ const completionSpec: Fig.Spec = {
           name: "--config",
           description:
             "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required",
+          args: {
+            name: "extra_config_path",
+            template: "filepaths",
+          },
         },
         {
           name: "--write-output",
           description:
             "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging",
+          args: {
+            name: "write_output",
+            template: "filepaths",
+          },
         },
         {
           name: "--annotation-level",
@@ -147,6 +192,7 @@ const completionSpec: Fig.Spec = {
       args: {
         template: "filepaths",
         isOptional: true,
+        isVariadic: true,
       },
       options: [
         {
@@ -157,6 +203,9 @@ const completionSpec: Fig.Spec = {
           name: ["--ignore", "-i"],
           description:
             "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally",
+          args: {
+            name: "errors",
+          },
         },
         {
           name: ["--verbose", "-v"],
@@ -164,17 +213,28 @@ const completionSpec: Fig.Spec = {
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
         },
         {
-          name: ["--exclude_rules", "-e"],
+          name: ["--exclude-rules", "-e"],
           description:
             "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist",
+          args: {
+            name: "exclude_rules",
+          },
         },
         {
           name: ["--rules", "-r"],
           description: "Narrow the search to only specific rules",
+          args: {
+            name: "rules",
+          },
         },
         {
           name: ["--templater", "-t"],
           description: "The templater to use (default=jinja)",
+          args: {
+            name: "templater",
+            description: "Name of templater to use, eg. raw",
+            suggestions: ["raw", "jinja", "python", "placeholders"],
+          },
         },
         {
           name: ["--dialect", "-d"],
@@ -203,19 +263,31 @@ const completionSpec: Fig.Spec = {
           name: ["--format", "-f"],
           description:
             "What format to return the lint result in (default=human)",
+          args: {
+            name: "format",
+            suggestions: [
+              "human",
+              "json",
+              "yaml",
+              "github-annotation",
+              "github-annotation-native",
+            ],
+          },
         },
         {
           name: ["--processes", "-p"],
           description:
             "The number of parallel processes to run. Positive numbers work as expected. Zero and negative numbers will work as number_of_cpus - number. e.g -1 means all cpus except one. 0 means all cpus",
+          args: {
+            name: "processes",
+          },
         },
         {
           name: ["--fixed-suffix", "-x"],
           description: "An optional suffix to add to fixed files",
-        },
-        {
-          name: "--version",
-          description: "Show the version and exit",
+          args: {
+            name: "fixed_suffix",
+          },
         },
         {
           name: "--disable-noqa",
@@ -238,6 +310,9 @@ const completionSpec: Fig.Spec = {
           name: "--encoding",
           description:
             "Specify encoding to use when reading and writing files. Defaults to autodetect",
+          args: {
+            name: "encoding",
+          },
         },
         {
           name: "--ignore-local-config",
@@ -248,11 +323,19 @@ const completionSpec: Fig.Spec = {
           name: "--config",
           description:
             "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required",
+          args: {
+            name: "extra_config_path",
+            template: "filepaths",
+          },
         },
         {
           name: "--write-output",
           description:
             "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging",
+          args: {
+            name: "write_output",
+            template: "filepaths",
+          },
         },
         {
           name: "--disable-progress-bar",
@@ -284,6 +367,9 @@ const completionSpec: Fig.Spec = {
           name: ["--ignore", "-i"],
           description:
             "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally",
+          args: {
+            name: "errors",
+          },
         },
         {
           name: ["--verbose", "-v"],
@@ -291,17 +377,28 @@ const completionSpec: Fig.Spec = {
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
         },
         {
-          name: ["--exclude_rules", "-e"],
+          name: ["--exclude-rules", "-e"],
           description:
             "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist",
+          args: {
+            name: "exclude_rules",
+          },
         },
         {
           name: ["--rules", "-r"],
           description: "Narrow the search to only specific rules",
+          args: {
+            name: "rules",
+          },
         },
         {
           name: ["--templater", "-t"],
           description: "The templater to use (default=jinja)",
+          args: {
+            name: "templater",
+            description: "Name of templater to use, eg. raw",
+            suggestions: ["raw", "jinja", "python", "placeholders"],
+          },
         },
         {
           name: ["--dialect", "-d"],
@@ -339,10 +436,16 @@ const completionSpec: Fig.Spec = {
           name: ["--format", "-f"],
           description:
             "What format to return the lint result in (default=human)",
-        },
-        {
-          name: "--version",
-          description: "Show the version and exit",
+          args: {
+            name: "format",
+            suggestions: [
+              "human",
+              "json",
+              "yaml",
+              "github-annotation",
+              "github-annotation-native",
+            ],
+          },
         },
         {
           name: "--disable-noqa",
@@ -355,6 +458,9 @@ const completionSpec: Fig.Spec = {
         {
           name: "--recurse",
           description: "The depth to recursively parse to (0 for unlimited)",
+          args: {
+            name: "recurse",
+          },
         },
         {
           name: "--logger",
@@ -369,6 +475,9 @@ const completionSpec: Fig.Spec = {
           name: "--encoding",
           description:
             "Specify encoding to use when reading and writing files. Defaults to autodetect",
+          args: {
+            name: "encoding",
+          },
         },
         {
           name: "--ignore-local-config",
@@ -379,11 +488,19 @@ const completionSpec: Fig.Spec = {
           name: "--config",
           description:
             "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required",
+          args: {
+            name: "extra_config_path",
+            template: "filepaths",
+          },
         },
         {
           name: "--write-output",
           description:
             "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging",
+          args: {
+            name: "write_output",
+            template: "filepaths",
+          },
         },
         {
           name: "--profiler",
@@ -409,10 +526,6 @@ const completionSpec: Fig.Spec = {
           description:
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
         },
-        {
-          name: "--version",
-          description: "Show the version and exit",
-        },
       ],
     },
     {
@@ -428,10 +541,6 @@ const completionSpec: Fig.Spec = {
           description:
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
         },
-        {
-          name: "--version",
-          description: "Show the version and exit",
-        },
       ],
     },
     {
@@ -446,10 +555,6 @@ const completionSpec: Fig.Spec = {
           name: ["--verbose", "-v"],
           description:
             "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
-        },
-        {
-          name: "--version",
-          description: "Show the version and exit",
         },
       ],
     },

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -4,6 +4,10 @@ const completionSpec: Fig.Spec = {
   subcommands: [{
     name: "lint",
     description: "Lint SQL files via passing a list of files or using stdin",
+		args: {
+			template: "filepaths",
+			isOptional: true
+		},
 		options: [
 			{
 				name: ["--nocolor", "-n"], 
@@ -123,6 +127,10 @@ const completionSpec: Fig.Spec = {
 	{
 		name: "fix",
 		description: "Fix SQL files.",
+		args: {
+			template: "filepaths",
+			isOptional: true
+		},
 		options: [
 			{
 				name: ["--nocolor", "-n"], 
@@ -231,6 +239,10 @@ const completionSpec: Fig.Spec = {
 	{
 		name: "parse",
 		description: "Parse SQL files and just spit out the result.",
+		args: {
+			template: "filepaths",
+			isOptional: false
+		},
 		options: [
 			{
 				name: ["--nocolor", "-n"], 

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -119,6 +119,115 @@ const completionSpec: Fig.Spec = {
 				description: "Show help for sqlfluff" 
 			}
 		],
-	}],
+	},
+	{
+		name: "fix",
+		description: "Fix SQL files.",
+		options: [
+			{
+				name: ["--nocolor", "-n"], 
+				description: "No color - output will be without ANSI color codes." 
+			},
+			{
+				name: ["--ignore", "-i"], 
+				description: "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally."
+			},
+			{
+				name: ["--verbose", "-v"], 
+				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
+			},
+			{
+				name: ["--exclude_rules", "-e"], 
+				description: "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist." 
+			},
+			{
+				name: ["--rules", "-r"], 
+				description: "Narrow the search to only specific rules." 
+			},
+			{
+				name: ["--templater", "-t"], 
+				description: "The templater to use (default=jinja)" 
+			},
+			{
+				name: ["--dialect", "-d"], 
+				description: "The dialect of SQL to lint",
+				args: [
+					{
+						name: "dialect",
+						description: "Name of dialect, eg. ANSI.",
+						suggestions: [
+							"ansi", "bigquery", "exasol", "hive", "mysql",
+							"oracle", "postgres", "redshift", "snowflake", 
+							"spark3", "sqllite", "teradata", "tsql"
+						]
+					}
+				],
+			},
+			{
+				name: ["--format", "-f"],
+				description: "What format to return the lint result in (default=human)."
+			},
+			{
+				name: ["--processes", "-p"],
+				description: "The number of parallel processes to run. Positive numbers work as expected. Zero and negative numbers will work as number_of_cpus - number. e.g -1 means all cpus except one. 0 means all cpus."
+			},
+			{
+				name: ["--fixed-suffix", "-x"],
+				description: "An optional suffix to add to fixed files."
+			},
+			{
+				name: "--version",
+				description: "Show the version and exit."
+			},
+			{
+				name: "--disable-noqa",
+				description: "Set this flag to ignore inline noqa comments."
+			},
+			{
+				name: "--bench",
+				description: "Set this flag to engage the benchmarking tool output."
+			},
+			{
+				name: "--logger",
+				description: "Choose to limit the logging to one of the loggers.",
+				args: [
+					{
+						name: "logger",
+						description: "Name of logger to limit to, eg. templater.",
+						suggestions: ["templater", "lexer", "parser", "linter", "rules"]
+					},
+				],
+			},
+			{
+				name: "--encoding",
+				description: "Specify encoding to use when reading and writing files. Defaults to autodetect."
+			},
+			{
+				name: "--ignore-local-config",
+				description: "Ignore config files in default search path locations. This option allows the user to lint with the default config or can be used in conjunction with –config to only reference the custom config file."
+			},
+			{
+				name: "--config",
+				description: "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required."
+			},
+			{
+				name: "--write-output",
+				description: "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging."
+			},
+			{
+				name: "--disable-progress-bar",
+				description: "Disables progress bars."
+			},
+			{
+				name: "--FIX-EVEN-UNPARSABLE",
+				description: "Enables fixing of files that have templating or parse errors."
+			},
+			{
+				name: "--show-lint-violations",
+				description: "Show lint violations."
+			},
+		]
+	},
+	],
 };
 export default completionSpec;

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -228,6 +228,24 @@ const completionSpec: Fig.Spec = {
 			},
 		]
 	},
+	{
+		name: "dialects",
+		description: "Show the current dialects available.",
+		options: [
+			{
+				name: ["--nocolor", "-n"],
+				description: "No color - output will be without ANSI color codes."
+			},
+			{
+				name: ["--verbose", "-v"], 
+				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
+			},
+			{
+				name: "--version",
+				description: "Show the version and exit."
+			},
+		],
+	},
 	],
 };
 export default completionSpec;

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -229,6 +229,114 @@ const completionSpec: Fig.Spec = {
 		]
 	},
 	{
+		name: "parse",
+		description: "Parse SQL files and just spit out the result.",
+		options: [
+			{
+				name: ["--nocolor", "-n"], 
+				description: "No color - output will be without ANSI color codes." 
+			},
+			{
+				name: ["--ignore", "-i"], 
+				description: "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally."
+			},
+			{
+				name: ["--verbose", "-v"], 
+				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
+			},
+			{
+				name: ["--exclude_rules", "-e"], 
+				description: "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist." 
+			},
+			{
+				name: ["--rules", "-r"], 
+				description: "Narrow the search to only specific rules." 
+			},
+			{
+				name: ["--templater", "-t"], 
+				description: "The templater to use (default=jinja)" 
+			},
+			{
+				name: ["--dialect", "-d"], 
+				description: "The dialect of SQL to lint",
+				args: [
+					{
+						name: "dialect",
+						description: "Name of dialect, eg. ANSI.",
+						suggestions: [
+							"ansi", "bigquery", "exasol", "hive", "mysql",
+							"oracle", "postgres", "redshift", "snowflake", 
+							"spark3", "sqllite", "teradata", "tsql"
+						]
+					}
+				],
+			},
+			{
+				name: ["--code-only", "-c"],
+				description: "Output only the code elements of the parse tree."
+			},
+			{
+				name: ["--include-meta", "-m"],
+				description: "Include meta segments (indents, dedents and placeholders) in the output. This only applies when outputting json or yaml."
+			},
+			{
+				name: ["--format", "-f"],
+				description: "What format to return the lint result in (default=human)."
+			},
+			{
+				name: "--version",
+				description: "Show the version and exit."
+			},
+			{
+				name: "--disable-noqa",
+				description: "Set this flag to ignore inline noqa comments."
+			},
+			{
+				name: "--bench",
+				description: "Set this flag to engage the benchmarking tool output."
+			},
+			{
+				name: "--recurse",
+				description: "The depth to recursively parse to (0 for unlimited)."
+			},
+			{
+				name: "--logger",
+				description: "Choose to limit the logging to one of the loggers.",
+				args: [
+					{
+						name: "logger",
+						description: "Name of logger to limit to, eg. templater.",
+						suggestions: ["templater", "lexer", "parser", "linter", "rules"]
+					},
+				],
+			},
+			{
+				name: "--encoding",
+				description: "Specify encoding to use when reading and writing files. Defaults to autodetect."
+			},
+			{
+				name: "--ignore-local-config",
+				description: "Ignore config files in default search path locations. This option allows the user to lint with the default config or can be used in conjunction with –config to only reference the custom config file."
+			},
+			{
+				name: "--config",
+				description: "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required."
+			},
+			{
+				name: "--write-output",
+				description: "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging."
+			},
+			{
+				name: "--profiler",
+				description: "Set this flag to engage the python profiler."
+			},
+			{
+				name: "--nofail",
+				description: "If set, the exit code will always be zero, regardless of violations found. This is potentially useful during rollout."
+			},
+		]
+	},
+	{
 		name: "dialects",
 		description: "Show the current dialects available.",
 		options: [

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -1,0 +1,124 @@
+const completionSpec: Fig.Spec = {
+  name: "sqlfluff",
+  description: "a dialect-flexible and configurable SQL linter",
+  subcommands: [{
+    name: "lint",
+    description: "Lint SQL files via passing a list of files or using stdin",
+		options: [
+			{
+				name: ["--nocolor", "-n"], 
+				description: "No color - output will be without ANSI color codes." 
+			},
+			{
+				name: ["--ignore", "-i"], 
+				description: "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally."
+			},
+			{
+				name: ["--verbose", "-v"], 
+				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
+			},
+			{
+				name: ["--exclude_rules", "-e"], 
+				description: "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist." 
+			},
+			{
+				name: ["--rules", "-r"], 
+				description: "Narrow the search to only specific rules." 
+			},
+			{
+				name: ["--templater", "-t"], 
+				description: "The templater to use (default=jinja)" 
+			},
+			{
+				name: ["--dialect", "-d"], 
+				description: "The dialect of SQL to lint",
+				args: [
+					{
+						name: "dialect",
+						description: "Name of dialect, eg. ANSI.",
+						suggestions: [
+							"ansi", "bigquery", "exasol", "hive", "mysql",
+							"oracle", "postgres", "redshift", "snowflake", 
+							"spark3", "sqllite", "teradata", "tsql"
+						]
+					}
+				],
+			},
+			{
+				name: ["--format", "-f"],
+				description: "What format to return the lint result in (default=human)."
+			},
+			{
+				name: ["--processes", "-p"],
+				description: "The number of parallel processes to run. Positive numbers work as expected. Zero and negative numbers will work as number_of_cpus - number. e.g -1 means all cpus except one. 0 means all cpus."
+			},
+			{
+				name: "--version",
+				description: "Show the version and exit."
+			},
+			{
+				name: "--disable-noqa",
+				description: "Set this flag to ignore inline noqa comments."
+			},
+			{
+				name: "--bench",
+				description: "Set this flag to engage the benchmarking tool output."
+			},
+			{
+				name: "--logger",
+				description: "Choose to limit the logging to one of the loggers.",
+				args: [
+					{
+						name: "logger",
+						description: "Name of logger to limit to, eg. templater.",
+						suggestions: ["templater", "lexer", "parser", "linter", "rules"]
+					},
+				],
+			},
+			{
+				name: "--encoding",
+				description: "Specify encoding to use when reading and writing files. Defaults to autodetect."
+			},
+			{
+				name: "--ignore-local-config",
+				description: "Ignore config files in default search path locations. This option allows the user to lint with the default config or can be used in conjunction with –config to only reference the custom config file."
+			},
+			{
+				name: "--config",
+				description: "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required."
+			},
+			{
+				name: "--write-output",
+				description: "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging."
+			},
+			{
+				name: "--annotation-level",
+				description: "When format is set to github-annotation or github-annotation-native, default annotation level (default=notice). failure and error are equivalent.",
+				args: [
+					{
+						name: "annotation-level",
+						description: "Level of annotation, eg. notice.",
+						suggestions: ["notice", "warning", "failure", "error"]
+					},
+				],
+			},
+			{
+				name: "--disregard-sqlfluffignores",
+				description: "Perform the operation regardless of .sqlfluffignore configurations."
+			},
+			{
+				name: "--disable-progress-bar",
+				description: "Disables progress bars."
+			},
+			{
+				name: "--nofail",
+				description: "If set, the exit code will always be zero, regardless of violations found. This is potentially useful during rollout."
+			}, 
+			{ 
+				name: ["--help", "-h"], 
+				description: "Show help for sqlfluff" 
+			}
+		],
+	}],
+};
+export default completionSpec;

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -264,6 +264,24 @@ const completionSpec: Fig.Spec = {
 			},
 		],
 	},
+	{
+		name: "rules",
+		description: "Show the current rules in use.",
+		options: [
+			{
+				name: ["--nocolor", "-n"],
+				description: "No color - output will be without ANSI color codes."
+			},
+			{
+				name: ["--verbose", "-v"], 
+				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
+			},
+			{
+				name: "--version",
+				description: "Show the version and exit."
+			},
+		],
+	},
 	],
 };
 export default completionSpec;

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -1,407 +1,458 @@
 const completionSpec: Fig.Spec = {
   name: "sqlfluff",
-  description: "a dialect-flexible and configurable SQL linter",
-  subcommands: [{
-    name: "lint",
-    description: "Lint SQL files via passing a list of files or using stdin",
-		args: {
-			template: "filepaths",
-			isOptional: true
-		},
-		options: [
-			{
-				name: ["--nocolor", "-n"], 
-				description: "No color - output will be without ANSI color codes." 
-			},
-			{
-				name: ["--ignore", "-i"], 
-				description: "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally."
-			},
-			{
-				name: ["--verbose", "-v"], 
-				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
-			},
-			{
-				name: ["--exclude_rules", "-e"], 
-				description: "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist." 
-			},
-			{
-				name: ["--rules", "-r"], 
-				description: "Narrow the search to only specific rules." 
-			},
-			{
-				name: ["--templater", "-t"], 
-				description: "The templater to use (default=jinja)" 
-			},
-			{
-				name: ["--dialect", "-d"], 
-				description: "The dialect of SQL to lint",
-				args: [
-					{
-						name: "dialect",
-						description: "Name of dialect, eg. ANSI.",
-						suggestions: [
-							"ansi", "bigquery", "exasol", "hive", "mysql",
-							"oracle", "postgres", "redshift", "snowflake", 
-							"spark3", "sqllite", "teradata", "tsql"
-						]
-					}
-				],
-			},
-			{
-				name: ["--format", "-f"],
-				description: "What format to return the lint result in (default=human)."
-			},
-			{
-				name: ["--processes", "-p"],
-				description: "The number of parallel processes to run. Positive numbers work as expected. Zero and negative numbers will work as number_of_cpus - number. e.g -1 means all cpus except one. 0 means all cpus."
-			},
-			{
-				name: "--version",
-				description: "Show the version and exit."
-			},
-			{
-				name: "--disable-noqa",
-				description: "Set this flag to ignore inline noqa comments."
-			},
-			{
-				name: "--bench",
-				description: "Set this flag to engage the benchmarking tool output."
-			},
-			{
-				name: "--logger",
-				description: "Choose to limit the logging to one of the loggers.",
-				args: [
-					{
-						name: "logger",
-						description: "Name of logger to limit to, eg. templater.",
-						suggestions: ["templater", "lexer", "parser", "linter", "rules"]
-					},
-				],
-			},
-			{
-				name: "--encoding",
-				description: "Specify encoding to use when reading and writing files. Defaults to autodetect."
-			},
-			{
-				name: "--ignore-local-config",
-				description: "Ignore config files in default search path locations. This option allows the user to lint with the default config or can be used in conjunction with –config to only reference the custom config file."
-			},
-			{
-				name: "--config",
-				description: "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required."
-			},
-			{
-				name: "--write-output",
-				description: "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging."
-			},
-			{
-				name: "--annotation-level",
-				description: "When format is set to github-annotation or github-annotation-native, default annotation level (default=notice). failure and error are equivalent.",
-				args: [
-					{
-						name: "annotation-level",
-						description: "Level of annotation, eg. notice.",
-						suggestions: ["notice", "warning", "failure", "error"]
-					},
-				],
-			},
-			{
-				name: "--disregard-sqlfluffignores",
-				description: "Perform the operation regardless of .sqlfluffignore configurations."
-			},
-			{
-				name: "--disable-progress-bar",
-				description: "Disables progress bars."
-			},
-			{
-				name: "--nofail",
-				description: "If set, the exit code will always be zero, regardless of violations found. This is potentially useful during rollout."
-			}, 
-			{ 
-				name: ["--help", "-h"], 
-				description: "Show help for sqlfluff" 
-			}
-		],
-	},
-	{
-		name: "fix",
-		description: "Fix SQL files.",
-		args: {
-			template: "filepaths",
-			isOptional: true
-		},
-		options: [
-			{
-				name: ["--nocolor", "-n"], 
-				description: "No color - output will be without ANSI color codes." 
-			},
-			{
-				name: ["--ignore", "-i"], 
-				description: "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally."
-			},
-			{
-				name: ["--verbose", "-v"], 
-				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
-			},
-			{
-				name: ["--exclude_rules", "-e"], 
-				description: "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist." 
-			},
-			{
-				name: ["--rules", "-r"], 
-				description: "Narrow the search to only specific rules." 
-			},
-			{
-				name: ["--templater", "-t"], 
-				description: "The templater to use (default=jinja)" 
-			},
-			{
-				name: ["--dialect", "-d"], 
-				description: "The dialect of SQL to lint",
-				args: [
-					{
-						name: "dialect",
-						description: "Name of dialect, eg. ANSI.",
-						suggestions: [
-							"ansi", "bigquery", "exasol", "hive", "mysql",
-							"oracle", "postgres", "redshift", "snowflake", 
-							"spark3", "sqllite", "teradata", "tsql"
-						]
-					}
-				],
-			},
-			{
-				name: ["--format", "-f"],
-				description: "What format to return the lint result in (default=human)."
-			},
-			{
-				name: ["--processes", "-p"],
-				description: "The number of parallel processes to run. Positive numbers work as expected. Zero and negative numbers will work as number_of_cpus - number. e.g -1 means all cpus except one. 0 means all cpus."
-			},
-			{
-				name: ["--fixed-suffix", "-x"],
-				description: "An optional suffix to add to fixed files."
-			},
-			{
-				name: "--version",
-				description: "Show the version and exit."
-			},
-			{
-				name: "--disable-noqa",
-				description: "Set this flag to ignore inline noqa comments."
-			},
-			{
-				name: "--bench",
-				description: "Set this flag to engage the benchmarking tool output."
-			},
-			{
-				name: "--logger",
-				description: "Choose to limit the logging to one of the loggers.",
-				args: [
-					{
-						name: "logger",
-						description: "Name of logger to limit to, eg. templater.",
-						suggestions: ["templater", "lexer", "parser", "linter", "rules"]
-					},
-				],
-			},
-			{
-				name: "--encoding",
-				description: "Specify encoding to use when reading and writing files. Defaults to autodetect."
-			},
-			{
-				name: "--ignore-local-config",
-				description: "Ignore config files in default search path locations. This option allows the user to lint with the default config or can be used in conjunction with –config to only reference the custom config file."
-			},
-			{
-				name: "--config",
-				description: "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required."
-			},
-			{
-				name: "--write-output",
-				description: "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging."
-			},
-			{
-				name: "--disable-progress-bar",
-				description: "Disables progress bars."
-			},
-			{
-				name: "--FIX-EVEN-UNPARSABLE",
-				description: "Enables fixing of files that have templating or parse errors."
-			},
-			{
-				name: "--show-lint-violations",
-				description: "Show lint violations."
-			},
-		]
-	},
-	{
-		name: "parse",
-		description: "Parse SQL files and just spit out the result.",
-		args: {
-			template: "filepaths",
-			isOptional: false
-		},
-		options: [
-			{
-				name: ["--nocolor", "-n"], 
-				description: "No color - output will be without ANSI color codes." 
-			},
-			{
-				name: ["--ignore", "-i"], 
-				description: "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally."
-			},
-			{
-				name: ["--verbose", "-v"], 
-				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
-			},
-			{
-				name: ["--exclude_rules", "-e"], 
-				description: "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist." 
-			},
-			{
-				name: ["--rules", "-r"], 
-				description: "Narrow the search to only specific rules." 
-			},
-			{
-				name: ["--templater", "-t"], 
-				description: "The templater to use (default=jinja)" 
-			},
-			{
-				name: ["--dialect", "-d"], 
-				description: "The dialect of SQL to lint",
-				args: [
-					{
-						name: "dialect",
-						description: "Name of dialect, eg. ANSI.",
-						suggestions: [
-							"ansi", "bigquery", "exasol", "hive", "mysql",
-							"oracle", "postgres", "redshift", "snowflake", 
-							"spark3", "sqllite", "teradata", "tsql"
-						]
-					}
-				],
-			},
-			{
-				name: ["--code-only", "-c"],
-				description: "Output only the code elements of the parse tree."
-			},
-			{
-				name: ["--include-meta", "-m"],
-				description: "Include meta segments (indents, dedents and placeholders) in the output. This only applies when outputting json or yaml."
-			},
-			{
-				name: ["--format", "-f"],
-				description: "What format to return the lint result in (default=human)."
-			},
-			{
-				name: "--version",
-				description: "Show the version and exit."
-			},
-			{
-				name: "--disable-noqa",
-				description: "Set this flag to ignore inline noqa comments."
-			},
-			{
-				name: "--bench",
-				description: "Set this flag to engage the benchmarking tool output."
-			},
-			{
-				name: "--recurse",
-				description: "The depth to recursively parse to (0 for unlimited)."
-			},
-			{
-				name: "--logger",
-				description: "Choose to limit the logging to one of the loggers.",
-				args: [
-					{
-						name: "logger",
-						description: "Name of logger to limit to, eg. templater.",
-						suggestions: ["templater", "lexer", "parser", "linter", "rules"]
-					},
-				],
-			},
-			{
-				name: "--encoding",
-				description: "Specify encoding to use when reading and writing files. Defaults to autodetect."
-			},
-			{
-				name: "--ignore-local-config",
-				description: "Ignore config files in default search path locations. This option allows the user to lint with the default config or can be used in conjunction with –config to only reference the custom config file."
-			},
-			{
-				name: "--config",
-				description: "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required."
-			},
-			{
-				name: "--write-output",
-				description: "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging."
-			},
-			{
-				name: "--profiler",
-				description: "Set this flag to engage the python profiler."
-			},
-			{
-				name: "--nofail",
-				description: "If set, the exit code will always be zero, regardless of violations found. This is potentially useful during rollout."
-			},
-		]
-	},
-	{
-		name: "dialects",
-		description: "Show the current dialects available.",
-		options: [
-			{
-				name: ["--nocolor", "-n"],
-				description: "No color - output will be without ANSI color codes."
-			},
-			{
-				name: ["--verbose", "-v"], 
-				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
-			},
-			{
-				name: "--version",
-				description: "Show the version and exit."
-			},
-		],
-	},
-	{
-		name: "version",
-		description: "Show the version of sqlfluff.",
-		options: [
-			{
-				name: ["--nocolor", "-n"],
-				description: "No color - output will be without ANSI color codes."
-			},
-			{
-				name: ["--verbose", "-v"], 
-				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
-			},
-			{
-				name: "--version",
-				description: "Show the version and exit."
-			},
-		],
-	},
-	{
-		name: "rules",
-		description: "Show the current rules in use.",
-		options: [
-			{
-				name: ["--nocolor", "-n"],
-				description: "No color - output will be without ANSI color codes."
-			},
-			{
-				name: ["--verbose", "-v"], 
-				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
-			},
-			{
-				name: "--version",
-				description: "Show the version and exit."
-			},
-		],
-	},
-	],
+  description: "A dialect-flexible and configurable SQL linter",
+  subcommands: [
+    {
+      name: "lint",
+      description: "Lint SQL files via passing a list of files or using stdin",
+      args: {
+        template: "filepaths",
+        isOptional: true,
+      },
+      options: [
+        {
+          name: ["--nocolor", "-n"],
+          description: "No color - output will be without ANSI color codes",
+        },
+        {
+          name: ["--ignore", "-i"],
+          description:
+            "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally",
+        },
+        {
+          name: ["--verbose", "-v"],
+          description:
+            "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+        },
+        {
+          name: ["--exclude_rules", "-e"],
+          description:
+            "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist",
+        },
+        {
+          name: ["--rules", "-r"],
+          description: "Narrow the search to only specific rules",
+        },
+        {
+          name: ["--templater", "-t"],
+          description: "The templater to use (default=jinja)",
+        },
+        {
+          name: ["--dialect", "-d"],
+          description: "The dialect of SQL to lint",
+          args: {
+            name: "dialect",
+            description: "Name of dialect, eg. ANSI",
+            suggestions: [
+              "ansi",
+              "bigquery",
+              "exasol",
+              "hive",
+              "mysql",
+              "oracle",
+              "postgres",
+              "redshift",
+              "snowflake",
+              "spark3",
+              "sqllite",
+              "teradata",
+              "tsql",
+            ],
+          },
+        },
+        {
+          name: ["--format", "-f"],
+          description:
+            "What format to return the lint result in (default=human)",
+        },
+        {
+          name: ["--processes", "-p"],
+          description:
+            "The number of parallel processes to run. Positive numbers work as expected. Zero and negative numbers will work as number_of_cpus - number. e.g -1 means all cpus except one. 0 means all cpus",
+        },
+        {
+          name: "--version",
+          description: "Show the version and exit",
+        },
+        {
+          name: "--disable-noqa",
+          description: "Set this flag to ignore inline noqa comments",
+        },
+        {
+          name: "--bench",
+          description: "Set this flag to engage the benchmarking tool output",
+        },
+        {
+          name: "--logger",
+          description: "Choose to limit the logging to one of the loggers",
+          args: {
+            name: "logger",
+            description: "Name of logger to limit to, eg. templater",
+            suggestions: ["templater", "lexer", "parser", "linter", "rules"],
+          },
+        },
+        {
+          name: "--encoding",
+          description:
+            "Specify encoding to use when reading and writing files. Defaults to autodetect",
+        },
+        {
+          name: "--ignore-local-config",
+          description:
+            "Ignore config files in default search path locations. This option allows the user to lint with the default config or can be used in conjunction with –config to only reference the custom config file",
+        },
+        {
+          name: "--config",
+          description:
+            "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required",
+        },
+        {
+          name: "--write-output",
+          description:
+            "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging",
+        },
+        {
+          name: "--annotation-level",
+          description:
+            "When format is set to github-annotation or github-annotation-native, default annotation level (default=notice). failure and error are equivalent",
+          args: {
+            name: "annotation-level",
+            description: "Level of annotation, eg. notice",
+            suggestions: ["notice", "warning", "failure", "error"],
+          },
+        },
+        {
+          name: "--disregard-sqlfluffignores",
+          description:
+            "Perform the operation regardless of .sqlfluffignore configurations",
+        },
+        {
+          name: "--disable-progress-bar",
+          description: "Disables progress bars",
+        },
+        {
+          name: "--nofail",
+          description:
+            "If set, the exit code will always be zero, regardless of violations found. This is potentially useful during rollout",
+        },
+        {
+          name: ["--help", "-h"],
+          description: "Show help for sqlfluff",
+        },
+      ],
+    },
+    {
+      name: "fix",
+      description: "Fix SQL files",
+      args: {
+        template: "filepaths",
+        isOptional: true,
+      },
+      options: [
+        {
+          name: ["--nocolor", "-n"],
+          description: "No color - output will be without ANSI color codes",
+        },
+        {
+          name: ["--ignore", "-i"],
+          description:
+            "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally",
+        },
+        {
+          name: ["--verbose", "-v"],
+          description:
+            "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+        },
+        {
+          name: ["--exclude_rules", "-e"],
+          description:
+            "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist",
+        },
+        {
+          name: ["--rules", "-r"],
+          description: "Narrow the search to only specific rules",
+        },
+        {
+          name: ["--templater", "-t"],
+          description: "The templater to use (default=jinja)",
+        },
+        {
+          name: ["--dialect", "-d"],
+          description: "The dialect of SQL to lint",
+          args: {
+            name: "dialect",
+            description: "Name of dialect, eg. ANSI",
+            suggestions: [
+              "ansi",
+              "bigquery",
+              "exasol",
+              "hive",
+              "mysql",
+              "oracle",
+              "postgres",
+              "redshift",
+              "snowflake",
+              "spark3",
+              "sqllite",
+              "teradata",
+              "tsql",
+            ],
+          },
+        },
+        {
+          name: ["--format", "-f"],
+          description:
+            "What format to return the lint result in (default=human)",
+        },
+        {
+          name: ["--processes", "-p"],
+          description:
+            "The number of parallel processes to run. Positive numbers work as expected. Zero and negative numbers will work as number_of_cpus - number. e.g -1 means all cpus except one. 0 means all cpus",
+        },
+        {
+          name: ["--fixed-suffix", "-x"],
+          description: "An optional suffix to add to fixed files",
+        },
+        {
+          name: "--version",
+          description: "Show the version and exit",
+        },
+        {
+          name: "--disable-noqa",
+          description: "Set this flag to ignore inline noqa comments",
+        },
+        {
+          name: "--bench",
+          description: "Set this flag to engage the benchmarking tool output",
+        },
+        {
+          name: "--logger",
+          description: "Choose to limit the logging to one of the loggers",
+          args: {
+            name: "logger",
+            description: "Name of logger to limit to, eg. templater",
+            suggestions: ["templater", "lexer", "parser", "linter", "rules"],
+          },
+        },
+        {
+          name: "--encoding",
+          description:
+            "Specify encoding to use when reading and writing files. Defaults to autodetect",
+        },
+        {
+          name: "--ignore-local-config",
+          description:
+            "Ignore config files in default search path locations. This option allows the user to lint with the default config or can be used in conjunction with –config to only reference the custom config file",
+        },
+        {
+          name: "--config",
+          description:
+            "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required",
+        },
+        {
+          name: "--write-output",
+          description:
+            "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging",
+        },
+        {
+          name: "--disable-progress-bar",
+          description: "Disables progress bars",
+        },
+        {
+          name: "--FIX-EVEN-UNPARSABLE",
+          description:
+            "Enables fixing of files that have templating or parse errors",
+        },
+        {
+          name: "--show-lint-violations",
+          description: "Show lint violations",
+        },
+      ],
+    },
+    {
+      name: "parse",
+      description: "Parse SQL files and just spit out the result",
+      args: {
+        template: "filepaths",
+      },
+      options: [
+        {
+          name: ["--nocolor", "-n"],
+          description: "No color - output will be without ANSI color codes",
+        },
+        {
+          name: ["--ignore", "-i"],
+          description:
+            "Ignore particular families of errors so that they don’t cause a failed run. -–ignore behaves somewhat like noqa comments, except it applies globally",
+        },
+        {
+          name: ["--verbose", "-v"],
+          description:
+            "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+        },
+        {
+          name: ["--exclude_rules", "-e"],
+          description:
+            "Exclude specific rules. This could either be the allowlist, or the general set if there is no specific allowlist",
+        },
+        {
+          name: ["--rules", "-r"],
+          description: "Narrow the search to only specific rules",
+        },
+        {
+          name: ["--templater", "-t"],
+          description: "The templater to use (default=jinja)",
+        },
+        {
+          name: ["--dialect", "-d"],
+          description: "The dialect of SQL to lint",
+          args: {
+            name: "dialect",
+            description: "Name of dialect, eg. ANSI",
+            suggestions: [
+              "ansi",
+              "bigquery",
+              "exasol",
+              "hive",
+              "mysql",
+              "oracle",
+              "postgres",
+              "redshift",
+              "snowflake",
+              "spark3",
+              "sqllite",
+              "teradata",
+              "tsql",
+            ],
+          },
+        },
+        {
+          name: ["--code-only", "-c"],
+          description: "Output only the code elements of the parse tree",
+        },
+        {
+          name: ["--include-meta", "-m"],
+          description:
+            "Include meta segments (indents, dedents and placeholders) in the output. This only applies when outputting json or yaml",
+        },
+        {
+          name: ["--format", "-f"],
+          description:
+            "What format to return the lint result in (default=human)",
+        },
+        {
+          name: "--version",
+          description: "Show the version and exit",
+        },
+        {
+          name: "--disable-noqa",
+          description: "Set this flag to ignore inline noqa comments",
+        },
+        {
+          name: "--bench",
+          description: "Set this flag to engage the benchmarking tool output",
+        },
+        {
+          name: "--recurse",
+          description: "The depth to recursively parse to (0 for unlimited)",
+        },
+        {
+          name: "--logger",
+          description: "Choose to limit the logging to one of the loggers",
+          args: {
+            name: "logger",
+            description: "Name of logger to limit to, eg. templater",
+            suggestions: ["templater", "lexer", "parser", "linter", "rules"],
+          },
+        },
+        {
+          name: "--encoding",
+          description:
+            "Specify encoding to use when reading and writing files. Defaults to autodetect",
+        },
+        {
+          name: "--ignore-local-config",
+          description:
+            "Ignore config files in default search path locations. This option allows the user to lint with the default config or can be used in conjunction with –config to only reference the custom config file",
+        },
+        {
+          name: "--config",
+          description:
+            "Include additional config file. By default the config is generated from the standard configuration files described in the documentation. This argument allows you to specify an additional configuration file that overrides the standard configuration files. N.B. cfg format is required",
+        },
+        {
+          name: "--write-output",
+          description:
+            "Optionally provide a filename to write the results to, mostly used in tandem with –format. NB: Setting an output file re-enables normal stdout logging",
+        },
+        {
+          name: "--profiler",
+          description: "Set this flag to engage the python profiler",
+        },
+        {
+          name: "--nofail",
+          description:
+            "If set, the exit code will always be zero, regardless of violations found. This is potentially useful during rollout",
+        },
+      ],
+    },
+    {
+      name: "dialects",
+      description: "Show the current dialects available",
+      options: [
+        {
+          name: ["--nocolor", "-n"],
+          description: "No color - output will be without ANSI color codes",
+        },
+        {
+          name: ["--verbose", "-v"],
+          description:
+            "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+        },
+        {
+          name: "--version",
+          description: "Show the version and exit",
+        },
+      ],
+    },
+    {
+      name: "version",
+      description: "Show the version of sqlfluff",
+      options: [
+        {
+          name: ["--nocolor", "-n"],
+          description: "No color - output will be without ANSI color codes",
+        },
+        {
+          name: ["--verbose", "-v"],
+          description:
+            "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+        },
+        {
+          name: "--version",
+          description: "Show the version and exit",
+        },
+      ],
+    },
+    {
+      name: "rules",
+      description: "Show the current rules in use",
+      options: [
+        {
+          name: ["--nocolor", "-n"],
+          description: "No color - output will be without ANSI color codes",
+        },
+        {
+          name: ["--verbose", "-v"],
+          description:
+            "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv",
+        },
+        {
+          name: "--version",
+          description: "Show the version and exit",
+        },
+      ],
+    },
+  ],
 };
 export default completionSpec;

--- a/src/sqlfluff.ts
+++ b/src/sqlfluff.ts
@@ -246,6 +246,24 @@ const completionSpec: Fig.Spec = {
 			},
 		],
 	},
+	{
+		name: "version",
+		description: "Show the version of sqlfluff.",
+		options: [
+			{
+				name: ["--nocolor", "-n"],
+				description: "No color - output will be without ANSI color codes."
+			},
+			{
+				name: ["--verbose", "-v"], 
+				description: "Verbosity, how detailed should the output be. This is stackable, so -vv is more verbose than -v. For the most verbose option try -vvvv or -vvvvv." 
+			},
+			{
+				name: "--version",
+				description: "Show the version and exit."
+			},
+		],
+	},
 	],
 };
 export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds a spec for [sqlfluff](https://docs.sqlfluff.com/en/stable/index.html).

**Additional info:**

All documentation for subcommands and there arguments has been taken from [sqlfluff's CLI reference](https://docs.sqlfluff.com/en/stable/index.html).

I was able to check and test out everything from the fig-bot checklist locally, however seemed to keep running into this error whilst trying to make any commits:
<img width="555" alt="image.png" src="https://user-images.githubusercontent.com/67965197/192171111-24d35c65-42bc-41ea-b30e-6e53edb0de24.png">

I wanted to confirm if there was any issues if I pushed the actual commits, and did so with the `-n` flag. But I would appreciate any guidance on how to navigate that error for any future contributions.
Thank you very much in advance!

> Hello @anubhavsharma515, thank you very much for creating a Pull Request! Here is a small checklist to get this PR merged as quickly as possible:
> 
> * [x]  Do all subcommands / options which take arguments include the `args` property (`args: {}`)?
> * [x]  Are all options modular? E.g. `-a` `-u` `-x` instead of `-aux`
> * [x]  Have all other checks passed?
> 
> Please add a 👍 as a reaction to this comment to show that you read this.

