### PR TITLE
fix: cherry-pick declared options as subcommands

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -7998,7 +7998,13 @@ const completionSpec: Fig.Spec = {
     {
       name: "cherry-pick",
       description: "Apply the changes introduced by some existing commits",
-      subcommands: [
+      args: {
+        name: "commit",
+        description: "Commits to cherry-pick",
+        isVariadic: true,
+        generators: gitGenerators.commits,
+      },
+      options: [
         {
           name: "--continue",
           description:
@@ -8018,14 +8024,6 @@ const completionSpec: Fig.Spec = {
           description:
             "Cancel the operation and return to the pre-sequence state",
         },
-      ],
-      args: {
-        name: "commit",
-        description: "Commits to cherry-pick",
-        isVariadic: true,
-        generators: gitGenerators.commits,
-      },
-      options: [
         {
           name: ["-e", "--edit"],
           description:


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**