### PR TITLE
feat(aws/sns): add publish-batch sub-command

### DIFF
--- a/src/aws/sns.ts
+++ b/src/aws/sns.ts
@@ -1001,6 +1001,53 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
+      name: "publish-batch",
+      description:
+        "Publishes up to ten messages to the specified topic. This is a batch version of Publish . For FIFO topics, multiple messages within a single batch are published in the order they are sent, and messages are deduplicated within the batch and across batches for 5 minutes. The result of publishing each message is reported individually in the response. Because the batch request can result in a combination of successful and unsuccessful actions, you should check for batch errors even when the call returns an HTTP status code of 200. The maximum allowed individual message size and the maximum total payload size (the sum of the individual lengths of all of the batched messages) are both 256 KB (262,144 bytes). Some actions take lists of parameters. These lists are specified using the param.n notation. Values of n are integers starting from 1. For example, a parameter list with two elements looks like this: &AttributeName.1=first &AttributeName.2=second If you send a batch message to a topic, Amazon SNS publishes the batch message to each endpoint that is subscribed to the topic. The format of the batch message depends on the notification protocol for each subscribed endpoint. When a messageId is returned, the batch message is saved and Amazon SNS immediately delivers the message to subscribers",
+      options: [
+        {
+          name: "--topic-arn",
+          description:
+            "The Amazon resource name (ARN) of the topic you want to batch publish to",
+          args: {
+            name: "string",
+          },
+        },
+        {
+          name: "--publish-batch-request-entries",
+          description:
+            "A list of PublishBatch request entries to be sent to the SNS topic",
+          args: {
+            name: "list",
+          },
+        },
+        {
+          name: "--cli-input-json",
+          description:
+            "Reads arguments from the JSON string provided. The JSON string follows the format provided by --generate-cli-skeleton. If other arguments are provided on the command line, those values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally. This may not be specified along with --cli-input-yaml",
+          args: {
+            name: "string",
+          },
+        },
+        {
+          name: "--cli-input-yaml",
+          description:
+            "Reads arguments from the JSON string provided. The JSON string follows the format provided by --generate-cli-skeleton. If other arguments are provided on the command line, those values will override the JSON-provided values. It is not possible to pass arbitrary binary values using a JSON-provided value as the string will be taken literally. This may not be specified along with --cli-input-yaml",
+          args: {
+            name: "string",
+          },
+        },
+        {
+          name: "--generate-cli-skeleton",
+          description:
+            "Prints a JSON skeleton to standard output without sending an API request. If provided with no value or the value input, prints a sample input JSON that can be used as an argument for --cli-input-json. Similarly, if provided yaml-input it will print a sample input YAML that can be used with --cli-input-yaml. If provided with the value output, it validates the command inputs and returns a sample output JSON for that command. The generated JSON skeleton is not stable between versions of the AWS CLI and there are no backwards compatibility guarantees in the JSON skeleton generated",
+          args: {
+            name: "string",
+          },
+        },
+      ],
+    },
+    {
       name: "remove-permission",
       description: "Removes a statement from a topic's access control policy",
       options: [


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

- add a missing sub-command of `aws sns` command

**What is the current behavior? (You can also link to an open issue here)**

- can not autocompletion

**What is the new behavior (if this is a feature change)?**


**Additional info:**

- https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sns/publish-batch.html