### PR TITLE
feat: update yarn completion spec

### DIFF
--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1328,6 +1328,13 @@ const completionSpec: Fig.Spec = {
       name: "version",
       description: "Update version of your package",
       options: [
+        ...commonOptions,
+        { name: ["-h", "--help"], description: "Output usage information" },
+        {
+          name: "--new-version",
+          description: "New version",
+          args: { name: "version" },
+        },
         {
           name: "--major",
           description: "Auto-increment major version number",
@@ -1340,6 +1347,39 @@ const completionSpec: Fig.Spec = {
           name: "--patch",
           description: "Auto-increment patch version number",
         },
+        {
+          name: "--premajor",
+          description: "Auto-increment premajor version number",
+        },
+        {
+          name: "--preminor",
+          description: "Auto-increment preminor version number",
+        },
+        {
+          name: "--prepatch",
+          description: "Auto-increment prepatch version number",
+        },
+        {
+          name: "--prerelease",
+          description: "Auto-increment prerelease version number",
+        },
+        {
+          name: "--preid",
+          description: "Add a custom identifier to the prerelease",
+          args: { name: "preid" },
+        },
+        {
+          name: "--message",
+          description: "Message",
+          args: { name: "message" },
+        },
+        { name: "--no-git-tag-version", description: "No git tag version" },
+        {
+          name: "--no-commit-hooks",
+          description: "Bypass git hooks when committing new version",
+        },
+        { name: "--access", description: "Access", args: { name: "access" } },
+        { name: "--tag", description: "Tag", args: { name: "tag" } },
       ],
     },
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This addresses the changes in https://github.com/withfig/autocomplete/issues/1285
the yarn command has more options for the `yarn version` command so here I did:
`yarn version -h` then added all the options that were present that had to do with version.

**What is the current behavior? (You can also link to an open issue here)**
The current behavior is that it only shows `--major/minor/patch`

**What is the new behavior (if this is a feature change)?**
Now we show in addition to major/minor/patch:
message, premajor, preminor, prepatch, prerelease, preid, no-git-tag-version, no-commit-hooks, access, tag
Also, I added commonOptions, because I saw those were present as well with the `yarn version -h` command

