### PR TITLE
spec(kubectl): add --namespce global command-line options

### DIFF
--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -3841,6 +3841,15 @@ const completionSpec: Fig.Spec = {
       ],
     },
   ],
+  options: [
+    {
+      name: ["-n", "--namespace"],
+      args: {
+        name: "namespace",
+      },
+      description: "If present, the namespace scope for this CLI request",
+    },
+  ],
 };
 
 export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature

**What is the current behavior? (You can also link to an open issue here)**
there is no `--namespace` global options

**What is the new behavior (if this is a feature change)?**
add a `--namespce` global command-line options, see `kubectl options` for all global options for kubectl

**Additional info:**
N/A