### PR TITLE
feat(fig): use fig internal command to list themes

### DIFF
--- a/src/fig/shared.ts
+++ b/src/fig/shared.ts
@@ -65,7 +65,7 @@ const disableForCommandsGenerator: Fig.Generator = {
 };
 
 export const themesGenerator: Fig.Generator = {
-  script: "\\ls -1 ~/.fig/themes",
+  script: "fig theme --list",
   postProcess: (output) => {
     const builtinThemes = [
       {


### PR DESCRIPTION
`fig theme --list` has been in the CLI a sufficient enough time (months) and will help migrate to Fig v2s new location for the theme folder
