### PR TITLE
feat(gh): add missing `gh repo` completions

### DIFF
--- a/src/gh.ts
+++ b/src/gh.ts
@@ -183,6 +183,15 @@ const ghGenerators: Record<string, Fig.Generator> = {
 const ghOptions: Record<string, Fig.Option> = {
   help: { name: "--help", description: "Show help for command" },
   clone: { name: "--clone", description: "Clone the fork {true|false}" },
+  cloneGitFlags: {
+    name: "--",
+    description: "Flags to pass to git when cloning",
+    priority: 25,
+    args: {
+      name: "flags",
+      description: "Flags to pass to git when cloning",
+    },
+  },
   confirm: {
     name: ["-y", "--confirm"],
     description: "Skip the confirmation prompt",
@@ -1541,7 +1550,18 @@ Pass additional 'git clone' flags by listing them after '--'`,
               isOptional: true,
             },
           ],
-          options: [ghOptions.help],
+          options: [
+            ghOptions.help,
+            ghOptions.cloneGitFlags,
+            {
+              name: ["-u", "--upstream-remote-name"],
+              description:
+                'Upstream remote name when cloning a fork (default "upstream")',
+              args: {
+                name: "string",
+              },
+            },
+          ],
         },
         {
           name: "create",
@@ -1579,12 +1599,72 @@ Pass '--push' to push any local commits to the new repository`,
               description: "Make the repository internal",
             },
             {
-              name: "--enable-issues",
-              description: "Enable issues in the new repository {true|false}",
+              name: ["-p", "--template"],
+              description:
+                "Make the new repository based on a template repository",
+              args: {
+                name: "string",
+              },
             },
             {
-              name: "--enable-wiki",
-              description: "Enable wiki in the new repository {true|false}",
+              name: ["-c", "--clone"],
+              description: "Clone the new repository to the current directory",
+            },
+            {
+              name: "--disable-issues",
+              description: "Disable issues in the new repository",
+            },
+            {
+              name: "--disable-wiki",
+              description: "Disable wiki in the new repository",
+            },
+            {
+              name: ["-g", "--gitignore"],
+              description: "Specify a gitignore template for the repository",
+              args: {
+                name: "string",
+              },
+            },
+            {
+              name: ["-l", "--license"],
+              description: "Specify an Open Source License for the repository",
+              args: {
+                name: "string",
+              },
+            },
+            {
+              name: ["-r", "--remote"],
+              description: "Specify remote name for the new repository",
+              args: {
+                name: "string",
+              },
+            },
+            {
+              name: ["-s", "--source"],
+              description: "Specify path to local repository to use as source",
+              args: {
+                name: "string",
+              },
+            },
+            {
+              name: ["-t", "--team"],
+              description:
+                "The name of the organization team to be granted access",
+              args: {
+                name: "string",
+              },
+            },
+            {
+              name: "--include-all-branches",
+              description: "Include all branches from template repository",
+            },
+            {
+              name: "--push",
+              description: "Push local commits to the new repository",
+            },
+            {
+              name: "--add-readme",
+              description: "Add a README file to the new repository",
             },
           ],
         },
@@ -1617,7 +1697,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
               name: "--add-topic",
               description: "Add repository topic",
               args: {
-                name: "topic name",
+                name: "topic names",
               },
             },
             {
@@ -1681,7 +1761,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
               name: "--remove-topic",
               description: "Remove repository topic",
               args: {
-                name: "topic name",
+                name: "topic names",
               },
             },
             {
@@ -1690,9 +1770,13 @@ To authorize, run "gh auth refresh -s delete_repo"`,
                 "Make the repository available as a template repository",
             },
             {
-              name: "--visibility string",
+              name: "--visibility",
               description:
                 "Change the visibility of the repository to {public,private,internal}",
+              args: {
+                name: "string",
+                suggestions: ["public", "private", "internal"],
+              },
             },
           ],
         },
@@ -1714,7 +1798,11 @@ Additional 'git clone' flags can be passed in by listing them after '--'`,
           },
           options: [
             ghOptions.help,
-            ghOptions.clone,
+            ghOptions.cloneGitFlags,
+            {
+              name: "--clone",
+              description: "Clone the fork",
+            },
             {
               name: "--remote",
               description: "Add remote for fork {true|false}",
@@ -1723,6 +1811,20 @@ Additional 'git clone' flags can be passed in by listing them after '--'`,
               name: "--remote-name",
               description:
                 'Specify a name for a fork\'s new remote. (default "origin")',
+              args: {
+                name: "string",
+              },
+            },
+            {
+              name: "--org",
+              description: "Create the fork in an organization",
+              args: {
+                name: "string",
+              },
+            },
+            {
+              name: "--fork-name",
+              description: "Rename the forked repository",
               args: {
                 name: "string",
               },
@@ -1739,6 +1841,14 @@ For more information about output formatting flags, see 'gh help formatting'`,
           },
           options: [
             ghOptions.help,
+            {
+              name: "--visibility",
+              description: "Filter repositories by visibility",
+              args: {
+                name: "visibility",
+                suggestions: ["public", "private", "internal"],
+              },
+            },
             {
               name: "--archived",
               description: "Show only archived repositories",
@@ -1760,14 +1870,6 @@ For more information about output formatting flags, see 'gh help formatting'`,
               name: "--no-archived",
               description: "Omit archived repositories",
             },
-            {
-              name: "--private",
-              description: "Show only private repositories",
-            },
-            {
-              name: "--public",
-              description: "Show only public repositories",
-            },
             { name: "--source", description: "Show only non-forks" },
             {
               name: ["-q", "--jq"],
@@ -1781,6 +1883,23 @@ For more information about output formatting flags, see 'gh help formatting'`,
               name: ["-t", "--template"],
               description: "Format JSON output using a Go template",
             },
+            {
+              name: "--topic",
+              description: "Filter by topic",
+              args: {
+                name: "topic",
+              },
+            },
+            {
+              name: "--private",
+              description: "Show only private repositories",
+              deprecated: true,
+            },
+            {
+              name: "--public",
+              description: "Show only public repositories",
+              deprecated: true,
+            },
           ],
         },
         {
@@ -1791,7 +1910,19 @@ By default, this renames the current repository; otherwise renames the specified
             name: "new-name",
             isOptional: true,
           },
-          options: [ghOptions.help, ghOptions.confirm, ghOptions.all],
+          options: [
+            ghOptions.help,
+            ghOptions.confirm,
+            ghOptions.all,
+            {
+              name: ["-R", "--repo"],
+              description:
+                "Select another repository using the `[HOST/]OWNER/REPO` format",
+              args: {
+                name: "[HOST/]OWNER/REPO",
+              },
+            },
+          ],
         },
         {
           name: "sync",
@@ -1858,6 +1989,27 @@ For more information about output formatting flags, see 'gh help formatting'`,
             {
               name: ["-w", "--web"],
               description: "Open a repository in the browser",
+            },
+            {
+              name: ["-q", "--jq"],
+              description: "Filter JSON output using a jq expression",
+              args: {
+                name: "expression",
+              },
+            },
+            {
+              name: "--json",
+              description: "Output JSON with the specified fields",
+              args: {
+                name: "fields",
+              },
+            },
+            {
+              name: ["-t", "--template"],
+              description: "Format JSON output using a Go template",
+              args: {
+                name: "string",
+              },
             },
           ],
         },

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -1669,6 +1669,60 @@ Pass '--push' to push any local commits to the new repository`,
           ],
         },
         {
+          name: "deploy-key",
+          description: "Manage deploy keys in a repository",
+          subcommands: [
+            {
+              name: "add",
+              description: "Add a deploy key to a GitHub repository",
+              args: {
+                name: "key-file",
+                description: "Path to the public key file",
+                template: "filepaths",
+              },
+              options: [
+                ghOptions.help,
+                {
+                  name: ["-w", "--allow-write"],
+                  description: "Allow write access for the key",
+                },
+                {
+                  name: ["-t", "--title"],
+                  description: "Title of the new key",
+                  args: {
+                    name: "string",
+                  },
+                },
+              ],
+            },
+            {
+              name: "delete",
+              description: "Delete a deploy key from a GitHub repository",
+              args: {
+                name: "key-id",
+                description: "ID of the key to delete",
+              },
+              options: [ghOptions.help],
+            },
+            {
+              name: "list",
+              description: "List deploy keys in a GitHub repository",
+              options: [ghOptions.help],
+            },
+          ],
+          options: [
+            ghOptions.help,
+            {
+              name: ["-R", "--repo"],
+              description:
+                "Select another repository using the `[HOST/]OWNER/REPO` format",
+              args: {
+                name: "[HOST/]OWNER/REPO",
+              },
+            },
+          ],
+        },
+        {
           name: "delete",
           description: `Delete a GitHub repository.
 With no argument, deletes the current repository. Otherwise, deletes the specified repository.

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -190,6 +190,7 @@ const ghOptions: Record<string, Fig.Option> = {
     args: {
       name: "flags",
       description: "Flags to pass to git when cloning",
+      isVariadic: true,
     },
   },
   confirm: {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

The PR adds missing options to various `gh repo` subcommands, and updates a few which were removed/deprecated.

**What is the current behavior? (You can also link to an open issue here)**

The `gh repo` spec is missing many options in its various subcommands.

**What is the new behavior (if this is a feature change)?**

Following options have been added:

**New subcommands:**
- `deploy-key`

**New options:**
- `clone`
	- `-u`, `--upstream-remote-name`
	- `--`
- `create`
	- `-c`, `--clone`
	- `--enable-issues` --> `--disable-issues`
	- `--enable-wiki` --> `--disable-wiki`
	- `-g`, `--gitignore`
	- `-l`, `--license`
	- `-r`, `--remote`
	- `-s`, `--source`
	- `-t`, `--team`
	- `--include-all-brances`
	- `--push`
	- `-add-readme`
- `edit`
	- `--visibility`
- `fork`
	- `--`
	- `--clone`
	- `--org`
	- `--fork-name`
- `list`
	- `--visibility`
	- `--topic`
	- deprecate `--private`
	- deprecate `--public`
- `rename`
	- `-R`, `--repo`
- `view`
	- `-q`, `--jq`
	- `--json`
	- `-t`, `--template`

**Additional info:**
Declaration: I am _not_ participating in Hacktoberfest, this is not a spam submission! 😄 