### PR TITLE
feat: Add spec for `seq`

### DIFF
--- a/src/seq.ts
+++ b/src/seq.ts
@@ -1,0 +1,46 @@
+const completionSpec: Fig.Spec = {
+  name: "seq",
+  description: "Print sequences of numbers. (Defaults to increments of 1)",
+  args: [
+    {
+      name: "first",
+      description: "Starting number in sequence",
+    },
+    {
+      name: "step",
+      description: "Increment interval",
+      isOptional: true,
+    },
+    {
+      name: "last",
+      description: "Last number in sequence",
+      isOptional: true,
+    },
+  ],
+  options: [
+    {
+      name: "-w",
+      description:
+        "Equalize the widths of all numbers by padding with zeros as necessary",
+    },
+    {
+      name: "-s",
+      description: "String separator between numbers. Default is newline",
+      insertValue: `-s "{cursor}"`,
+      args: {
+        name: "string",
+        description: "Separator",
+      },
+    },
+    {
+      name: "-f",
+      description: "Use a printf(3) style format to print each number",
+      insertValue: `-f %{cursor}`,
+      args: {
+        name: "format",
+        description: "Print all numbers using format",
+      },
+    },
+  ],
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
- New spec

**What is the current behavior? (You can also link to an open issue here)**
- Resolves #1464 

**What is the new behavior (if this is a feature change)?**
- Add new `seq` spec

**Additional info:**
- [seq man page](https://man.openbsd.org/seq.1)
- `seq` doesn't take any subcommands and only takes in arguments and flags. If no flags are passed in, the only required argument is the `first` number. After that, it will optionally accept either a `step` or `last` argument and those arguments differ depending on whether two or all three arguments are passed in. 
   - The order of operations with flags and arguments affects the output and I was a little unsure of how to handle all the permutations so just wanted to mention that ahead of time in case there are any improvements that you think I need to make around that area.