### PR TITLE
feat(echo): add environment variable generator

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -6,7 +6,11 @@ const environmentVariableGenerator: Fig.Generator = {
       : out
           .split("\n")
           .map((env) => env.split("=")[0])
-          .map((suggestion) => ({ name: `$${suggestion}`, type: "option" })),
+          .map((suggestion) => ({
+            name: `$${suggestion}`,
+            type: "arg",
+            description: "Environment Variable",
+          })),
 };
 
 const completionSpec: Fig.Spec = {

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -1,3 +1,14 @@
+const environmentVariableGenerator: Fig.Generator = {
+  script: "env",
+  postProcess: (out) =>
+    out.length === 0
+      ? []
+      : out
+          .split("\n")
+          .map((env) => env.split("=")[0])
+          .map((suggestion) => ({ name: `$${suggestion}`, type: "option" })),
+};
+
 const completionSpec: Fig.Spec = {
   name: "echo",
   description: "Write arguments to the standard output",
@@ -5,6 +16,7 @@ const completionSpec: Fig.Spec = {
     name: "string",
     isVariadic: true,
     optionsCanBreakVariadicArg: false,
+    generators: environmentVariableGenerator,
   },
   options: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature: Generate args for environment variables on the users system.

**What is the current behavior? (You can also link to an open issue here)**
Fig currently only returns -n, -e and -E as options for the echo command.

**What is the new behavior (if this is a feature change)?**
Displays an arg for each environment currently contained on the system

**Additional info:**