### PR TITLE
feat(gh): Add completion for aliases

### DIFF
--- a/src/gh.ts
+++ b/src/gh.ts
@@ -218,6 +218,20 @@ const completionSpec: Fig.Spec = {
     description: "Custom user defined gh alias",
     isOptional: true,
     generators: ghGenerators.listAlias,
+    parserDirectives: {
+      alias: async (token, executeShellCommand) => {
+        const out = await executeShellCommand(`gh alias list`);
+        const alias = out
+          .split("\n")
+          .find((line) => line.startsWith(`${token}:\t`));
+
+        if (!alias) {
+          throw new Error("Failed to parse alias");
+        }
+
+        return alias.slice(token.length + 1).trim();
+      },
+    },
   },
   subcommands: [
     {


### PR DESCRIPTION
<img width="459" alt="CleanShot 2022-09-28 at 11 02 10@2x" src="https://user-images.githubusercontent.com/52195359/192663975-6565f051-2d8d-4e55-974a-5f32f2d50dc9.png">

Adds support for completions for gh aliases