### PR TITLE
feat(nextflow): add secrets command and generator

### DIFF
--- a/src/nextflow.ts
+++ b/src/nextflow.ts
@@ -40,6 +40,21 @@ const dockerimage: Fig.Generator = {
   },
 };
 
+const secretname: Fig.Generator = {
+  script: `grep -o '"name": *"[^"]*"' $HOME/.nextflow/secrets/store.json | grep -o '"[^"]*"$' | tr -d \\"`,
+  postProcess: (output) => {
+    if (output == "") {
+      return [];
+    }
+    return output.split("\n").map((secretname) => {
+      return {
+        name: secretname.replace("*", "").trim(),
+        description: "Secret name",
+      };
+    });
+  },
+};
+
 const completionSpec: Fig.Spec = {
   name: "nextflow",
   description:
@@ -939,6 +954,48 @@ const completionSpec: Fig.Spec = {
           description: "Directory where intermediate result files are stored",
           args: {
             name: "work dir",
+          },
+        },
+      ],
+    },
+    {
+      name: "secrets",
+      description:
+        "Handle and manage sensitive information for pipeline execution in a safe manner",
+      options: [
+        {
+          name: "list",
+          description:
+            "List secrets available in the current store e.g. nextflow secrets list",
+        },
+        {
+          name: "get",
+          description:
+            "Allows retrieving a secret value e.g. nextflow secrets get FOO",
+          args: {
+            name: "secret name",
+            generators: secretname,
+          },
+        },
+        {
+          name: "set",
+          description:
+            'Allows creating creating a new secret or overriding an existing one e.g. nextflow secrets set FOO "Hello world"',
+          isDangerous: true,
+          args: {
+            name: "secret name and value",
+            generators: secretname,
+            suggestCurrentToken: true,
+          },
+        },
+        {
+          name: "delete",
+          description:
+            "Allows deleting an existing secret e.g. nextflow secrets delete FOO",
+          isDangerous: true,
+          args: {
+            name: "secret name",
+            generators: secretname,
           },
         },
       ],


### PR DESCRIPTION
- feat(nextflow): Add secrets command and generator

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
It adds autocomplete for the new secrets command, and a generator for its args.

**What is the current behavior? (You can also link to an open issue here)**
There is no autocomplete for the secrets command.
