### PR TITLE
feat: add spec for multipass

### DIFF
--- a/src/multipass.ts
+++ b/src/multipass.ts
@@ -2,10 +2,12 @@ const sharedOpts: Record<string, Fig.Option> = {
   help: {
     name: ["-h", "--help"],
     description: "Displays help on commandline options",
+    isPersistent: true,
   },
   helpAll: {
     name: "--help-all",
     description: "Displays help including Qt specific options",
+    isPersistent: true,
   },
   verbose: {
     name: ["-v", "--verbose"],
@@ -13,6 +15,7 @@ const sharedOpts: Record<string, Fig.Option> = {
       "Increase logging verbosity. Repeat the 'v' in the short " +
       "option for more detail. Maximum verbosity is obtained " +
       "with 4 (or more) v's, i.e. -vvvv",
+    isPersistent: true,
   },
   format: {
     name: "--format",
@@ -129,25 +132,16 @@ const completionSpec: Fig.Spec = {
             "Name given to the alias being defined, defaults to <command>",
         },
       ],
-      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
     },
     {
       name: "aliases",
       description: "List available aliases",
-      options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
-        sharedOpts.format,
-      ],
+      options: [sharedOpts.format],
     },
     {
       name: "delete",
       description: "Delete instances",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         {
           name: "--all",
           description: "Delete all instances",
@@ -178,15 +172,11 @@ const completionSpec: Fig.Spec = {
           description: "Command to execute on the instance",
         },
       ],
-      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
     },
     {
       name: "find",
       description: "Display available images to create instances from",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         sharedOpts.format,
         {
           name: "--show-unsupported",
@@ -209,9 +199,6 @@ const completionSpec: Fig.Spec = {
       name: "get",
       description: "Get a configuration setting",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         {
           name: "--raw",
           description:
@@ -236,7 +223,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "help",
       description: "Display help about a command",
-      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
       args: {
         name: "command",
         description: "Name of command to display help for",
@@ -247,9 +233,6 @@ const completionSpec: Fig.Spec = {
       name: "info",
       description: "Display information about instances",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         sharedOpts.format,
         {
           name: "--all",
@@ -267,9 +250,6 @@ const completionSpec: Fig.Spec = {
       name: "launch",
       description: "Create and start an Ubuntu instance",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         sharedOpts.timeout,
         {
           name: ["-c", "--cpus"],
@@ -348,20 +328,12 @@ const completionSpec: Fig.Spec = {
     {
       name: "list",
       description: "List all available instances",
-      options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
-        sharedOpts.format,
-      ],
+      options: [sharedOpts.format],
     },
     {
       name: "mount",
       description: "Mount a local directory in the instance",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         {
           name: ["-g", "--gid-map"],
           description:
@@ -406,25 +378,16 @@ const completionSpec: Fig.Spec = {
     {
       name: "networks",
       description: "List all available networks interfaces",
-      options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
-        sharedOpts.format,
-      ],
+      options: [sharedOpts.format],
     },
     {
       name: "purge",
       description: "Purge all deleted instances permanently",
-      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
     },
     {
       name: "recover",
       description: "Recover deleted instances",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         {
           name: "--all",
           description: "Recover all deleted instances",
@@ -441,9 +404,6 @@ const completionSpec: Fig.Spec = {
       name: "restart",
       description: "Restart instances",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         sharedOpts.timeout,
         {
           name: "--all",
@@ -463,7 +423,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "set",
       description: "Set a configuration setting",
-      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
       args: {
         name: "key=value",
         description:
@@ -482,12 +441,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "shell",
       description: "Open a shell on a running instance",
-      options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
-        sharedOpts.timeout,
-      ],
+      options: [sharedOpts.timeout],
       args: {
         isVariadic: true,
         isOptional: true,
@@ -504,9 +458,6 @@ const completionSpec: Fig.Spec = {
       name: "start",
       description: "Start instances",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         sharedOpts.timeout,
         {
           name: "--all",
@@ -531,9 +482,6 @@ const completionSpec: Fig.Spec = {
       name: "stop",
       description: "Stop running instances",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         {
           name: "--all",
           description: "Stop all instances",
@@ -565,9 +513,6 @@ const completionSpec: Fig.Spec = {
       name: "suspend",
       description: "Suspend running instances",
       options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
         {
           name: "--all",
           description: "Suspend all instances",
@@ -586,7 +531,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "transfer",
       description: "Transfer files between the host and instances",
-      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
       args: [
         {
           isVariadic: true,
@@ -608,7 +552,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "umount",
       description: "Unmount a directory from an instance",
-      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
       args: {
         isVariadic: true,
         name: "mount",
@@ -621,7 +564,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "unalias",
       description: "Remove an alias",
-      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
       args: {
         name: "name",
         description: "The name of the alias to remove",
@@ -630,12 +572,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "version",
       description: "Show version details",
-      options: [
-        sharedOpts.help,
-        sharedOpts.helpAll,
-        sharedOpts.verbose,
-        sharedOpts.format,
-      ],
+      options: [sharedOpts.format],
     },
   ],
   options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],

--- a/src/multipass.ts
+++ b/src/multipass.ts
@@ -1,0 +1,102 @@
+const sharedOpts: Record<string, Fig.Option> = {
+  help: {
+    name: ["-h", "--help"],
+    description: "Displays help on commandline options",
+  },
+  helpAll: {
+    name: "--help-all",
+    description: "Displays help including Qt specific options",
+  },
+  verbose: {
+    name: ["-v", "--verbose"],
+    description:
+      "Increase logging verbosity. Repeat the 'v' in the short option for more detail. Maximum verbosity is obtained with 4 (or more) v's, i.e. -vvvv",
+  },
+};
+
+const completionSpec: Fig.Spec = {
+  name: "multipass",
+  description: "Create, control and connect to Ubuntu instances",
+  subcommands: [
+    {
+      name: "alias",
+      description: "Create an alias",
+      args: [
+        {
+          name: "options",
+          isOptional: true,
+        },
+        {
+          name: "definition",
+          description: "Alias definition in the form <instance>:<command>",
+        },
+        {
+          isOptional: true,
+          name: "name",
+          description:
+            "Name given to the alias being defined, defaults to <command>",
+        },
+      ],
+      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
+    },
+    {
+      name: "aliases",
+      description: "List available aliases",
+      options: [
+        sharedOpts.help,
+        sharedOpts.helpAll,
+        sharedOpts.verbose,
+        {
+          name: "--format",
+          description:
+            "Output list in the requested format. Valid formats are: table (default), json, csv and yaml",
+          args: {
+            name: "format",
+            suggestions: ["table", "csv", "json", "yaml"],
+          },
+        },
+      ],
+    },
+    {
+      name: "delete",
+      description: "Delete instances",
+      args: {
+        isVariadic: true,
+        name: "name",
+        description: "Name of instances to delete",
+      },
+      options: [
+        sharedOpts.help,
+        sharedOpts.helpAll,
+        sharedOpts.verbose,
+        {
+          name: "--all",
+          description: "Delete all instances",
+        },
+        {
+          name: ["-p", "--purge"],
+          description: "Purge instances immediately",
+        },
+      ],
+    },
+    {
+      name: "exec",
+      description: "Run a command on an instance",
+      args: [
+        {
+          name: "name",
+          description: "Name of the instance to run the command on",
+        },
+        {
+          name: "command",
+          description: "Command to execute on the instance",
+        },
+      ],
+      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
+    },
+  ],
+  options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
+  // Only uncomment if multipass takes an argument
+  // args: {}
+};
+export default completionSpec;

--- a/src/multipass.ts
+++ b/src/multipass.ts
@@ -39,41 +39,37 @@ const sharedOpts: Record<string, Fig.Option> = {
 };
 
 const multipassGenerators: Record<string, Fig.Generator> = {
-  allAvailableInstances: {
-    script: "multipass list --format=csv | tail -n +2",
+  allAvailableImages: {
+    script: "multipass find --format=json",
     postProcess: (out) => {
-      return out.split("\n").map((instance) => {
-        const instanceSplit = instance.split(",");
+      const images = JSON.parse(out).images;
+      return Object.keys(images).map((key) => {
         return {
-          name: instanceSplit[0],
-          description: instanceSplit[4],
+          name: key,
+          description: images[key].os + " " + images[key].release,
         };
       });
     },
   },
-  allAvailableImages: {
-    script: "multipass find --format=csv | tail -n +2",
+  allAvailableInstances: {
+    script: "multipass list --format=json",
     postProcess: (out) => {
-      return out.split("\n").map((image) => {
-        const imageSplit = image.split(",");
+      return JSON.parse(out).list.map((instance) => {
         return {
-          name: imageSplit[0],
-          description: imageSplit[3] + " " + imageSplit[4],
+          name: instance.name,
+          description: instance.release,
         };
       });
     },
   },
   allRunningInstances: {
-    script: "multipass list --format=csv | tail -n +2",
+    script: "multipass list --format=json",
     postProcess: (out) => {
-      // out = Name,State,IPv4,IPv6,Release,AllIPv4
-      // only return instances that are running
-      return out.split("\n").map((instance) => {
-        const instanceSplit = instance.split(",");
-        if (instanceSplit[1] === "RUNNING") {
+      return JSON.parse(out).list.map((instance) => {
+        if (instance.state === "Running") {
           return {
-            name: instanceSplit[0],
-            description: instanceSplit[4],
+            name: instance.name,
+            description: instance.release,
           };
         }
       });

--- a/src/multipass.ts
+++ b/src/multipass.ts
@@ -12,6 +12,16 @@ const sharedOpts: Record<string, Fig.Option> = {
     description:
       "Increase logging verbosity. Repeat the 'v' in the short option for more detail. Maximum verbosity is obtained with 4 (or more) v's, i.e. -vvvv",
   },
+  format: {
+    name: "--format",
+    description:
+      "Output list in the requested format. Valid formats are: table (default), json, csv and yaml",
+    args: {
+      name: "format",
+      suggestions: ["table", "json", "csv", "yaml"],
+      default: "table",
+    },
+  },
 };
 
 const completionSpec: Fig.Spec = {
@@ -46,15 +56,7 @@ const completionSpec: Fig.Spec = {
         sharedOpts.help,
         sharedOpts.helpAll,
         sharedOpts.verbose,
-        {
-          name: "--format",
-          description:
-            "Output list in the requested format. Valid formats are: table (default), json, csv and yaml",
-          args: {
-            name: "format",
-            suggestions: ["table", "csv", "json", "yaml"],
-          },
-        },
+        sharedOpts.format,
       ],
     },
     {
@@ -93,6 +95,81 @@ const completionSpec: Fig.Spec = {
         },
       ],
       options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
+    },
+    {
+      name: "find",
+      description: "Display available images to create instances from",
+      options: [
+        sharedOpts.help,
+        sharedOpts.helpAll,
+        sharedOpts.verbose,
+        sharedOpts.format,
+        {
+          name: "--show-unsupported",
+          description: "Show unsupported cloud images as well",
+        },
+      ],
+      args: {
+        name: "string",
+        description:
+          "An optional value to search for in [<remote:>]<string> format, where <remote> can be either 'release’ or 'daily’. If <remote> is omitted, it will search 'release' first, and if no matches are found, it will then search 'daily'. <string> can be a partial image hash or an Ubuntu release version, codename or alias",
+      },
+    },
+    {
+      name: "get",
+      description: "Get a configuration setting",
+      options: [
+        sharedOpts.help,
+        sharedOpts.helpAll,
+        sharedOpts.verbose,
+        {
+          name: "--raw",
+          description:
+            'Output in raw format. For now, this affects only the representation of empty values (i.e. "" instead of "<empty>")',
+        },
+      ],
+      args: {
+        name: "key",
+        description:
+          "Path to the setting whose configured value should be obtained",
+        suggestions: [
+          "client.gui.autostart",
+          "client.gui.hotkey",
+          "client.primary-name",
+          "local.bridged-network",
+          "local.driver",
+          "local.privileged-mounts",
+        ],
+      },
+    },
+    {
+      name: "help",
+      description: "Display help about a command",
+      options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],
+      args: {
+        name: "command",
+        description: "Name of command to display help for",
+        isOptional: true,
+      },
+    },
+    {
+      name: "info",
+      description: "Display information about instances",
+      options: [
+        sharedOpts.help,
+        sharedOpts.helpAll,
+        sharedOpts.verbose,
+        sharedOpts.format,
+        {
+          name: "--all",
+          description: "Display info for all instances",
+        },
+      ],
+      args: {
+        isVariadic: true,
+        name: "name",
+        description: "Names of instances to display information about",
+      },
     },
   ],
   options: [sharedOpts.help, sharedOpts.helpAll, sharedOpts.verbose],

--- a/src/multipass.ts
+++ b/src/multipass.ts
@@ -40,7 +40,7 @@ const sharedOpts: Record<string, Fig.Option> = {
 
 const multipassGenerators: Record<string, Fig.Generator> = {
   allAvailableInstances: {
-    script: "multipass list --format=csv | tail -n +2 | cut -d, -f1",
+    script: "multipass list --format=csv | tail -n +2",
     postProcess: (out) => {
       return out.split("\n").map((instance) => {
         const instanceSplit = instance.split(",");
@@ -64,7 +64,7 @@ const multipassGenerators: Record<string, Fig.Generator> = {
     },
   },
   allRunningInstances: {
-    script: "multipass list --format=csv | tail -n +2 | cut -d, -f1",
+    script: "multipass list --format=csv | tail -n +2",
     postProcess: (out) => {
       // out = Name,State,IPv4,IPv6,Release,AllIPv4
       // only return instances that are running


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

- New spec

**What is the current behavior? (You can also link to an open issue here)**

- Fig does not autocomplete this tool

**What is the new behavior (if this is a feature change)?**

- Add new spec for multipass ubuntu cli (https://multipass.run/)

**Additional info:**

TODO:
- [x] `multipass alias`
- [x] `multipass aliases`
- [x] `multipass delete`
- [x] `multipass exec`
- [x] `multipass find`
- [x] `multipass get`
- [x] `multipass help`
- [x] `multipass info`
- [x] `multipass launch`
- [x] `multipass list`
- [x] `multipass mount`
- [x] `multipass networks`
- [x] `multipass purge`
- [x] `multipass recover`
- [x] `multipass restart`
- [x] `multipass set`
- [x] `multipass shell`
- [x] `multipass start`
- [x] `multipass stop`
- [x] `multipass suspend`
- [x] `multipass transfer`
- [x] `multipass umount`
- [x] `multipass unalias`
- [x] `multipass version`
