### PR TITLE
feat(code): add missing flags

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -1,7 +1,7 @@
 const commonOptions: Fig.Option[] = [
   {
     name: ["-"],
-    description: "Read from stdin",
+    description: "Read from stdin (e.g. 'ps aux | grep code | code -')",
   },
   {
     name: ["-d", "--diff"],
@@ -165,7 +165,7 @@ const extensionManagementOptions: Fig.Option[] = [
   {
     name: "--install-extension",
     description:
-      "Installs or updates the extension. The identifier of an extension is always `${publisher}.${name}\n\nUse `--force` argument to update to latest version. To install a specific version provide `@${version}`. For example: 'vscode.csharp@1.2.3'",
+      "Installs or updates an extension. The argument is either an extension id or a path to a VSIX. The identifier of an extension is '${publisher}.${name}'. Use '--force' argument to update to latest version. To install a specific version provide '@${version}'. For example: 'vscode.csharp@1.2.3'",
     args: {
       // TODO: Create extension ID generator
       name: "extension-id[@version] | path-to-vsix",

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,5 +1,9 @@
 const commonOptions: Fig.Option[] = [
   {
+    name: ["-"],
+    description: "Read from stdin",
+  },
+  {
     name: ["-d", "--diff"],
     description: "Compare two files with each other",
     args: [
@@ -9,6 +13,28 @@ const commonOptions: Fig.Option[] = [
       },
       {
         name: "file",
+        template: "filepaths",
+      },
+    ],
+  },
+  {
+    name: ["-m", "--merge"],
+    description: "Perform a three-way merge by providing paths for two modified versions of a file, the common origin of both modified versions and the output file to save merge results",
+    args: [
+      {
+        name: "path1",
+        template: "filepaths",
+      },
+      {
+        name: "path2",
+        template: "filepaths",
+      },
+      {
+        name: "base",
+        template: "filepaths",
+      },
+      {
+        name: "result",
         template: "filepaths",
       },
     ],
@@ -78,6 +104,14 @@ const commonOptions: Fig.Option[] = [
     },
   },
   {
+    name: "--profile",
+    description:
+      "Opens the provided folder or workspace with the given profile and associates the profile with the workspace. If the profile does not exist, a new empty one is created. A folder or workspace must be provided for the profile to take effect",
+    args: {
+      name: "settingsProfileName",
+    },
+  },
+  {
     name: ["-h", "--help"],
     description: "Print usage",
   },
@@ -95,6 +129,10 @@ const extensionManagementOptions: Fig.Option[] = [
   {
     name: "--list-extensions",
     description: "List the installed extensions",
+  },
+  {
+    name: "--show-versions",
+    description: "Show versions of installed extensions, when using --list-extensions",
   },
   {
     name: "--category",
@@ -125,11 +163,6 @@ const extensionManagementOptions: Fig.Option[] = [
     },
   },
   {
-    name: "--show-versions",
-    description:
-      "Show versions of installed extensions, when using --list-extensions",
-  },
-  {
     name: "--install-extension",
     description:
       "Installs or updates the extension. The identifier of an extension is always `${publisher}.${name}\n\nUse `--force` argument to update to latest version. To install a specific version provide `@${version}`. For example: 'vscode.csharp@1.2.3'",
@@ -137,6 +170,10 @@ const extensionManagementOptions: Fig.Option[] = [
       // TODO: Create extension ID generator
       name: "extension-id[@version] | path-to-vsix",
     },
+  },
+  {
+    name: "--pre-release",
+    description: "Installs the pre-release version of the extension, when using --install-extension",
   },
   {
     name: "--uninstall-extension",

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,6 +1,6 @@
 const commonOptions: Fig.Option[] = [
   {
-    name: ["-"],
+    name: "-",
     description: "Read from stdin (e.g. 'ps aux | grep code | code -')",
   },
   {


### PR DESCRIPTION
Motivated by missing `-` option.

See also:

https://github.com/microsoft/vscode/blob/main/src/vs/platform/environment/node/argv.ts
Complete.

https://github.com/microsoft/vscode/blob/main/cli/src/commands/args.rs
Missing `profile`, maybe more.

https://github.com/microsoft/vscode/blob/main/resources/completions/zsh/_code
Missing `profile`, maybe more.

_(I'll open a PR on `microsoft/vscode` about those later)_

```
>code -v
1.71.2
```