### PR TITLE
feat(curl): add missing options

### DIFF
--- a/src/curl.ts
+++ b/src/curl.ts
@@ -370,6 +370,17 @@ const completionSpec: Fig.Spec = {
       args: { name: "name" },
     },
     {
+      name: "--etag-compare",
+      description:
+        "Make a conditional HTTP request for the ETag read from the given file",
+      args: { name: "file" },
+    },
+    {
+      name: "--etag-save",
+      description: "Save an HTTP ETag to the specified file",
+      args: { name: "file" },
+    },
+    {
       name: "--expect100-timeout",
       description: "How long to wait for 100-continue",
       args: { name: "seconds" },
@@ -377,6 +388,11 @@ const completionSpec: Fig.Spec = {
     {
       name: "--fail-early",
       description: "Fail on first transfer error, do not continue",
+    },
+    {
+      name: "--fail-with-body",
+      description:
+        "On HTTP errors, return an error and also output any HTML response",
     },
     { name: "--false-start", description: "Enable TLS False Start" },
     {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
Resolves #1680 (the completion spec for `curl` is missing several options).

**What is the new behavior (if this is a feature change)?**
The missing options are added.
