### PR TITLE
feat(whereis): add completion spec

### DIFF
--- a/src/whereis.ts
+++ b/src/whereis.ts
@@ -1,0 +1,59 @@
+const completionSpec: Fig.Spec = {
+  name: "whereis",
+  description: "Locate the binary, source, and manual page files for a command",
+  options: [
+    {
+      name: "-b",
+      description: "Search only for binaries",
+    },
+    {
+      name: "-m",
+      description: "Search only for manual sections",
+    },
+    {
+      name: "-s",
+      description: "Search only for sources",
+    },
+    {
+      name: "-u",
+      description: "Search for unusual entries",
+    },
+    {
+      name: "-B",
+      description: "Search for binaries only in the specified directory",
+      args: {
+        name: "directory",
+        description: "The directory to search in",
+        template: "folders",
+      },
+    },
+    {
+      name: "-M",
+      description: "Search for manual pages only in the specified directory",
+      args: {
+        name: "directory",
+        description: "The directory to search in",
+        template: "folders",
+      },
+    },
+    {
+      name: "-S",
+      description: "Search for sources only in the specified directory",
+      args: {
+        name: "directory",
+        description: "The directory to search in",
+        template: "folders",
+      },
+    },
+    {
+      name: "-f",
+      description: "Terminate the -B, -M, and -S options",
+    },
+  ],
+  // Only uncomment if whereis takes an argument
+  args: {
+    name: "Filename",
+    description: "The file to search for",
+  },
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
adds a completion spec for whereis 
fixes #1529 
**What is the current behavior? (You can also link to an open issue here)**
no spec for whereis
**What is the new behavior (if this is a feature change)?**
completion for whereis, no generator for main argument
**Additional info:**
NA