### PR TITLE
feat: add bcd spec

### DIFF
--- a/src/bcd.ts
+++ b/src/bcd.ts
@@ -4,7 +4,7 @@ const completion: Fig.Spec = {
   options: [
     {
       name: ["-s", "--store"],
-      description: "Store the current directory as a bookmark STORE",
+      description: "Store the current directory as a bookmark",
       isRepeatable: true,
       args: {
         name: "store",
@@ -13,7 +13,7 @@ const completion: Fig.Spec = {
     },
     {
       name: ["-r", "--remove"],
-      description: "Remove a specified bookmark REMOVE",
+      description: "Remove a specified bookmark",
       isRepeatable: true,
       args: {
         name: "remove",

--- a/src/bcd.ts
+++ b/src/bcd.ts
@@ -1,0 +1,46 @@
+const completion: Fig.Spec = {
+  name: "bcd",
+  description: "Bookmark directories and move to them",
+  options: [
+    {
+      name: ["-s", "--store"],
+      description: "Store the current directory as a bookmark STORE",
+      isRepeatable: true,
+      args: {
+        name: "store",
+        isOptional: true,
+      },
+    },
+    {
+      name: ["-r", "--remove"],
+      description: "Remove a specified bookmark REMOVE",
+      isRepeatable: true,
+      args: {
+        name: "remove",
+        isOptional: true,
+      },
+    },
+    {
+      name: ["-i", "--install"],
+      description: "Setup the the shell init script",
+    },
+    {
+      name: ["-l", "--list"],
+      description: "List the stored bookmarks",
+    },
+    {
+      name: ["-V", "--version"],
+      description: "Print version information",
+    },
+    {
+      name: ["-h", "--help"],
+      description: "Print help information",
+    },
+  ],
+  args: {
+    name: "bookmark",
+    isOptional: true,
+  },
+};
+
+export default completion;


### PR DESCRIPTION
Usage: bcd [OPTIONS] [BOOKMARK]

Arguments:
  [BOOKMARK]  Bookmarked directory to change to

Options:
  -s, --store <STORE>    Store the current directory as a bookmark STORE
  -r, --remove <REMOVE>  Remove a specified bookmark REMOVE
  -l, --list             List the stored bookmarks
  -V, --version          Print version information
  -h, --help             Print help information command from https://bcd.noser.net

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
new application support

**What is the current behavior? (You can also link to an open issue here)**
N/A

**What is the new behavior (if this is a feature change)?**
Support for `bcd` command line tool

**Additional info:**
File automatically generated using `clap_complete_fig` as a part of the build.