### PR TITLE
feat(aws): add `--profile` option support

### DIFF
--- a/src/aws.ts
+++ b/src/aws.ts
@@ -1,3 +1,32 @@
+export const awsProfileGenerator: Fig.Generator = {
+  cache: {
+    strategy: "stale-while-revalidate",
+    cacheByDirectory: true,
+  },
+  script: "aws configure list-profiles",
+  postProcess: function (out, [awsClient]) {
+    if (out.trim() == "") {
+      return [];
+    }
+
+    try {
+      const lines = out.split("\n");
+
+      if (lines) {
+        return lines.map((line) => {
+          return {
+            name: line,
+          };
+        });
+      }
+    } catch (e) {
+      console.error(e);
+    }
+
+    return [];
+  },
+};
+
 const completionSpec: Fig.Spec = {
   name: "aws",
   async generateSpec(_, executeShellCommand) {
@@ -19,6 +48,16 @@ const completionSpec: Fig.Spec = {
       ],
     };
   },
+  options: [
+    {
+      name: "--profile",
+      description: "Use a specific profile from your credential file",
+      args: {
+        generators: awsProfileGenerator,
+        filterStrategy: "fuzzy",
+      },
+    },
+  ],
   subcommands: [
     {
       name: "accessanalyzer",

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -11,6 +11,7 @@ export const awsProfileGenerator: Fig.Generator = {
 
     return out.split("\n").map((line) => ({
       name: line,
+      icon: "👤",
     }));
   },
 };

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -4,26 +4,14 @@ export const awsProfileGenerator: Fig.Generator = {
     cacheByDirectory: true,
   },
   script: "aws configure list-profiles",
-  postProcess: function (out, [awsClient]) {
+  postProcess: function (out) {
     if (out.trim() == "") {
       return [];
     }
 
-    try {
-      const lines = out.split("\n");
-
-      if (lines) {
-        return lines.map((line) => {
-          return {
-            name: line,
-          };
-        });
-      }
-    } catch (e) {
-      console.error(e);
-    }
-
-    return [];
+    return out.split("\n").map((line) => ({
+      name: line,
+    }));
   },
 };
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
In this commit, we want to make it so aws --profile auto completes
with the list of profiles you have available.

**What is the current behavior? (You can also link to an open issue here)**
Currently the aws command doesn't know about --profiles

**What is the new behavior (if this is a feature change)?**
Generally these profiles live inside a credentials file
but instead of directly looking at the credentials file,
we ask aws to give us a list of the profiles using
`aws configure list-profiles`

**Additional info:**

closes #542