### PR TITLE
feat(z): add z cache results to completion

### DIFF
--- a/src/z.ts
+++ b/src/z.ts
@@ -3,10 +3,53 @@ const completionSpec: Fig.Spec = {
   name: "z",
   description: "CLI tool to jump around directories",
   args: {
-    template: ["folders"],
-    name: "regex",
+    name: "directory",
     isVariadic: true,
     isOptional: true,
+    generators: {
+      script: "cat ${${ZSHZ_DATA:-${_Z_DATA:-${HOME}/.z}}:A}",
+      postProcess: (out, ctx) => {
+        const lines = out.split("\n").map((line) => {
+          const [path, weight, time] = line.split("|");
+          return {
+            path,
+            weight: Number(weight),
+            time: Number(time),
+          };
+        });
+
+        // filter for valid "directory" entries within the arguments
+        const args = ctx.filter(
+          (arg) => arg && arg !== "z" && !arg.startsWith("-")
+        );
+
+        // directory arg is variadic with each subsequent arg being an
+        // additional filter. filtered will filter directories by all args.
+        const filtered = lines.filter(({ path }) =>
+          args.every((arg) => path.includes(arg))
+        );
+
+        return filtered.map(({ path, weight, time }) => {
+          const splitPath = path.split("/");
+          const name = splitPath[splitPath.length - 1];
+
+          // arg is variadic but we don't want to suggest something
+          // that's already been entered. This 'if' prevents redundant
+          // suggestions.
+          if (!args.includes(name)) {
+            return {
+              name,
+              description: path,
+              // Docs state max weight is 100 but this seems
+              // to work regardless of any amount over that limit.
+              // Fig should defer assigning priority to z.
+              // 75 added to keep args above options.
+              priority: 75 + weight,
+            };
+          }
+        });
+      },
+    },
   },
   options: [
     {

--- a/src/z.ts
+++ b/src/z.ts
@@ -44,7 +44,8 @@ const completionSpec: Fig.Spec = {
               // to work regardless of any amount over that limit.
               // Fig should defer assigning priority to z.
               // 75 added to keep args above options.
-              priority: 75 + (weight >= 100 ? 100 : weight),
+              // NOTE: 9000 is the default max priority. If a custom value is set this will work if "custom_value <= 9000" but not otherwise
+              priority: 75 + (weight * 25 / 9000),
             };
           }
         });

--- a/src/z.ts
+++ b/src/z.ts
@@ -45,7 +45,7 @@ const completionSpec: Fig.Spec = {
               // Fig should defer assigning priority to z.
               // 75 added to keep args above options.
               // NOTE: 9000 is the default max priority. If a custom value is set this will work if "custom_value <= 9000" but not otherwise
-              priority: 75 + (weight * 25 / 9000),
+              priority: 75 + (weight * 25) / 9000,
             };
           }
         });

--- a/src/z.ts
+++ b/src/z.ts
@@ -44,7 +44,7 @@ const completionSpec: Fig.Spec = {
               // to work regardless of any amount over that limit.
               // Fig should defer assigning priority to z.
               // 75 added to keep args above options.
-              priority: 75 + weight,
+              priority: 75 + (weight >= 100 ? 100 : weight),
             };
           }
         });


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**

The current behavior is that z only shows the paths in the current folder. 

**What is the new behavior (if this is a feature change)?**

The PR changes the z completion to take into account the directories cached by z and the weighting that z provides them. Now you will be able to see all the possible paths that z can take you.

<img width="543" alt="image" src="https://user-images.githubusercontent.com/13592854/193857928-9550e019-2595-4ecf-8f68-c0fdbdca06ad.png">

**Additional info:**