### PR TITLE
feat: dscacheutil spec

### DIFF
--- a/src/dscacheutil.ts
+++ b/src/dscacheutil.ts
@@ -1,0 +1,80 @@
+import { keyValue } from "@fig/autocomplete-generators";
+
+const categoryKeysMapping = {
+  group: ["name", "gid"],
+  host: ["name", "ip_address"],
+  mount: ["name"],
+  protocol: ["name", "number"],
+  rpc: ["name", "number"],
+  service: ["name", "port"],
+  user: ["name", "uid"],
+};
+const categories = Array.from(Object.keys(categoryKeysMapping));
+const associatedKeys = Array.from(Object.values(categoryKeysMapping));
+
+const completionSpec: Fig.Spec = {
+  name: "dscacheutil",
+  description: "Utility for managing the Directory Service cache",
+  subcommands: [
+    {
+      name: "-h",
+      description: "List the options for calling dscacheutil",
+    },
+    {
+      name: "-q",
+      description: "Query the Directory Service cache",
+      options: [
+        {
+          name: "-a",
+          description: "Attribute to query",
+          args: {
+            name: "name value",
+            generators: keyValue({
+              separator: " ",
+              keys: ["name", "gid", "ip_address", "port", "uid"],
+            }),
+          },
+        },
+      ],
+      args: {
+        name: "category",
+        description: "Category to query",
+        suggestions: categories,
+      },
+    },
+    {
+      name: "-cachedump",
+      description: "Get an overview of the cache by default",
+      options: [
+        {
+          name: "-buckets",
+          description: "Get an overview of the cache by default",
+        },
+        {
+          name: "-entries",
+          description: "Dump detailed information about cache entries",
+          args: {
+            name: "entry",
+            suggestions: categories,
+          },
+        },
+      ],
+    },
+    {
+      name: "-configuration",
+      description:
+        "Get the current configuration information, such as the search policy and cache parameters",
+    },
+    {
+      name: "-flushcache",
+      description: "Flush the entire cache",
+    },
+    {
+      name: "-statistics",
+      description:
+        "Get statistics from the cache, including an overview an detailed call statistics",
+    },
+  ],
+};
+
+export default completionSpec;

--- a/src/dscacheutil.ts
+++ b/src/dscacheutil.ts
@@ -1,5 +1,3 @@
-import { keyValue } from "@fig/autocomplete-generators";
-
 const categoryKeysMapping = {
   group: ["name", "gid"],
   host: ["name", "ip_address"],
@@ -38,7 +36,11 @@ const postProcessQuery =
 const dscacheutilGenerators: Record<string, Fig.Generator> = {
   keys: {
     custom: async (tokens, executeShellCommand) => {
-      const category = tokens[tokens.length - 2];
+      const category = tokens[tokens.length - 3];
+      if (!categories.includes(category)) {
+        return [];
+      }
+
       return categoryKeysMapping[category].map((key: string) => ({
         name: key,
       }));


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
closes #1553 
dscacheutil spec
**What is the current behavior? (You can also link to an open issue here)**
Not implemented
**What is the new behavior (if this is a feature change)?**
![Kapture 2022-10-06 at 13 35 41](https://user-images.githubusercontent.com/59517082/194381073-16e54ba7-bdda-43dc-af6f-539ba331581a.gif)
![Kapture 2022-10-06 at 20 25 01](https://user-images.githubusercontent.com/59517082/194441669-b2040901-4584-45a8-ab0b-517de59bb8c6.gif)

**Additional info:**
1. For the -q subcommand, we can improve -a arg suggestions if we can pass in the value passed to -q. Is this possible right now?
2. There seems to be a bug with the -buckets and -entries options in -cachedump since the name of those options are more than 1 character long (excluding the dash), chaining multiple don't work. See the gif below
![Kapture 2022-10-06 at 13 33 30](https://user-images.githubusercontent.com/59517082/194380834-77a85b9e-8de5-4fe7-be8b-67bc3e48248a.gif)
