### PR TITLE
Update robot.ts

### DIFF
--- a/src/robot.ts
+++ b/src/robot.ts
@@ -64,7 +64,7 @@ const testCasesGenerator: Fig.Generator = {
     for (const [_, block] of iter) {
       // get every test case name
       // regex: word/s at the start of a line until '#'
-      const lines = block.matchAll(/^(\w+ *)+(?!.\#.*)(?!.\#.*)/gm);
+      const lines = block.matchAll(/^(\w+( |-)*)+(?!.\#.*)(?!.\#.*)/gm);
       // go through all the test cases names found
       for (let [testCase] of lines) {
         testCase = testCase.trim();


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix of regex used for searching test case names

**What is the current behavior? (You can also link to an open issue here)**
Current regex doesn't select the whole test case name, if it includes a dash ("-").

**What is the new behavior (if this is a feature change)?**
New regex adds dash as a possible "spacing" character.

**Additional info:**
_None_