### PR TITLE
feat(rsync): add generators

### DIFF
--- a/src/rsync.ts
+++ b/src/rsync.ts
@@ -1,3 +1,5 @@
+import { knownHosts, configHosts } from "./ssh";
+
 const infoArgs: Fig.SingleOrArray<Fig.Arg> = [
   { name: "BACKUP", description: "Mention files backed up" },
   {
@@ -101,11 +103,20 @@ const completionSpec: Fig.Spec = {
   args: [
     {
       name: "SRC",
-      template: "history",
+      isVariadic: true,
+      generators: [
+        knownHosts,
+        configHosts,
+        { template: ["history", "filepaths", "folders"] },
+      ],
     },
     {
       name: "DEST",
-      template: "history",
+      generators: [
+        knownHosts,
+        configHosts,
+        { template: ["history", "filepaths", "folders"] },
+      ],
     },
   ],
   options: [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

- Update `rsync` spec to add generators for SRC and DEST

**What is the current behavior? (You can also link to an open issue here)**

- No generators

**What is the new behavior (if this is a feature change)?**

- Now fig suggest ssh hosts and files

**Additional info:**