### PR TITLE
feat(which): add generator to pull executables from $PATH

### DIFF
--- a/src/which.ts
+++ b/src/which.ts
@@ -1,9 +1,19 @@
+const programGenerator: Fig.Generator = {
+  script: `for i in $(echo $PATH | tr ":" "\n"); do find $i -maxdepth 1 -perm -111 -type f; done`,
+  postProcess: (out) =>
+    out
+      .split("\n")
+      .map((path) => path.split("/")[path.split("/").length - 1])
+      .map((pr) => ({ name: pr, description: "Executable file", type: "arg" })),
+};
+
 const completionSpec: Fig.Spec = {
   name: "which",
   description: "Locate a program in the user's PATH",
   args: {
     name: "names",
     isVariadic: true,
+    generators: programGenerator,
   },
   options: [
     {

--- a/src/which.ts
+++ b/src/which.ts
@@ -15,6 +15,7 @@ const completionSpec: Fig.Spec = {
     isVariadic: true,
     generators: programGenerator,
     filterStrategy: "fuzzy",
+    filterStrategy: "fuzzy",
   },
   options: [
     {

--- a/src/which.ts
+++ b/src/which.ts
@@ -14,6 +14,7 @@ const completionSpec: Fig.Spec = {
     name: "names",
     isVariadic: true,
     generators: programGenerator,
+    filterStrategy: "fuzzy",
   },
   options: [
     {

--- a/src/which.ts
+++ b/src/which.ts
@@ -15,7 +15,6 @@ const completionSpec: Fig.Spec = {
     isVariadic: true,
     generators: programGenerator,
     filterStrategy: "fuzzy",
-    filterStrategy: "fuzzy",
   },
   options: [
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
Currently which only suggests the -s and -a options

**What is the new behavior (if this is a feature change)?**
Suggests names of programs located in $PATH variable when running the "which" command ([issue that suggested this feature](https://github.com/withfig/autocomplete/issues/1527))

**Additional info:**