### PR TITLE
feat: Add `pytest` spec

### DIFF
--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -63,7 +63,7 @@ const completionSpec: Fig.Spec = {
       name: "--code-highlight",
       description:
         "Whether code should be highlighted (only if --color is also enabled)",
-      dependsOn: "--color",
+      dependsOn: ["--color"],
       args: {
         name: "Highlight",
         suggestions: ["yes", "no"],

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -214,6 +214,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "Mode",
         default: "prepend",
+        suggestions: ["prepend", "append", "importlib"],
       },
     },
     {

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -10,6 +10,14 @@ const completionSpec: Fig.Spec = {
   },
   options: [
     {
+      name: "-c",
+      description:
+        "Load configuration from `file` instead of trying to locate one of the implicit configuration files",
+      args: {
+        name: "File",
+      },
+    },
+    {
       name: "--cache-clear",
       description: "Remove all cache contents at start of test run",
     },
@@ -41,12 +49,32 @@ const completionSpec: Fig.Spec = {
       },
     },
     {
+      name: ["--co", "--collect-only"],
+      description: "Only collect tests, don't execute them",
+    },
+    {
+      name: "--collect-in-virtualenv",
+      description: "Don't ignore tests in a local virtualenv directory",
+    },
+    {
       name: "--color",
       description: "Color terminal output",
       args: {
         name: "Color",
         description: "(yes/no/auto)",
       },
+    },
+    {
+      name: "--confcutdir",
+      description: "Only load conftest.py's relative to specified dir",
+      args: {
+        name: "Dir",
+      },
+    },
+
+    {
+      name: "--continue-on-collection-errors",
+      description: "Force test execution even if collection errors occur",
     },
     {
       name: "--durations",
@@ -65,8 +93,44 @@ const completionSpec: Fig.Spec = {
       },
     },
     {
+      name: "--deselect",
+      description:
+        "Deselect item (via node id prefix) during collection (multi-allowed)",
+      args: {
+        name: "nodeid_prefix",
+      },
+    },
+    {
       name: ["--disable-warnings", "--disable-pytest-warnings"],
       description: "Disable warnings summary",
+    },
+    {
+      name: "--doctest-continue-on-failure",
+      description:
+        "For a given doctest, continue to run after the first failure",
+    },
+    {
+      name: "--doctest-ignore-import-errors",
+      description: "Ignore doctest ImportErrors",
+    },
+    {
+      name: "--doctest-modules",
+      description: "Run doctests in all .py modules",
+    },
+    {
+      name: "--doctest-report",
+      description: "Choose another output format for diffs on doctest failure",
+      args: {
+        name: "Output format",
+        description: "None,cdiff,ndiff,udiff,only_first_failure",
+      },
+    },
+    {
+      name: "--doctest-glob",
+      description: "Doctests file matching pattern, default: test*.txt",
+      args: {
+        name: "Pattern",
+      },
     },
     {
       name: ["--exitfirst", "-x"],
@@ -95,6 +159,29 @@ const completionSpec: Fig.Spec = {
       description: "This shows help on command line and config-line options",
     },
     {
+      name: "--ignore",
+      description: "Ignore path during collection (multi-allowed)",
+      args: {
+        name: "Path",
+      },
+    },
+    {
+      name: "--ignore-glob",
+      description: "Ignore path pattern during collection (multi-allowed)",
+      args: {
+        name: "Path",
+      },
+    },
+    {
+      name: "--import-mode",
+      description:
+        "Prepend/append to sys.path when importing test modules and conftest files, default is to prepend",
+      args: {
+        name: "Mode",
+        default: "prepend",
+      },
+    },
+    {
       name: "--junit-xml",
       description: "Create junit-xml style report file at given path",
       args: {
@@ -121,6 +208,10 @@ const completionSpec: Fig.Spec = {
         name: "Expression",
         description: "Ex: 'test_method or test_other'",
       },
+    },
+    {
+      name: "--keep-duplicates",
+      description: "Keep duplicate tests",
     },
     {
       name: ["--showlocals", "-l"],
@@ -152,9 +243,20 @@ const completionSpec: Fig.Spec = {
       description: "Show markers (builtin, plugin and per-project ones)",
     },
     {
+      name: "--maxfail",
+      description: "Exit after first num failures or errors",
+      args: {
+        name: "num",
+      },
+    },
+    {
       name: ["--new-first", "--nf"],
       description:
         "Run tests from new files first, then the rest of the tests sorted by file mtime",
+    },
+    {
+      name: "--noconftest",
+      description: "Don't load any conftest.py files",
     },
     {
       name: "--no-header",
@@ -186,6 +288,10 @@ const completionSpec: Fig.Spec = {
       },
     },
     {
+      name: "--pyargs",
+      description: "Try to interpret all arguments as python packages",
+    },
+    {
       name: ["--quiet", "-q"],
       description: "Decrease verbosity",
     },
@@ -197,6 +303,15 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "chars",
         description: "",
+      },
+    },
+    {
+      name: "--rootdir",
+      description:
+        "Define root directory for tests. Can be relative path: 'root_dir', './root_dir', 'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables:\
+                    '$HOME/root_dir'",
+      args: {
+        name: "ROOTDIR",
       },
     },
     {
@@ -229,6 +344,20 @@ const completionSpec: Fig.Spec = {
         "Ignore the first failing test but stop on the next failing test",
     },
     {
+      name: "--strict",
+      description: "(deprecated) alias to --strict-markers",
+    },
+    {
+      name: "--strict-config",
+      description:
+        "Any warnings encountered while parsing the `pytest` section of the configuration file raise errors",
+    },
+    {
+      name: "--strict-markers",
+      description:
+        "Markers not registered in the `markers` section of the configuration file raise errors",
+    },
+    {
       name: "--tb",
       description: "Traceback print mode",
       args: {
@@ -257,6 +386,14 @@ const completionSpec: Fig.Spec = {
       description:
         "Display pytest version and information about plugins. \
         When given twice, also display information about plugins",
+    },
+    {
+      name: "--pythonwarnings, -W",
+      description:
+        "Set which warnings to report, see -W option of python itself",
+      args: {
+        name: "Python Warnings",
+      },
     },
   ],
 };

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -512,6 +512,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["--verbose", "-v"],
       description: "Increase verbosity",
+      isRepeatable: true,
     },
     {
       name: "--verbosity",

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -25,6 +25,7 @@ const completionSpec: Fig.Spec = {
         "Base temporary directory for this test run.(warning: this directory is removed if it exists)",
       args: {
         name: "Directory",
+        template: "folders",
       },
     },
     {
@@ -128,6 +129,7 @@ const completionSpec: Fig.Spec = {
       name: "--deselect",
       description:
         "Deselect item (via node id prefix) during collection (multi-allowed)",
+      isRepeatable: true,
       args: {
         name: "nodeid_prefix",
       },
@@ -194,6 +196,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--ignore",
       description: "Ignore path during collection (multi-allowed)",
+      isRepeatable: true,
       args: {
         name: "Path",
         template: "filepaths",
@@ -202,6 +205,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--ignore-glob",
       description: "Ignore path pattern during collection (multi-allowed)",
+      isRepeatable: true,
       args: {
         name: "Path",
         template: "filepaths",
@@ -391,6 +395,7 @@ const completionSpec: Fig.Spec = {
       name: "-p",
       description:
         "Early-load given plugin module name or entry point (multi-allowed)",
+      isRepeatable: true,
       args: {
         name: "Plugin name",
       },
@@ -441,7 +446,7 @@ const completionSpec: Fig.Spec = {
         "Define root directory for tests. Can be relative path: 'root_dir', './root_dir', 'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables:'$HOME/root_dir'",
       args: {
         name: "Root Dir",
-        template: "filepaths",
+        template: "folders",
       },
     },
     {

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -279,6 +279,7 @@ const completionSpec: Fig.Spec = {
       description: "Cli logging level",
       args: {
         name: "Log CLI Level",
+        suggestions: ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
       },
     },
     {

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -7,15 +7,16 @@ const completionSpec: Fig.Spec = {
       of the files of the form test_*.py or *_test.py in the current directory \
       and its subdirectories",
     isOptional: true,
-    template: ["filepaths", "folders"]
+    template: ["filepaths", "folders"],
   },
   options: [
     {
       name: "--assert",
-      description: "Control assertion debugging tools. 'plain' performs no assertion debugging. 'rewrite' (the default) rewrites assert statements in test modules on import to provide assert expression information",
+      description:
+        "Control assertion debugging tools. 'plain' performs no assertion debugging. 'rewrite' (the default) rewrites assert statements in test modules on import to provide assert expression information",
       args: {
         name: "Mode",
-        suggestions: ["plain", "rewrite"]
+        suggestions: ["plain", "rewrite"],
       },
     },
     {
@@ -28,10 +29,11 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "-c",
-      description: "Load configuration from `file` instead of trying to locate one of the implicit configuration files",
+      description:
+        "Load configuration from `file` instead of trying to locate one of the implicit configuration files",
       args: {
         name: "File",
-        template: "filepaths"
+        template: "filepaths",
       },
     },
     {
@@ -40,7 +42,8 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "--cache-show",
-      description: "Show cache contents, don't perform collection or tests. Optional argument: glob (default: '*')",
+      description:
+        "Show cache contents, don't perform collection or tests. Optional argument: glob (default: '*')",
       args: {
         name: "Glob",
         isOptional: true,
@@ -53,7 +56,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "Method",
         description: "One of fd|sys|no|tee-sys",
-        suggestions: ["fd", "sys", "no", "tee-sys"]
+        suggestions: ["fd", "sys", "no", "tee-sys"],
       },
     },
     {
@@ -63,7 +66,7 @@ const completionSpec: Fig.Spec = {
       dependsOn: "--color",
       args: {
         name: "Highlight",
-        suggestions: ["yes", "no"]
+        suggestions: ["yes", "no"],
       },
     },
     {
@@ -79,7 +82,7 @@ const completionSpec: Fig.Spec = {
       description: "Color terminal output",
       args: {
         name: "Color",
-        suggestions: ["yes", "no", "auto"]
+        suggestions: ["yes", "no", "auto"],
       },
     },
     {
@@ -87,7 +90,7 @@ const completionSpec: Fig.Spec = {
       description: "Only load conftest.py's relative to specified dir",
       args: {
         name: "Dir",
-        template: ["folders"]
+        template: ["folders"],
       },
     },
 
@@ -152,7 +155,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "Output format",
         description: "None,cdiff,ndiff,udiff,only_first_failure",
-        suggestions: ["none", "cdiff", "ndiff", "udiff", "only_first_failure"]
+        suggestions: ["none", "cdiff", "ndiff", "udiff", "only_first_failure"],
       },
     },
     {
@@ -160,7 +163,7 @@ const completionSpec: Fig.Spec = {
       description: "Doctests file matching pattern, default: test*.txt",
       args: {
         name: "Pattern",
-        default: "test*.txt"
+        default: "test*.txt",
       },
     },
     {
@@ -193,7 +196,7 @@ const completionSpec: Fig.Spec = {
       description: "Ignore path during collection (multi-allowed)",
       args: {
         name: "Path",
-        template: "filepaths"
+        template: "filepaths",
       },
     },
     {
@@ -201,7 +204,7 @@ const completionSpec: Fig.Spec = {
       description: "Ignore path pattern during collection (multi-allowed)",
       args: {
         name: "Path",
-        template: "filepaths"
+        template: "filepaths",
       },
     },
     {
@@ -218,7 +221,7 @@ const completionSpec: Fig.Spec = {
       description: "Create junit-xml style report file at given path",
       args: {
         name: "Path",
-        template: ["filepaths", "folders"]
+        template: ["filepaths", "folders"],
       },
     },
     {
@@ -267,7 +270,7 @@ const completionSpec: Fig.Spec = {
         "Auto-indent multiline messages passed to the logging module. Accepts true|on, false|off or an integer",
       args: {
         name: "Log Auto Indent Setting",
-        suggestions: ["true", "false"]
+        suggestions: ["true", "false"],
       },
     },
     {
@@ -374,11 +377,10 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["--override-ini", "-o"],
-      description:
-        "Override ini option with `option=value` style`",
+      description: "Override ini option with `option=value` style`",
       args: {
         name: "Override INI",
-        description: "Ex: `-o xfail_strict=True -o cache_dir=cache"
+        description: "Ex: `-o xfail_strict=True -o cache_dir=cache",
       },
     },
     {
@@ -394,7 +396,7 @@ const completionSpec: Fig.Spec = {
       description: "Send failed|all info to bpaste.net pastebin service",
       args: {
         name: "mode",
-        suggestions: ["failed", "all"]
+        suggestions: ["failed", "all"],
       },
     },
     {
@@ -426,7 +428,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "chars",
         suggestions: ["a", "A", "E", "f", "N", "p", "P", "s", "w", "x", "X"],
-        default: 'fE'
+        default: "fE",
       },
     },
     {
@@ -435,7 +437,7 @@ const completionSpec: Fig.Spec = {
         "Define root directory for tests. Can be relative path: 'root_dir', './root_dir', 'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables:'$HOME/root_dir'",
       args: {
         name: "Root Dir",
-        template: "filepaths"
+        template: "filepaths",
       },
     },
     {
@@ -482,7 +484,8 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "--strict",
-      description: "(deprecated) alias to --strict-markers",
+      description: "Alias to --strict-markers",
+      deprecated: true,
     },
     {
       name: "--strict-config",
@@ -499,7 +502,7 @@ const completionSpec: Fig.Spec = {
       description: "Traceback print mode",
       args: {
         name: "Traceback print mode",
-        suggestions: ["auto", "long", "short", "line", "native", "no"]
+        suggestions: ["auto", "long", "short", "line", "native", "no"],
       },
     },
     {

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -40,7 +40,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "--cache-show",
-      description: "Show cache contents, don't perform collection or tests. Optional argument: glob (default: '*').",
+      description: "Show cache contents, don't perform collection or tests. Optional argument: glob (default: '*')",
       args: {
         name: "Glob",
         isOptional: true,

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -10,6 +10,25 @@ const completionSpec: Fig.Spec = {
   },
   options: [
     {
+      name: "--assert",
+      description:
+        "Control assertion debugging tools. \
+                    'plain' performs no assertion debugging. \
+                    'rewrite' (the default) rewrites assert statements in \
+                    test modules on import to provide assert expression information",
+      args: {
+        name: "Mode",
+      },
+    },
+    {
+      name: "--basetemp",
+      description:
+        "Base temporary directory for this test run.(warning: this directory is removed if it exists)",
+      args: {
+        name: "Directory",
+      },
+    },
+    {
       name: "-c",
       description:
         "Load configuration from `file` instead of trying to locate one of the implicit configuration files",
@@ -75,6 +94,18 @@ const completionSpec: Fig.Spec = {
     {
       name: "--continue-on-collection-errors",
       description: "Force test execution even if collection errors occur",
+    },
+    {
+      name: "--debug",
+      description:
+        "Store internal tracing debug information in this log file. \
+                    This file is opened with 'w' and truncated as a result, care advised. \
+                    Defaults to 'pytestdebug.log'",
+      args: {
+        name: "DEBUG_FILE_NAME",
+        isOptional: true,
+        default: "pytestdebug.log",
+      },
     },
     {
       name: "--durations",
@@ -232,6 +263,82 @@ const completionSpec: Fig.Spec = {
         "Rerun only the tests that failed at the last run (or all if none failed)",
     },
     {
+      name: "--log-auto-indent",
+      description:
+        "Auto-indent multiline messages passed to the logging module. \
+                  Accepts true|on, false|off or an integer",
+      args: {
+        name: "Log Auto Indent Setting",
+      },
+    },
+    {
+      name: "--log-cli-level",
+      description: "Cli logging level",
+      args: {
+        name: "Log CLI Level",
+      },
+    },
+    {
+      name: "--log-cli-format",
+      description: "Log format as used by the logging module",
+      args: {
+        name: "Log CLI Format",
+      },
+    },
+    {
+      name: "--log-cli-date-format",
+      description: "Log date format as used by the logging module",
+      args: { name: "Log CLI Date Format" },
+    },
+    {
+      name: "--log-date-format",
+      description: "Log date format as used by the logging module",
+      args: { name: "Log Date Format" },
+    },
+    {
+      name: "--log-format",
+      description: "Log format as used by the logging module",
+      args: {
+        name: "Log Format",
+      },
+    },
+    {
+      name: "--log-file",
+      description: "Path to a file when logging will be written to",
+      args: {
+        name: "Log File Path",
+      },
+    },
+    {
+      name: "--log-file-level",
+      description: "Log file logging level",
+      args: {
+        name: "Log File Level",
+      },
+    },
+    {
+      name: "--log-file-date-format",
+      description: "Log date format as used by the logging module",
+      args: { name: "Log File Date Format" },
+    },
+    {
+      name: "--log-file-format",
+      description: "Log format as used by the logging module",
+      args: {
+        name: "Log File Format",
+      },
+    },
+    {
+      name: "--log-level",
+      description:
+        "Level of messages to catch/display. \
+          Not set by default, so it depends on the root/parent \
+          log handler's effective level, where it is `WARNING` by default",
+      args: {
+        name: "Level",
+      },
+    },
+    {
       name: "-m",
       description: "Only run tests matching given mark expression",
       args: {
@@ -265,6 +372,22 @@ const completionSpec: Fig.Spec = {
     {
       name: "--no-summary",
       description: "Disable summary",
+    },
+    {
+      name: ["--override-ini", "-o"],
+      description:
+        "Override ini option with `option=value` style, e.g. `-o xfail_strict=True -o cache_dir=cache`",
+      args: {
+        name: "OVERRIDE_INI",
+      },
+    },
+    {
+      name: "-p",
+      description:
+        "Early-load given plugin module name or entry point (multi-allowed)",
+      args: {
+        name: "Plugin name",
+      },
     },
     {
       name: "--pastebin",
@@ -311,7 +434,7 @@ const completionSpec: Fig.Spec = {
         "Define root directory for tests. Can be relative path: 'root_dir', './root_dir', 'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables:\
                     '$HOME/root_dir'",
       args: {
-        name: "ROOTDIR",
+        name: "Root Dir",
       },
     },
     {
@@ -324,11 +447,24 @@ const completionSpec: Fig.Spec = {
       description: "Shortcut for --capture=no",
     },
     {
+      name: "--setup-only",
+      description: "Only setup fixtures, do not execute tests",
+    },
+    {
+      name: "--setup-show",
+      description: "Show setup of fixtures while executing tests",
+    },
+    {
+      name: "--setup-plan",
+      description:
+        "Show what fixtures and tests would be executed but don't execute anything",
+    },
+    {
       name: "--show-capture",
       description:
         "Controls how captured stdout/stderr/log is shown on failed tests",
       args: {
-        name: "Capture",
+        name: "Capture method",
         description: "No,stdout,stderr,log,all",
         default: "all",
       },
@@ -361,13 +497,17 @@ const completionSpec: Fig.Spec = {
       name: "--tb",
       description: "Traceback print mode",
       args: {
-        name: "Style",
+        name: "Traceback print mode",
         description: "(auto/long/short/line/native/no)",
       },
     },
     {
       name: "--trace",
       description: "Immediately break when running each test",
+    },
+    {
+      name: " --trace-config",
+      description: "Trace considerations of conftest.py files",
     },
     {
       name: ["--verbose", "-v"],
@@ -377,7 +517,7 @@ const completionSpec: Fig.Spec = {
       name: "--verbosity",
       description: "Set verbosity. Default is 0",
       args: {
-        name: "verbosity",
+        name: "Verbosity level",
         default: "0",
       },
     },
@@ -392,7 +532,7 @@ const completionSpec: Fig.Spec = {
       description:
         "Set which warnings to report, see -W option of python itself",
       args: {
-        name: "Python Warnings",
+        name: "Warnings to report",
       },
     },
   ],

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -319,6 +319,7 @@ const completionSpec: Fig.Spec = {
       description: "Log file logging level",
       args: {
         name: "Log File Level",
+        suggestions: ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
       },
     },
     {

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -1,0 +1,263 @@
+const completionSpec: Fig.Spec = {
+  name: "pytest",
+  args: {
+    name: "File or Directory",
+    description:
+      "The test file or directory you want to run pytest on. If omitted, pytest will run all \
+      of the files of the form test_*.py or *_test.py in the current directory \
+      and its subdirectories",
+    isOptional: true,
+  },
+  options: [
+    {
+      name: "--cache-clear",
+      description: "Remove all cache contents at start of test run",
+    },
+    {
+      name: "--cache-show",
+      description: "",
+      args: {
+        name: "Glob",
+        description: "",
+        isOptional: true,
+        default: "*",
+      },
+    },
+    {
+      name: "--capture",
+      description: "Per-test capturing method",
+      args: {
+        name: "Method",
+        description: "One of fd|sys|no|tee-sys",
+      },
+    },
+    {
+      name: "--code-highlight",
+      description:
+        "Whether code should be highlighted (only if --color is also enabled)",
+      args: {
+        name: "",
+        description: "{yes,no}",
+      },
+    },
+    {
+      name: "--color",
+      description: "Color terminal output",
+      args: {
+        name: "Color",
+        description: "(yes/no/auto)",
+      },
+    },
+    {
+      name: "--durations",
+      description: "Show N slowest setup/test durations (N=0 for all)",
+      args: {
+        name: "N",
+        description: "(N=0 for all)",
+      },
+    },
+    {
+      name: "--durations-min",
+      description: "Minimal duration in seconds for inclusion in slowest list",
+      args: {
+        name: "N",
+        default: "0.005",
+      },
+    },
+    {
+      name: ["--disable-warnings", "--disable-pytest-warnings"],
+      description: "Disable warnings summary",
+    },
+    {
+      name: ["--exitfirst", "-x"],
+      description: "Exit instantly on first error or failed test",
+    },
+    {
+      name: ["--failed-first", "--ff"],
+      description: "Run all tests, but run the last failures first",
+    },
+    {
+      name: "--fixtures",
+      description:
+        "Shows builtin and custom fixtures. \
+        Note that this command omits fixtures with leading _ unless the -v option is added",
+    },
+    {
+      name: "--fixtures-per-test",
+      description: "Show fixtures per test",
+    },
+    {
+      name: "--full-trace",
+      description: "Don't cut any tracebacks (default is to cut)",
+    },
+    {
+      name: ["--help", "-h"],
+      description: "This shows help on command line and config-line options",
+    },
+    {
+      name: "--junit-xml",
+      description: "Create junit-xml style report file at given path",
+      args: {
+        name: "Path",
+      },
+    },
+    {
+      name: "--junit-prefix",
+      description: "Prepend prefix to classnames in junit-xml output",
+      args: {
+        name: "Str",
+        description: "String to prepend",
+      },
+    },
+    {
+      name: "-k",
+      description:
+        "Only run tests which match the given substring expression. An expression is a python evaluatable expression where all names are substring-matched against test names and their \
+                    parent classes. Example: -k 'test_method or test_other' matches all test functions and classes whose name contains 'test_method' or 'test_other', while -k 'not test_method' \
+                    matches those that don't contain 'test_method' in their names. -k 'not test_method and not test_other' will eliminate the matches. Additionally keywords are matched to \
+                    classes and functions containing extra names in their 'extra_keyword_matches' set, as well as functions which have names assigned directly to them. The matching is case- \
+                    insensitive",
+      args: {
+        name: "Expression",
+        description: "Ex: 'test_method or test_other'",
+      },
+    },
+    {
+      name: ["--showlocals", "-l"],
+      description: "Show locals in tracebacks (disabled by default)",
+    },
+
+    {
+      name: ["--last-failed-no-failures", "--lfnf"],
+      description: "Which tests to run with no previously (known) failures",
+      args: {
+        name: "{all, none}",
+        default: "all",
+      },
+    },
+    {
+      name: ["--last-failed", "--lf"],
+      description:
+        "Rerun only the tests that failed at the last run (or all if none failed)",
+    },
+    {
+      name: "-m",
+      description: "Only run tests matching given mark expression",
+      args: {
+        name: "Mark Expression",
+      },
+    },
+    {
+      name: "--markers",
+      description: "Show markers (builtin, plugin and per-project ones)",
+    },
+    {
+      name: ["--new-first", "--nf"],
+      description:
+        "Run tests from new files first, then the rest of the tests sorted by file mtime",
+    },
+    {
+      name: "--no-header",
+      description: "Disable header",
+    },
+    {
+      name: "--no-summary",
+      description: "Disable summary",
+    },
+    {
+      name: "--pastebin",
+      description: "Send failed|all info to bpaste.net pastebin service",
+      args: {
+        name: "mode",
+      },
+    },
+    {
+      name: "--pdb",
+      description:
+        "Start the interactive Python debugger on errors or KeyboardInterrupt",
+    },
+    {
+      name: "--pdbcls",
+      description:
+        "Specify a custom interactive Python debugger for use with --pdb",
+      args: {
+        name: "modulename:classname",
+        description: "Ex: --pdbcls=IPython.terminal.debugger:TerminalPdb",
+      },
+    },
+    {
+      name: ["--quiet", "-q"],
+      description: "Decrease verbosity",
+    },
+    {
+      name: "-r",
+      description:
+        "Show extra test summary info as specified by chars: (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed, (p)assed, (P)assed with output, (a)ll except passed (p/P), or (A)ll. \
+                    (w)arnings are enabled by default (see --disable-warnings), 'N' can be used to reset the list. (default: 'fE')",
+      args: {
+        name: "chars",
+        description: "",
+      },
+    },
+    {
+      name: "--runxfail",
+      description:
+        "Report the results of xfail tests as if they were not marked",
+    },
+    {
+      name: "-s",
+      description: "Shortcut for --capture=no",
+    },
+    {
+      name: "--show-capture",
+      description:
+        "Controls how captured stdout/stderr/log is shown on failed tests",
+      args: {
+        name: "Capture",
+        description: "No,stdout,stderr,log,all",
+        default: "all",
+      },
+    },
+    {
+      name: ["--stepwise", "--sw"],
+      description:
+        "Exit on test failure and continue from last failing test next time",
+    },
+    {
+      name: ["--stepwise-skip", "--sw-skip"],
+      description:
+        "Ignore the first failing test but stop on the next failing test",
+    },
+    {
+      name: "--tb",
+      description: "Traceback print mode",
+      args: {
+        name: "Style",
+        description: "(auto/long/short/line/native/no)",
+      },
+    },
+    {
+      name: "--trace",
+      description: "Immediately break when running each test",
+    },
+    {
+      name: ["--verbose", "-v"],
+      description: "Increase verbosity",
+    },
+    {
+      name: "--verbosity",
+      description: "Set verbosity. Default is 0",
+      args: {
+        name: "verbosity",
+        default: "0",
+      },
+    },
+    {
+      name: ["--version", "-V"],
+      description:
+        "Display pytest version and information about plugins. \
+        When given twice, also display information about plugins",
+    },
+  ],
+};
+export default completionSpec;

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -341,6 +341,7 @@ const completionSpec: Fig.Spec = {
         "Level of messages to catch/display. Not set by default, so it depends on the root/parent log handler's effective level, where it is `WARNING` by default",
       args: {
         name: "Level",
+        suggestions: ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
       },
     },
     {

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -306,7 +306,8 @@ const completionSpec: Fig.Spec = {
       description: "Path to a file where logging will be written to",
       args: {
         name: "Log File Path",
-        template: "filepaths"
+        template: "filepaths",
+        suggestCurrentToken: true,
       },
     },
     {

--- a/src/pytest.ts
+++ b/src/pytest.ts
@@ -7,17 +7,15 @@ const completionSpec: Fig.Spec = {
       of the files of the form test_*.py or *_test.py in the current directory \
       and its subdirectories",
     isOptional: true,
+    template: ["filepaths", "folders"]
   },
   options: [
     {
       name: "--assert",
-      description:
-        "Control assertion debugging tools. \
-                    'plain' performs no assertion debugging. \
-                    'rewrite' (the default) rewrites assert statements in \
-                    test modules on import to provide assert expression information",
+      description: "Control assertion debugging tools. 'plain' performs no assertion debugging. 'rewrite' (the default) rewrites assert statements in test modules on import to provide assert expression information",
       args: {
         name: "Mode",
+        suggestions: ["plain", "rewrite"]
       },
     },
     {
@@ -30,10 +28,10 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "-c",
-      description:
-        "Load configuration from `file` instead of trying to locate one of the implicit configuration files",
+      description: "Load configuration from `file` instead of trying to locate one of the implicit configuration files",
       args: {
         name: "File",
+        template: "filepaths"
       },
     },
     {
@@ -42,10 +40,9 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "--cache-show",
-      description: "",
+      description: "Show cache contents, don't perform collection or tests. Optional argument: glob (default: '*').",
       args: {
         name: "Glob",
-        description: "",
         isOptional: true,
         default: "*",
       },
@@ -56,15 +53,17 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "Method",
         description: "One of fd|sys|no|tee-sys",
+        suggestions: ["fd", "sys", "no", "tee-sys"]
       },
     },
     {
       name: "--code-highlight",
       description:
         "Whether code should be highlighted (only if --color is also enabled)",
+      dependsOn: "--color",
       args: {
-        name: "",
-        description: "{yes,no}",
+        name: "Highlight",
+        suggestions: ["yes", "no"]
       },
     },
     {
@@ -80,7 +79,7 @@ const completionSpec: Fig.Spec = {
       description: "Color terminal output",
       args: {
         name: "Color",
-        description: "(yes/no/auto)",
+        suggestions: ["yes", "no", "auto"]
       },
     },
     {
@@ -88,6 +87,7 @@ const completionSpec: Fig.Spec = {
       description: "Only load conftest.py's relative to specified dir",
       args: {
         name: "Dir",
+        template: ["folders"]
       },
     },
 
@@ -98,11 +98,9 @@ const completionSpec: Fig.Spec = {
     {
       name: "--debug",
       description:
-        "Store internal tracing debug information in this log file. \
-                    This file is opened with 'w' and truncated as a result, care advised. \
-                    Defaults to 'pytestdebug.log'",
+        "Store internal tracing debug information in this log file. This file is opened with 'w' and truncated as a result, care advised. Defaults to 'pytestdebug.log'",
       args: {
-        name: "DEBUG_FILE_NAME",
+        name: "Debug File Name",
         isOptional: true,
         default: "pytestdebug.log",
       },
@@ -154,6 +152,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "Output format",
         description: "None,cdiff,ndiff,udiff,only_first_failure",
+        suggestions: ["none", "cdiff", "ndiff", "udiff", "only_first_failure"]
       },
     },
     {
@@ -161,6 +160,7 @@ const completionSpec: Fig.Spec = {
       description: "Doctests file matching pattern, default: test*.txt",
       args: {
         name: "Pattern",
+        default: "test*.txt"
       },
     },
     {
@@ -174,8 +174,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--fixtures",
       description:
-        "Shows builtin and custom fixtures. \
-        Note that this command omits fixtures with leading _ unless the -v option is added",
+        "Shows builtin and custom fixtures. Note that this command omits fixtures with leading _ unless the -v option is added",
     },
     {
       name: "--fixtures-per-test",
@@ -194,6 +193,7 @@ const completionSpec: Fig.Spec = {
       description: "Ignore path during collection (multi-allowed)",
       args: {
         name: "Path",
+        template: "filepaths"
       },
     },
     {
@@ -201,6 +201,7 @@ const completionSpec: Fig.Spec = {
       description: "Ignore path pattern during collection (multi-allowed)",
       args: {
         name: "Path",
+        template: "filepaths"
       },
     },
     {
@@ -217,6 +218,7 @@ const completionSpec: Fig.Spec = {
       description: "Create junit-xml style report file at given path",
       args: {
         name: "Path",
+        template: ["filepaths", "folders"]
       },
     },
     {
@@ -230,11 +232,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "-k",
       description:
-        "Only run tests which match the given substring expression. An expression is a python evaluatable expression where all names are substring-matched against test names and their \
-                    parent classes. Example: -k 'test_method or test_other' matches all test functions and classes whose name contains 'test_method' or 'test_other', while -k 'not test_method' \
-                    matches those that don't contain 'test_method' in their names. -k 'not test_method and not test_other' will eliminate the matches. Additionally keywords are matched to \
-                    classes and functions containing extra names in their 'extra_keyword_matches' set, as well as functions which have names assigned directly to them. The matching is case- \
-                    insensitive",
+        "Only run tests which match the given substring expression. An expression is a python evaluatable expression where all names are substring-matched against test names and their parent classes. Example: -k 'test_method or test_other' matches all test functions and classes whose name contains 'test_method' or 'test_other', while -k 'not test_method' matches those that don't contain 'test_method' in their names. -k 'not test_method and not test_other' will eliminate the matches. Additionally keywords are matched to classes and functions containing extra names in their 'extra_keyword_matches' set, as well as functions which have names assigned directly to them. The matching is case- insensitive",
       args: {
         name: "Expression",
         description: "Ex: 'test_method or test_other'",
@@ -253,7 +251,8 @@ const completionSpec: Fig.Spec = {
       name: ["--last-failed-no-failures", "--lfnf"],
       description: "Which tests to run with no previously (known) failures",
       args: {
-        name: "{all, none}",
+        name: "Tests",
+        suggestions: ["all", "none"],
         default: "all",
       },
     },
@@ -265,10 +264,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "--log-auto-indent",
       description:
-        "Auto-indent multiline messages passed to the logging module. \
-                  Accepts true|on, false|off or an integer",
+        "Auto-indent multiline messages passed to the logging module. Accepts true|on, false|off or an integer",
       args: {
         name: "Log Auto Indent Setting",
+        suggestions: ["true", "false"]
       },
     },
     {
@@ -304,9 +303,10 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "--log-file",
-      description: "Path to a file when logging will be written to",
+      description: "Path to a file where logging will be written to",
       args: {
         name: "Log File Path",
+        template: "filepaths"
       },
     },
     {
@@ -331,9 +331,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "--log-level",
       description:
-        "Level of messages to catch/display. \
-          Not set by default, so it depends on the root/parent \
-          log handler's effective level, where it is `WARNING` by default",
+        "Level of messages to catch/display. Not set by default, so it depends on the root/parent log handler's effective level, where it is `WARNING` by default",
       args: {
         name: "Level",
       },
@@ -376,9 +374,10 @@ const completionSpec: Fig.Spec = {
     {
       name: ["--override-ini", "-o"],
       description:
-        "Override ini option with `option=value` style, e.g. `-o xfail_strict=True -o cache_dir=cache`",
+        "Override ini option with `option=value` style`",
       args: {
-        name: "OVERRIDE_INI",
+        name: "Override INI",
+        description: "Ex: `-o xfail_strict=True -o cache_dir=cache"
       },
     },
     {
@@ -394,6 +393,7 @@ const completionSpec: Fig.Spec = {
       description: "Send failed|all info to bpaste.net pastebin service",
       args: {
         name: "mode",
+        suggestions: ["failed", "all"]
       },
     },
     {
@@ -421,20 +421,20 @@ const completionSpec: Fig.Spec = {
     {
       name: "-r",
       description:
-        "Show extra test summary info as specified by chars: (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed, (p)assed, (P)assed with output, (a)ll except passed (p/P), or (A)ll. \
-                    (w)arnings are enabled by default (see --disable-warnings), 'N' can be used to reset the list. (default: 'fE')",
+        "Show extra test summary info as specified by chars: (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed, (p)assed, (P)assed with output, (a)ll except passed (p/P), or (A)ll. (w)arnings are enabled by default (see --disable-warnings), 'N' can be used to reset the list. (default: 'fE')",
       args: {
         name: "chars",
-        description: "",
+        suggestions: ["a", "A", "E", "f", "N", "p", "P", "s", "w", "x", "X"],
+        default: 'fE'
       },
     },
     {
       name: "--rootdir",
       description:
-        "Define root directory for tests. Can be relative path: 'root_dir', './root_dir', 'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables:\
-                    '$HOME/root_dir'",
+        "Define root directory for tests. Can be relative path: 'root_dir', './root_dir', 'root_dir/another_dir/'; absolute path: '/home/user/root_dir'; path with variables:'$HOME/root_dir'",
       args: {
         name: "Root Dir",
+        template: "filepaths"
       },
     },
     {
@@ -465,7 +465,7 @@ const completionSpec: Fig.Spec = {
         "Controls how captured stdout/stderr/log is shown on failed tests",
       args: {
         name: "Capture method",
-        description: "No,stdout,stderr,log,all",
+        suggestions: ["no", "stdout", "stderr", "log", "all"],
         default: "all",
       },
     },
@@ -498,7 +498,7 @@ const completionSpec: Fig.Spec = {
       description: "Traceback print mode",
       args: {
         name: "Traceback print mode",
-        description: "(auto/long/short/line/native/no)",
+        suggestions: ["auto", "long", "short", "line", "native", "no"]
       },
     },
     {
@@ -524,8 +524,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["--version", "-V"],
       description:
-        "Display pytest version and information about plugins. \
-        When given twice, also display information about plugins",
+        "Display pytest version and information about plugins. When given twice, also display information about plugins",
     },
     {
       name: "--pythonwarnings, -W",


### PR DESCRIPTION
Add spec file for pytest cli

Additional info:
The [pytest](https://docs.pytest.org/en/7.1.x/) framework makes it easy to write small, readable tests, and can scale to support complex functional testing for applications and libraries.

