### PR TITLE
feat(login): Add completion spec

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -1,0 +1,41 @@
+const completionSpec: Fig.Spec = {
+  name: "login",
+  description: "Begin session on the system",
+  options: [
+    {
+      name: "-p",
+      description: "Preserve environment",
+    },
+    {
+      name: "-r",
+      description: "Perform autologin protocol for rlogin",
+    },
+    {
+      name: "-h",
+      description: "Specify host",
+      args: {
+        name: "host",
+      },
+    },
+    {
+      name: "-f",
+      description: "Don't authenticate user, user is preauthenticated",
+    },
+  ],
+  args: {
+    name: "username",
+    generators: {
+      script: "cat /etc/passwd",
+      postProcess: (out) => {
+        return out.split("\n").map((line) => {
+          const [username] = line.split(":");
+          return {
+            name: username,
+            icon: "👤",
+          };
+        });
+      },
+    },
+  },
+};
+export default completionSpec;


### PR DESCRIPTION
Add completion spec for `login` command
Based off [Ubuntu manpage](https://manpages.ubuntu.com/manpages/jammy/en/man1/login.1.html), potentially other OS have additional syntax and this won't work?

Closes #1537 