### PR TITLE
feat: add spec for `mdls`

### DIFF
--- a/src/mdls.ts
+++ b/src/mdls.ts
@@ -1,6 +1,9 @@
 const completionSpec: Fig.Spec = {
   name: "mdls",
   description: "Lists the metadata attributes for the specified file",
+  parserDirectives: {
+    flagsArePosixNoncompliant: true,
+  },
   args: {
     name: "file",
     template: "filepaths",

--- a/src/mdls.ts
+++ b/src/mdls.ts
@@ -64,6 +64,7 @@ const completionSpec: Fig.Spec = {
       insertValue: `--nullMarker "{cursor}"`,
       dependsOn: ["--raw", "-raw"],
     },
+    // TODO(platform): Add --plist macos only option
   ],
 };
 export default completionSpec;

--- a/src/mdls.ts
+++ b/src/mdls.ts
@@ -1,0 +1,66 @@
+const completionSpec: Fig.Spec = {
+  name: "mdls",
+  description: "Lists the metadata attributes for the specified file",
+  args: {
+    name: "file",
+    template: "filepaths",
+    isVariadic: true,
+  },
+  options: [
+    {
+      name: ["--name", "-name"],
+      description:
+        "Print only the matching metadata attribute value.  Can be used multiple times",
+      isRepeatable: true,
+      args: {
+        name: "attributeName",
+        description: "Metadata attribute name",
+        suggestions: [
+          "_kMDItemDisplayNameWithExtensions",
+          "kMDItemContentCreationDate",
+          "kMDItemContentCreationDate_Ranking",
+          "kMDItemContentModificationDate",
+          "kMDItemContentModificationDate_Ranking",
+          "kMDItemContentType",
+          "kMDItemContentTypeTree",
+          "kMDItemDateAdded",
+          "kMDItemDateAdded_Ranking",
+          "kMDItemDisplayName",
+          "kMDItemDocumentIdentifier",
+          "kMDItemFSContentChangeDate",
+          "kMDItemFSCreationDate",
+          "kMDItemFSCreatorCode",
+          "kMDItemFSFinderFlags",
+          "kMDItemFSHasCustomIcon",
+          "kMDItemFSInvisible",
+          "kMDItemFSIsExtensionHidden",
+          "kMDItemFSIsStationery",
+          "kMDItemFSLabel",
+          "kMDItemFSName",
+          "kMDItemFSNodeCount",
+          "kMDItemFSOwnerGroupID",
+          "kMDItemFSOwnerUserID",
+          "kMDItemFSSize",
+          "kMDItemFSTypeCode",
+          "kMDItemInterestingDate_Ranking",
+          "kMDItemKind",
+          "kMDItemLogicalSize",
+          "kMDItemPhysicalSize",
+        ],
+      },
+    },
+    {
+      name: ["--raw", "-raw"],
+      description:
+        "Print raw attribute data in the order that was requested. Fields will be separated with a ASCII NUL character, suitable for piping to xargs(1) -0",
+    },
+    {
+      name: ["--nullMarker", "-nullMarker"],
+      description:
+        "Sets a marker string to be used when a requested attribute is null. Only used in -raw mode.  Default is '(null)'",
+      insertValue: `--nullMarker "{cursor}"`,
+      dependsOn: ["--raw", "-raw"],
+    },
+  ],
+};
+export default completionSpec;

--- a/src/mdls.ts
+++ b/src/mdls.ts
@@ -15,6 +15,7 @@ const completionSpec: Fig.Spec = {
       description:
         "Print only the matching metadata attribute value.  Can be used multiple times",
       isRepeatable: true,
+      exclusiveOn: ["--plist", "-plist"],
       args: {
         name: "attributeName",
         description: "Metadata attribute name",
@@ -56,6 +57,7 @@ const completionSpec: Fig.Spec = {
       name: ["--raw", "-raw"],
       description:
         "Print raw attribute data in the order that was requested. Fields will be separated with a ASCII NUL character, suitable for piping to xargs(1) -0",
+      exclusiveOn: ["--plist", "-plist"],
     },
     {
       name: ["--nullMarker", "-nullMarker"],
@@ -63,8 +65,41 @@ const completionSpec: Fig.Spec = {
         "Sets a marker string to be used when a requested attribute is null. Only used in -raw mode.  Default is '(null)'",
       insertValue: `--nullMarker "{cursor}"`,
       dependsOn: ["--raw", "-raw"],
+      exclusiveOn: ["--plist", "-plist"],
     },
-    // TODO(platform): Add --plist macos only option
+    // TODO(platform): macos only option
+    {
+      name: ["--plist", "-plist"],
+      description:
+        "Output attributes in XML format to file. Use - to write to stdout option. Incompatible with options -raw, -nullMarker, and -name",
+      exclusiveOn: [
+        "--raw",
+        "-raw",
+        "--nullMarker",
+        "-nullMarker",
+        "--name",
+        "-name",
+      ],
+      args: [
+        {
+          name: "stdout or file",
+          description: "XML output location",
+          template: "filepaths",
+          suggestions: [
+            {
+              name: "-",
+              description: "Writes to stdout",
+              priority: 77,
+            },
+          ],
+        },
+        {
+          name: "file",
+          description: "File to read from",
+          template: "filepaths",
+        },
+      ],
+    },
   ],
 };
 export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
- New spec

**What is the current behavior? (You can also link to an open issue here)**
- Resolves #1548 

**What is the new behavior (if this is a feature change)?**
- Add new `mdls` spec

**Additional info:**
```
MDLS(1)                   BSD General Commands Manual                  MDLS(1)
NAME
     mdls -- lists the metadata attributes for the specified file

SYNOPSIS
     mdls [-name attributeName] [-raw [-nullMarker markerString]] file ...

DESCRIPTION
     The mdls command prints the values of all the metadata attributes associated with the files pro-
     vided as an argument.

     The following options are available:

     -name        Print only the matching metadata attribute value.  Can be used multiple times.

     -raw         Print raw attribute data in the order that was requested.  Fields will be separated
                  with a ASCII NUL character, suitable for piping to xargs(1) -0.

     -nullMarker  Sets a marker string to be used when a requested attribute is null.  Only used in
                  -raw mode.  Default is "(null)".
```