### PR TITLE
feat(brew): aliases and fixes for `uninstall`, `abv` and `info`

### DIFF
--- a/src/brew.ts
+++ b/src/brew.ts
@@ -1558,7 +1558,7 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: "home",
+      name: ["home", "homepage"],
       description:
         "Open a formula, cask's homepage in a browser, or open Homebrew's own homepage if no argument is provided",
       args: {

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -1557,6 +1557,29 @@ const completionSpec: Fig.Spec = {
         },
       ],
     },
+    {
+      name: "home",
+      description:
+        "Open a formula, cask's homepage in a browser, or open Homebrew's own homepage if no argument is provided",
+      args: {
+        isVariadic: true,
+        isOptional: true,
+        name: "formula",
+        description: "Formula or cask to open homepage for",
+        generators: [generateAllFormulae, generateAllCasks],
+      },
+      options: [
+        ...commonOptions,
+        {
+          name: ["--formula", "--formulae"],
+          description: "Treat all named arguments as formulae",
+        },
+        {
+          name: ["--cask", "--casks"],
+          description: "Treat all named arguments as casks",
+        },
+      ],
+    },
   ],
   options: [
     {

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -1194,8 +1194,8 @@ const completionSpec: Fig.Spec = {
       },
     },
     {
-      name: "uninstall",
-      description: "Uninstall <formula>",
+      name: ["uninstall", "remove", "rm"],
+      description: "Uninstall a formula or cask",
       args: {
         isVariadic: true,
         name: "formula",

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -84,109 +84,6 @@ const commonOptions: Fig.Option[] = [
   { name: ["-h", "--help"], description: "Show help message" },
 ];
 
-// brew info is equiv to brew abv. Everything but 'name' is shared.
-const brewInfo = (name: string): Fig.Subcommand => ({
-  name,
-  description: "Display brief statistics for your Homebrew installation",
-  args: {
-    isVariadic: true,
-    isOptional: true,
-    name: "formula",
-    description: "Formula or cask to summarize",
-    generators: [generateAllFormulae, generateAllCasks],
-  },
-  options: [
-    {
-      name: ["--cask", "--casks"],
-      description: "List only casks, or treat all named arguments as casks",
-    },
-    {
-      name: "--analytics",
-      description:
-        "List global Homebrew analytics data or, if specified, installation and build error data for formula",
-    },
-    {
-      name: "--days",
-      description: "How many days of analytics data to retrieve",
-      exclusiveOn: ["--analytics"],
-      args: {
-        name: "days",
-        description: "Number of days of data to retrieve",
-        suggestions: ["30", "90", "365"],
-      },
-    },
-    {
-      name: "--category",
-      description: "Which type of analytics data to retrieve",
-      exclusiveOn: ["--analytics"],
-      args: {
-        generators: {
-          custom: async (ctx) => {
-            // if anything provided after the subcommand does not begin with '-'
-            // then a formula has been provided and we should provide info on it
-            if (
-              ctx.slice(2, ctx.length - 1).some((token) => token[0] !== "-")
-            ) {
-              return ["install", "install-on-request", "build-error"].map(
-                (sugg) => ({
-                  name: sugg,
-                })
-              );
-            }
-
-            // if no formulas are specified, then we should provide system info
-            return ["cask-install", "os-version"].map((sugg) => ({
-              name: sugg,
-            }));
-          },
-        },
-      },
-    },
-    {
-      name: "--github",
-      description: "Open the GitHub source page for formula in a browser",
-    },
-    {
-      name: "--json",
-      description: "Print a JSON representation",
-    },
-    {
-      name: "--installed",
-      exclusiveOn: ["--json"],
-      description: "Print JSON of formulae that are currently installed",
-    },
-    {
-      name: "--all",
-      exclusiveOn: ["--json"],
-      description: "Print JSON of all available formulae",
-    },
-    {
-      name: ["-v", "--verbose"],
-      description: "Show more verbose analytics data for formulae",
-    },
-    {
-      name: "--formula",
-      description: "Treat all named arguments as formulae",
-    },
-    {
-      name: "--cash",
-      description: "Treat all named arguments as casks",
-    },
-    {
-      name: ["-d", "--debug"],
-      description: "Display any debugging information",
-    },
-    {
-      name: ["-q", "--quiet"],
-      description: "List only the names of outdated kegs",
-    },
-    {
-      name: ["-h", "--help"],
-      description: "Get help with services command",
-    },
-  ],
-});
-
 const completionSpec: Fig.Spec = {
   name: "brew",
   description: "Package manager for macOS",
@@ -363,8 +260,107 @@ const completionSpec: Fig.Spec = {
         },
       ],
     },
-    brewInfo("info"),
-    brewInfo("abv"),
+    {
+      name: ["abv", "info"],
+      description: "Display brief statistics for your Homebrew installation",
+      args: {
+        isVariadic: true,
+        isOptional: true,
+        name: "formula",
+        description: "Formula or cask to summarize",
+        generators: [generateAllFormulae, generateAllCasks],
+      },
+      options: [
+        {
+          name: ["--cask", "--casks"],
+          description: "List only casks, or treat all named arguments as casks",
+        },
+        {
+          name: "--analytics",
+          description:
+            "List global Homebrew analytics data or, if specified, installation and build error data for formula",
+        },
+        {
+          name: "--days",
+          description: "How many days of analytics data to retrieve",
+          exclusiveOn: ["--analytics"],
+          args: {
+            name: "days",
+            description: "Number of days of data to retrieve",
+            suggestions: ["30", "90", "365"],
+          },
+        },
+        {
+          name: "--category",
+          description: "Which type of analytics data to retrieve",
+          exclusiveOn: ["--analytics"],
+          args: {
+            generators: {
+              custom: async (ctx) => {
+                // if anything provided after the subcommand does not begin with '-'
+                // then a formula has been provided and we should provide info on it
+                if (
+                  ctx.slice(2, ctx.length - 1).some((token) => token[0] !== "-")
+                ) {
+                  return ["install", "install-on-request", "build-error"].map(
+                    (sugg) => ({
+                      name: sugg,
+                    })
+                  );
+                }
+
+                // if no formulas are specified, then we should provide system info
+                return ["cask-install", "os-version"].map((sugg) => ({
+                  name: sugg,
+                }));
+              },
+            },
+          },
+        },
+        {
+          name: "--github",
+          description: "Open the GitHub source page for formula in a browser",
+        },
+        {
+          name: "--json",
+          description: "Print a JSON representation",
+        },
+        {
+          name: "--installed",
+          exclusiveOn: ["--json"],
+          description: "Print JSON of formulae that are currently installed",
+        },
+        {
+          name: "--all",
+          exclusiveOn: ["--json"],
+          description: "Print JSON of all available formulae",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Show more verbose analytics data for formulae",
+        },
+        {
+          name: "--formula",
+          description: "Treat all named arguments as formulae",
+        },
+        {
+          name: "--cash",
+          description: "Treat all named arguments as casks",
+        },
+        {
+          name: ["-d", "--debug"],
+          description: "Display any debugging information",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "List only the names of outdated kegs",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Get help with services command",
+        },
+      ],
+    },
     {
       name: "update",
       description: "Fetch the newest version of Homebrew and all formulae",

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -81,7 +81,7 @@ const commonOptions: Fig.Option[] = [
     name: ["-v", "--verbose"],
     description: "Make some output more verbose",
   },
-  { name: ["-h", "--help"], description: "Show this message" },
+  { name: ["-h", "--help"], description: "Show help message" },
 ];
 
 // brew info is equiv to brew abv. Everything but 'name' is shared.


### PR DESCRIPTION
1. added `rm` and `remove` synonyms for `uninstall` subcommand;
<img width="546" alt="Screenshot 2022-11-09 at 21 08 42" src="https://user-images.githubusercontent.com/33508383/200907299-c4d265a7-73af-489b-8ef8-50fdfc534333.png">

3. `abv` and `info` were separated into subcommands though did the same so I joined them;

<img width="401" alt="Screenshot 2022-11-09 at 21 10 12" src="https://user-images.githubusercontent.com/33508383/200907440-6c7b4031-5bb0-408e-97fc-28a0adbe2e4a.png">

5. default description for `—help` option were `Show this message` which didn't make sense so I changed it to more sensible `Show help message`.

<img width="323" alt="Screenshot 2022-11-09 at 21 14 37" src="https://user-images.githubusercontent.com/33508383/200908944-befd9be6-184a-4017-9abf-5fcd98e81052.png">
