### PR TITLE
feat: add spec for `kafkactl`

### DIFF
--- a/src/kafkactl.ts
+++ b/src/kafkactl.ts
@@ -1,0 +1,864 @@
+const completionSpec: Fig.Spec = {
+    name: "kafkactl",
+    description: "command-line interface for Apache Kafka",
+    subcommands: [
+      {
+        name: ["edit", "alter"],
+        description: "alter topics, partitions",
+        subcommands: [
+          {
+            name: ["partition"],
+            description: "alter a partition",
+            options: [
+              {
+                name: ["--replicas", "-r"],
+                description: "set replicas for a partition",
+                isRepeatable: true,
+                args: [{ name: "replicas" }],
+              },
+              { name: ["--validate-only", "-v"], description: "validate only" },
+            ],
+          },
+          {
+            name: ["topic"],
+            description: "alter a topic",
+            options: [
+              {
+                name: ["--config", "-c"],
+                description: "configs in format `key=value`",
+                isRepeatable: true,
+                args: [{ name: "config" }],
+              },
+              {
+                name: ["--partitions", "-p"],
+                description: "number of partitions",
+                args: [{ name: "partitions", default: "0" }],
+              },
+              {
+                name: ["--replication-factor", "-r"],
+                description: "replication factor",
+                args: [{ name: "replication-factor", default: "0" }],
+              },
+              { name: ["--validate-only", "-v"], description: "validate only" },
+            ],
+          },
+        ],
+      },
+      {
+        name: ["attach"],
+        description: "run kafkactl pod in kubernetes and attach to it",
+      },
+      {
+        name: ["clone"],
+        description: "clone topics, consumerGroups",
+        subcommands: [
+          {
+            name: ["cg", "consumer-group"],
+            description: "clone existing consumerGroup with all offsets",
+          },
+          {
+            name: ["topic"],
+            description:
+              "clone existing topic (number of partitions, replication factor, config entries) to new one",
+          },
+        ],
+      },
+      {
+        name: ["completion"],
+        description: "generate shell auto-completion file",
+      },
+      {
+        name: ["config"],
+        description: "show and edit configurations",
+        subcommands: [
+          {
+            name: ["currentContext", "current-context"],
+            description: "show current context",
+          },
+          {
+            name: ["getContexts", "get-contexts"],
+            description: "list configured contexts",
+            options: [
+              {
+                name: ["--output", "-o"],
+                description: "output format. One of: compact",
+                args: [{ name: "output" }],
+              },
+            ],
+          },
+          {
+            name: ["useContext", "use-context"],
+            description: "switch active context",
+          },
+          { name: ["view"], description: "show contents of config file" },
+        ],
+      },
+      {
+        name: ["consume"],
+        description: "consume messages from a topic",
+        options: [
+          {
+            name: ["--exit", "-e"],
+            description: "stop consuming when latest offset is reached",
+          },
+          {
+            name: ["--from-beginning", "-b"],
+            description: "set offset for consumer to the oldest offset",
+          },
+          {
+            name: ["--group", "-g"],
+            description: "consumer group to join",
+            args: [{ name: "group" }],
+          },
+          {
+            name: ["--key-encoding"],
+            description:
+              "key encoding (auto-detected by default). One of: none|hex|base64",
+            args: [{ name: "key-encoding" }],
+          },
+          {
+            name: ["--key-proto-type"],
+            description: "key protobuf message type",
+            args: [{ name: "key-proto-type" }],
+          },
+          {
+            name: ["--max-messages"],
+            description: "stop consuming after n messages have been read",
+            args: [{ name: "max-messages", default: "-1" }],
+          },
+          {
+            name: ["--offset"],
+            description:
+              "offsets in format `partition=offset (for partitions not specified, other parameters apply)`",
+            isRepeatable: true,
+            args: [{ name: "offset" }],
+          },
+          {
+            name: ["--output", "-o"],
+            description: "output format. One of: json|yaml",
+            args: [{ name: "output" }],
+          },
+          {
+            name: ["--partitions", "-p"],
+            description:
+              "partitions to consume. The default is to consume from all partitions.",
+            isRepeatable: true,
+            args: [{ name: "partitions" }],
+          },
+          { name: ["--print-headers"], description: "print message headers" },
+          { name: ["--print-keys", "-k"], description: "print message keys" },
+          {
+            name: ["--print-schema", "-a"],
+            description: "print details about avro schema used for decoding",
+          },
+          {
+            name: ["--print-timestamps", "-t"],
+            description: "print message timestamps",
+          },
+          {
+            name: ["--proto-file"],
+            description:
+              "additional protobuf description file for searching message description",
+            isRepeatable: true,
+            args: [{ name: "proto-file" }],
+          },
+          {
+            name: ["--proto-import-path"],
+            description:
+              "additional path to search files listed in proto 'import' directive",
+            isRepeatable: true,
+            args: [{ name: "proto-import-path" }],
+          },
+          {
+            name: ["--protoset-file"],
+            description:
+              "additional compiled protobuf description file for searching message description",
+            isRepeatable: true,
+            args: [{ name: "protoset-file" }],
+          },
+          {
+            name: ["--separator", "-s"],
+            description: "separator to split key and value",
+            args: [{ name: "separator", default: "#" }],
+          },
+          {
+            name: ["--tail"],
+            description: "show only the last n messages on the topic",
+            args: [{ name: "tail", default: "-1" }],
+          },
+          {
+            name: ["--value-encoding"],
+            description:
+              "value encoding (auto-detected by default). One of: none|hex|base64",
+            args: [{ name: "value-encoding" }],
+          },
+          {
+            name: ["--value-proto-type"],
+            description: "value protobuf message type",
+            args: [{ name: "value-proto-type" }],
+          },
+        ],
+      },
+      {
+        name: ["create"],
+        description: "create topics, consumerGroups, acls",
+        subcommands: [
+          {
+            name: ["acl", "access-control-list"],
+            description: "create an acl",
+            options: [
+              {
+                name: ["--allow", "-a"],
+                description:
+                  "acl of permissionType 'allow' (choose this or 'deny')",
+              },
+              {
+                name: ["--cluster", "-c"],
+                description: "create acl for the cluster",
+              },
+              {
+                name: ["--deny", "-d"],
+                description:
+                  "acl of permissionType 'deny' (choose this or 'allow')",
+              },
+              {
+                name: ["--group", "-g"],
+                description: "create acl for a consumer group",
+                args: [{ name: "group" }],
+              },
+              {
+                name: ["--host"],
+                description: "hosts to allow",
+                isRepeatable: true,
+                args: [{ name: "host" }],
+              },
+              {
+                name: ["--operation", "-o"],
+                description: "operations of acl",
+                isRepeatable: true,
+                args: [{ name: "operation" }],
+                isRequired: true,
+              },
+              {
+                name: ["--pattern"],
+                description: "pattern type. one of (match, prefixed, literal)",
+                args: [{ name: "pattern", default: "literal" }],
+              },
+              {
+                name: ["--principal", "-p"],
+                description: "principal to be authenticated",
+                args: [{ name: "principal" }],
+                isRequired: true,
+              },
+              {
+                name: ["--topic", "-t"],
+                description: "create acl for a topic",
+                args: [{ name: "topic" }],
+              },
+              { name: ["--validate-only", "-v"], description: "validate only" },
+            ],
+          },
+          {
+            name: ["cg", "consumer-group"],
+            description: "create a consumerGroup",
+            options: [
+              {
+                name: ["--newest"],
+                description:
+                  "set the offset to newest offset (for all partitions or the specified partition)",
+              },
+              {
+                name: ["--offset"],
+                description:
+                  "set offset to this value. offset with value -1 is ignored",
+                args: [{ name: "offset", default: "-1" }],
+              },
+              {
+                name: ["--oldest"],
+                description:
+                  "set the offset to oldest offset (for all partitions or the specified partition)",
+              },
+              {
+                name: ["--partition", "-p"],
+                description:
+                  "partition to create group for. -1 stands for all partitions",
+                args: [{ name: "partition", default: "-1" }],
+              },
+              {
+                name: ["--topic", "-t"],
+                description: "one or more topics to create group for",
+                isRepeatable: true,
+                args: [{ name: "topic" }],
+              },
+            ],
+          },
+          {
+            name: ["topic"],
+            description: "create a topic",
+            options: [
+              {
+                name: ["--config", "-c"],
+                description: "configs in format `key=value`",
+                isRepeatable: true,
+                args: [{ name: "config" }],
+              },
+              {
+                name: ["--partitions", "-p"],
+                description: "number of partitions",
+                args: [{ name: "partitions", default: "1" }],
+              },
+              {
+                name: ["--replication-factor", "-r"],
+                description: "replication factor",
+                args: [{ name: "replication-factor", default: "1" }],
+              },
+              { name: ["--validate-only", "-v"], description: "validate only" },
+            ],
+          },
+        ],
+      },
+      {
+        name: ["delete"],
+        description: "delete topics, consumerGroups, consumer-group-offset, acls",
+        subcommands: [
+          {
+            name: ["acl", "access-control-list"],
+            description: "delete an acl",
+            options: [
+              {
+                name: ["--allow", "-a"],
+                description: "acl of permissionType 'allow'",
+              },
+              {
+                name: ["--cluster", "-c"],
+                description: "delete acl for the cluster",
+              },
+              {
+                name: ["--deny", "-d"],
+                description: "acl of permissionType 'deny'",
+              },
+              {
+                name: ["--groups", "-g"],
+                description: "delete acl for a consumer group",
+              },
+              {
+                name: ["--operation", "-o"],
+                description: "operation of acl",
+                args: [{ name: "operation" }],
+                isRequired: true,
+              },
+              {
+                name: ["--pattern"],
+                description:
+                  "pattern type. one of (any, match, prefixed, literal)",
+                args: [{ name: "pattern" }],
+                isRequired: true,
+              },
+              { name: ["--topics", "-t"], description: "delete acl for a topic" },
+              { name: ["--validate-only", "-v"], description: "validate only" },
+            ],
+          },
+          {
+            name: ["consumer-groups", "consumer-group"],
+            description: "delete a consumer-group",
+          },
+          {
+            name: ["cgo", "offset", "consumer-group-offset"],
+            description: "delete a consumer-group-offset",
+            options: [
+              {
+                name: ["--partition", "-p"],
+                description:
+                  "delete offset for this partition. -1 stands for all partitions",
+                args: [{ name: "partition", default: "-1" }],
+              },
+              {
+                name: ["--topic", "-t"],
+                description: "delete offset for this topic",
+                args: [{ name: "topic" }],
+              },
+            ],
+          },
+          { name: ["topic"], description: "delete a topic" },
+        ],
+      },
+      {
+        name: ["describe"],
+        description: "describe topics, consumerGroups, brokers",
+        subcommands: [
+          {
+            name: ["broker"],
+            description: "describe a broker",
+            options: [
+              {
+                name: ["--output", "-o"],
+                description: "output format. One of: json|yaml|wide",
+                args: [{ name: "output" }],
+              },
+            ],
+          },
+          {
+            name: ["cg", "consumer-group"],
+            description: "describe a consumerGroup",
+            options: [
+              {
+                name: ["--only-with-lag", "-l"],
+                description: "show only partitions that have a lag",
+              },
+              {
+                name: ["--output", "-o"],
+                description: "output format. One of: json|yaml|wide",
+                args: [{ name: "output" }],
+              },
+              {
+                name: ["--print-members", "-m"],
+                description: "print group members",
+              },
+              {
+                name: ["--print-topics", "-T"],
+                description: "print topic details",
+              },
+              {
+                name: ["--topic", "-t"],
+                description: "show group details for given topic only",
+                args: [{ name: "topic" }],
+              },
+            ],
+          },
+          {
+            name: ["topic"],
+            description: "describe a topic",
+            options: [
+              {
+                name: ["--output", "-o"],
+                description: "output format. One of: json|yaml|wide",
+                args: [{ name: "output" }],
+              },
+              { name: ["--print-configs", "-c"], description: "print configs" },
+              {
+                name: ["--skip-empty", "-s"],
+                description: "show only partitions that have a messages",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: ["list", "get"],
+        description: "get info about topics, consumerGroups, acls, brokers",
+        subcommands: [
+          {
+            name: ["acl", "access-control-list"],
+            description: "list available acls",
+            options: [
+              {
+                name: ["--allow", "-a"],
+                description: "acl of permissionType 'allow'",
+              },
+              {
+                name: ["--cluster", "-c"],
+                description: "list acl for the cluster",
+              },
+              {
+                name: ["--deny", "-d"],
+                description: "acl of permissionType 'deny'",
+              },
+              {
+                name: ["--groups", "-g"],
+                description: "list acl for consumer groups",
+              },
+              {
+                name: ["--operation"],
+                description: "operation of acl",
+                args: [{ name: "operation", default: "any" }],
+              },
+              {
+                name: ["--output", "-o"],
+                description: "output format. One of: json|yaml",
+                args: [{ name: "output" }],
+              },
+              {
+                name: ["--pattern"],
+                description:
+                  "pattern type. one of (any, match, prefixed, literal)",
+                args: [{ name: "pattern", default: "any" }],
+              },
+              { name: ["--topics", "-t"], description: "list acl for topics" },
+            ],
+          },
+          {
+            name: ["brokers"],
+            description: "list brokers",
+            options: [
+              {
+                name: ["--output", "-o"],
+                description: "output format. One of: json|yaml|compact",
+                args: [{ name: "output" }],
+              },
+            ],
+          },
+          {
+            name: ["cg", "consumer-groups"],
+            description: "list available consumerGroups",
+            options: [
+              {
+                name: ["--output", "-o"],
+                description: "output format. One of: json|yaml|wide|compact",
+                args: [{ name: "output" }],
+              },
+              {
+                name: ["--topic", "-t"],
+                description: "show groups for given topic only",
+                args: [{ name: "topic" }],
+              },
+            ],
+          },
+          {
+            name: ["topics"],
+            description: "list available topics",
+            options: [
+              {
+                name: ["--output", "-o"],
+                description: "output format. One of: json|yaml|wide|compact",
+                args: [{ name: "output" }],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: ["produce"],
+        description: "produce messages to a topic",
+        options: [
+          {
+            name: ["--file", "-f"],
+            description: "file to read input from",
+            args: [{ name: "file" }],
+          },
+          {
+            name: ["--header", "-H"],
+            description: "headers in format `key:value`",
+            isRepeatable: true,
+            args: [{ name: "header" }],
+          },
+          {
+            name: ["--key", "-k"],
+            description: "key to use for all messages",
+            args: [{ name: "key" }],
+          },
+          {
+            name: ["--key-encoding"],
+            description:
+              "key encoding (none by default). One of: none|hex|base64",
+            args: [{ name: "key-encoding" }],
+          },
+          {
+            name: ["--key-proto-type"],
+            description: "key protobuf message type",
+            args: [{ name: "key-proto-type" }],
+          },
+          {
+            name: ["--key-schema-version", "-K"],
+            description:
+              "avro schema version that should be used for key serialization (default is latest)",
+            args: [{ name: "key-schema-version", default: "-1" }],
+          },
+          {
+            name: ["--lineSeparator", "-L"],
+            description:
+              "separator to split multiple messages from stdin or file",
+            args: [{ name: "lineSeparator", default: "" }],
+          },
+          {
+            name: ["--max-message-bytes"],
+            description:
+              "the maximum permitted size of a message (defaults to 1000000)",
+            args: [{ name: "max-message-bytes", default: "0" }],
+          },
+          {
+            name: ["--null-value"],
+            description:
+              "produce a null value (can be used instead of providing a value with --value)",
+          },
+          {
+            name: ["--partition", "-p"],
+            description: "partition to produce to",
+            args: [{ name: "partition", default: "-1" }],
+          },
+          {
+            name: ["--partitioner", "-P"],
+            description:
+              "the partitioning scheme to use. Can be `murmur2`, `hash`, `hash-ref` `manual`, or `random`. (default is murmur2)",
+            args: [{ name: "partitioner" }],
+          },
+          {
+            name: ["--proto-file"],
+            description:
+              "additional protobuf description file for searching message description",
+            isRepeatable: true,
+            args: [{ name: "proto-file" }],
+          },
+          {
+            name: ["--proto-import-path"],
+            description:
+              "additional path to search files listed in proto 'import' directive",
+            isRepeatable: true,
+            args: [{ name: "proto-import-path" }],
+          },
+          {
+            name: ["--protoset-file"],
+            description:
+              "additional compiled protobuf description file for searching message description",
+            isRepeatable: true,
+            args: [{ name: "protoset-file" }],
+          },
+          {
+            name: ["--rate", "-r"],
+            description: "amount of messages per second to produce on the topic",
+            args: [{ name: "rate", default: "-1" }],
+          },
+          {
+            name: ["--required-acks"],
+            description:
+              "required acks. One of `NoResponse`, `WaitForLocal`, `WaitForAll`. (default is WaitForLocal)",
+            args: [{ name: "required-acks" }],
+          },
+          {
+            name: ["--separator", "-S"],
+            description: "separator to split key and value from stdin or file",
+            args: [{ name: "separator" }],
+          },
+          {
+            name: ["--silent", "-s"],
+            description: "do not write to standard output",
+          },
+          {
+            name: ["--value", "-v"],
+            description: "value to produce",
+            args: [{ name: "value" }],
+          },
+          {
+            name: ["--value-encoding"],
+            description:
+              "value encoding (none by default). One of: none|hex|base64",
+            args: [{ name: "value-encoding" }],
+          },
+          {
+            name: ["--value-proto-type"],
+            description: "value protobuf message type",
+            args: [{ name: "value-proto-type" }],
+          },
+          {
+            name: ["--value-schema-version", "-i"],
+            description:
+              "avro schema version that should be used for value serialization (default is latest)",
+            args: [{ name: "value-schema-version", default: "-1" }],
+          },
+        ],
+      },
+      {
+        name: ["reset"],
+        description: "reset consumerGroupsOffset",
+        subcommands: [
+          {
+            name: ["cgo", "offset", "consumer-group-offset"],
+            description: "reset a consumer group offset",
+            options: [
+              {
+                name: ["--all-topics"],
+                description:
+                  "do the operation for all topics in the consumer group",
+              },
+              {
+                name: ["--execute", "-e"],
+                description:
+                  "execute the reset (as default only the results are displayed for validation)",
+              },
+              {
+                name: ["--newest"],
+                description:
+                  "set the offset to newest offset (for all partitions or the specified partition)",
+              },
+              {
+                name: ["--offset"],
+                description:
+                  "set offset to this value. offset with value -1 is ignored",
+                args: [{ name: "offset", default: "-1" }],
+              },
+              {
+                name: ["--oldest"],
+                description:
+                  "set the offset to oldest offset (for all partitions or the specified partition)",
+              },
+              {
+                name: ["--output", "-o"],
+                description: "output format. One of: json|yaml",
+                args: [{ name: "output" }],
+              },
+              {
+                name: ["--partition", "-p"],
+                description:
+                  "partition to apply the offset. -1 stands for all partitions",
+                args: [{ name: "partition", default: "-1" }],
+              },
+              {
+                name: ["--topic", "-t"],
+                description: "one ore more topics to change offset for",
+                isRepeatable: true,
+                args: [{ name: "topic" }],
+              },
+            ],
+          },
+        ],
+      },
+      { name: ["version"], description: "print the version of kafkactl" },
+      {
+        name: ["help"],
+        description: "Help about any command",
+        subcommands: [
+          {
+            name: ["edit", "alter"],
+            description: "alter topics, partitions",
+            subcommands: [
+              { name: ["partition"], description: "alter a partition" },
+              { name: ["topic"], description: "alter a topic" },
+            ],
+          },
+          {
+            name: ["attach"],
+            description: "run kafkactl pod in kubernetes and attach to it",
+          },
+          {
+            name: ["clone"],
+            description: "clone topics, consumerGroups",
+            subcommands: [
+              {
+                name: ["cg", "consumer-group"],
+                description: "clone existing consumerGroup with all offsets",
+              },
+              {
+                name: ["topic"],
+                description:
+                  "clone existing topic (number of partitions, replication factor, config entries) to new one",
+              },
+            ],
+          },
+          {
+            name: ["completion"],
+            description: "generate shell auto-completion file",
+          },
+          {
+            name: ["config"],
+            description: "show and edit configurations",
+            subcommands: [
+              {
+                name: ["currentContext", "current-context"],
+                description: "show current context",
+              },
+              {
+                name: ["getContexts", "get-contexts"],
+                description: "list configured contexts",
+              },
+              {
+                name: ["useContext", "use-context"],
+                description: "switch active context",
+              },
+              { name: ["view"], description: "show contents of config file" },
+            ],
+          },
+          { name: ["consume"], description: "consume messages from a topic" },
+          {
+            name: ["create"],
+            description: "create topics, consumerGroups, acls",
+            subcommands: [
+              {
+                name: ["acl", "access-control-list"],
+                description: "create an acl",
+              },
+              {
+                name: ["cg", "consumer-group"],
+                description: "create a consumerGroup",
+              },
+              { name: ["topic"], description: "create a topic" },
+            ],
+          },
+          {
+            name: ["delete"],
+            description:
+              "delete topics, consumerGroups, consumer-group-offset, acls",
+            subcommands: [
+              {
+                name: ["acl", "access-control-list"],
+                description: "delete an acl",
+              },
+              {
+                name: ["consumer-groups", "consumer-group"],
+                description: "delete a consumer-group",
+              },
+              {
+                name: ["cgo", "offset", "consumer-group-offset"],
+                description: "delete a consumer-group-offset",
+              },
+              { name: ["topic"], description: "delete a topic" },
+            ],
+          },
+          {
+            name: ["describe"],
+            description: "describe topics, consumerGroups, brokers",
+            subcommands: [
+              { name: ["broker"], description: "describe a broker" },
+              {
+                name: ["cg", "consumer-group"],
+                description: "describe a consumerGroup",
+              },
+              { name: ["topic"], description: "describe a topic" },
+            ],
+          },
+          {
+            name: ["list", "get"],
+            description: "get info about topics, consumerGroups, acls, brokers",
+            subcommands: [
+              {
+                name: ["acl", "access-control-list"],
+                description: "list available acls",
+              },
+              { name: ["brokers"], description: "list brokers" },
+              {
+                name: ["cg", "consumer-groups"],
+                description: "list available consumerGroups",
+              },
+              { name: ["topics"], description: "list available topics" },
+            ],
+          },
+          { name: ["produce"], description: "produce messages to a topic" },
+          {
+            name: ["reset"],
+            description: "reset consumerGroupsOffset",
+            subcommands: [
+              {
+                name: ["cgo", "offset", "consumer-group-offset"],
+                description: "reset a consumer group offset",
+              },
+            ],
+          },
+          { name: ["version"], description: "print the version of kafkactl" },
+        ],
+      },
+    ],
+    options: [
+      {
+        name: ["--config-file", "-C"],
+        description:
+          "config file. one of: [$HOME/.config/kafkactl $HOME/.kafkactl $SNAP_REAL_HOME/.config/kafkactl $SNAP_DATA/kafkactl /etc/kafkactl]",
+        isPersistent: true,
+        args: [{ name: "config-file" }],
+      },
+      {
+        name: ["--verbose", "-V"],
+        description: "verbose output",
+        isPersistent: true,
+      },
+      { name: ["--help", "-h"], description: "Display help", isPersistent: true },
+    ],
+  };
+  export default completionSpec;

--- a/src/kafkactl.ts
+++ b/src/kafkactl.ts
@@ -1,864 +1,885 @@
 const completionSpec: Fig.Spec = {
-    name: "kafkactl",
-    description: "command-line interface for Apache Kafka",
-    subcommands: [
-      {
-        name: ["edit", "alter"],
-        description: "alter topics, partitions",
-        subcommands: [
-          {
-            name: ["partition"],
-            description: "alter a partition",
-            options: [
-              {
-                name: ["--replicas", "-r"],
-                description: "set replicas for a partition",
-                isRepeatable: true,
-                args: [{ name: "replicas" }],
-              },
-              { name: ["--validate-only", "-v"], description: "validate only" },
-            ],
+  name: "kafkactl",
+  description: "Command-line interface for Apache Kafka",
+  subcommands: [
+    {
+      name: ["edit", "alter"],
+      description: "Alter topics, partitions",
+      subcommands: [
+        {
+          name: "partition",
+          description: "Alter a partition",
+          options: [
+            {
+              name: ["--replicas", "-r"],
+              description: "Set replicas for a partition",
+              isRepeatable: true,
+              args: { name: "replicas" },
+            },
+            { name: ["--validate-only", "-v"], description: "Validate only" },
+          ],
+        },
+        {
+          name: "topic",
+          description: "Alter a topic",
+          options: [
+            {
+              name: ["--config", "-c"],
+              description: "Configs in format `key=value`",
+              isRepeatable: true,
+              args: { name: "config" },
+            },
+            {
+              name: ["--partitions", "-p"],
+              description: "Number of partitions",
+              args: { name: "partitions", default: "0" },
+            },
+            {
+              name: ["--replication-factor", "-r"],
+              description: "Replication factor",
+              args: { name: "replication-factor", default: "0" },
+            },
+            { name: ["--validate-only", "-v"], description: "Validate only" },
+          ],
+        },
+      ],
+    },
+    {
+      name: "attach",
+      description: "Run kafkactl pod in kubernetes and attach to it",
+    },
+    {
+      name: "clone",
+      description: "Clone topics, consumerGroups",
+      subcommands: [
+        {
+          name: ["cg", "consumer-group"],
+          description: "Clone existing consumerGroup with all offsets",
+        },
+        {
+          name: "topic",
+          description:
+            "Clone existing topic (number of partitions, replication factor, config entries) to new one",
+        },
+      ],
+    },
+    {
+      name: "completion",
+      description: "Generate shell auto-completion file",
+    },
+    {
+      name: "config",
+      description: "Show and edit configurations",
+      subcommands: [
+        {
+          name: ["currentContext", "current-context"],
+          description: "Show current context",
+        },
+        {
+          name: ["getContexts", "get-contexts"],
+          description: "List configured contexts",
+          options: [
+            {
+              name: ["--output", "-o"],
+              description: "Output format. One of: compact",
+              args: { name: "output" },
+            },
+          ],
+        },
+        {
+          name: ["useContext", "use-context"],
+          description: "Switch active context",
+        },
+        { name: "view", description: "Show contents of config file" },
+      ],
+    },
+    {
+      name: "consume",
+      description: "Consume messages from a topic",
+      options: [
+        {
+          name: ["--exit", "-e"],
+          description: "Stop consuming when latest offset is reached",
+        },
+        {
+          name: ["--from-beginning", "-b"],
+          description: "Set offset for consumer to the oldest offset",
+        },
+        {
+          name: ["--group", "-g"],
+          description: "Consumer group to join",
+          args: { name: "group" },
+        },
+        {
+          name: "--key-encoding",
+          description:
+            "Key encoding (auto-detected by default). One of: none|hex|base64",
+          args: { name: "key-encoding" },
+        },
+        {
+          name: "--key-proto-type",
+          description: "Key protobuf message type",
+          args: { name: "key-proto-type" },
+        },
+        {
+          name: "--max-messages",
+          description: "Stop consuming after n messages have been read",
+          args: { name: "max-messages", default: "-1" },
+        },
+        {
+          name: "--offset",
+          description:
+            "Offsets in format `partition=offset (for partitions not specified, other parameters apply)`",
+          isRepeatable: true,
+          args: { name: "offset" },
+        },
+        {
+          name: ["--output", "-o"],
+          description: "Output format. One of: json|yaml",
+          args: { name: "output" },
+        },
+        {
+          name: ["--partitions", "-p"],
+          description:
+            "Partitions to consume. The default is to consume from all partitions",
+          isRepeatable: true,
+          args: { name: "partitions" },
+        },
+        { name: "--print-headers", description: "Print message headers" },
+        { name: ["--print-keys", "-k"], description: "Print message keys" },
+        {
+          name: ["--print-schema", "-a"],
+          description: "Print details about avro schema used for decoding",
+        },
+        {
+          name: ["--print-timestamps", "-t"],
+          description: "Print message timestamps",
+        },
+        {
+          name: "--proto-file",
+          description:
+            "Additional protobuf description file for searching message description",
+          isRepeatable: true,
+          args: {
+            name: "proto-file",
+            template: "filepaths",
           },
-          {
-            name: ["topic"],
-            description: "alter a topic",
-            options: [
-              {
-                name: ["--config", "-c"],
-                description: "configs in format `key=value`",
-                isRepeatable: true,
-                args: [{ name: "config" }],
-              },
-              {
-                name: ["--partitions", "-p"],
-                description: "number of partitions",
-                args: [{ name: "partitions", default: "0" }],
-              },
-              {
-                name: ["--replication-factor", "-r"],
-                description: "replication factor",
-                args: [{ name: "replication-factor", default: "0" }],
-              },
-              { name: ["--validate-only", "-v"], description: "validate only" },
-            ],
+        },
+        {
+          name: "--proto-import-path",
+          description:
+            "Additional path to search files listed in proto 'import' directive",
+          isRepeatable: true,
+          args: {
+            name: "proto-import-path",
+            template: "folders",
           },
-        ],
+        },
+        {
+          name: "--protoset-file",
+          description:
+            "Additional compiled protobuf description file for searching message description",
+          isRepeatable: true,
+          args: {
+            name: "protoset-file",
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["--separator", "-s"],
+          description: "Separator to split key and value",
+          args: { name: "separator", default: "#" },
+        },
+        {
+          name: "--tail",
+          description: "Show only the last n messages on the topic",
+          args: { name: "tail", default: "-1" },
+        },
+        {
+          name: "--value-encoding",
+          description:
+            "Value encoding (auto-detected by default). One of: none|hex|base64",
+          args: { name: "value-encoding" },
+        },
+        {
+          name: "--value-proto-type",
+          description: "Value protobuf message type",
+          args: { name: "value-proto-type" },
+        },
+      ],
+    },
+    {
+      name: "create",
+      description: "Create topics, consumerGroups, acls",
+      subcommands: [
+        {
+          name: ["acl", "access-control-list"],
+          description: "Create an acl",
+          options: [
+            {
+              name: ["--allow", "-a"],
+              description:
+                "Acl of permissionType 'allow' (choose this or 'deny')",
+            },
+            {
+              name: ["--cluster", "-c"],
+              description: "Create acl for the cluster",
+            },
+            {
+              name: ["--deny", "-d"],
+              description:
+                "Acl of permissionType 'deny' (choose this or 'allow')",
+            },
+            {
+              name: ["--group", "-g"],
+              description: "Create acl for a consumer group",
+              args: { name: "group" },
+            },
+            {
+              name: "--host",
+              description: "Hosts to allow",
+              isRepeatable: true,
+              args: { name: "host" },
+            },
+            {
+              name: ["--operation", "-o"],
+              description: "Operations of acl",
+              isRepeatable: true,
+              args: { name: "operation" },
+              isRequired: true,
+            },
+            {
+              name: "--pattern",
+              description: "Pattern type. one of (match, prefixed, literal)",
+              args: { name: "pattern", default: "literal" },
+            },
+            {
+              name: ["--principal", "-p"],
+              description: "Principal to be authenticated",
+              args: { name: "principal" },
+              isRequired: true,
+            },
+            {
+              name: ["--topic", "-t"],
+              description: "Create acl for a topic",
+              args: { name: "topic" },
+            },
+            { name: ["--validate-only", "-v"], description: "Validate only" },
+          ],
+        },
+        {
+          name: ["cg", "consumer-group"],
+          description: "Create a consumerGroup",
+          options: [
+            {
+              name: "--newest",
+              description:
+                "Set the offset to newest offset (for all partitions or the specified partition)",
+            },
+            {
+              name: "--offset",
+              description:
+                "Set offset to this value. offset with value -1 is ignored",
+              args: { name: "offset", default: "-1" },
+            },
+            {
+              name: "--oldest",
+              description:
+                "Set the offset to oldest offset (for all partitions or the specified partition)",
+            },
+            {
+              name: ["--partition", "-p"],
+              description:
+                "Partition to create group for. -1 stands for all partitions",
+              args: { name: "partition", default: "-1" },
+            },
+            {
+              name: ["--topic", "-t"],
+              description: "One or more topics to create group for",
+              isRepeatable: true,
+              args: { name: "topic" },
+            },
+          ],
+        },
+        {
+          name: "topic",
+          description: "Create a topic",
+          options: [
+            {
+              name: ["--config", "-c"],
+              description: "Configs in format `key=value`",
+              isRepeatable: true,
+              args: { name: "config" },
+            },
+            {
+              name: ["--partitions", "-p"],
+              description: "Number of partitions",
+              args: { name: "partitions", default: "1" },
+            },
+            {
+              name: ["--replication-factor", "-r"],
+              description: "Replication factor",
+              args: { name: "replication-factor", default: "1" },
+            },
+            { name: ["--validate-only", "-v"], description: "Validate only" },
+          ],
+        },
+      ],
+    },
+    {
+      name: "delete",
+      description: "Delete topics, consumerGroups, consumer-group-offset, acls",
+      subcommands: [
+        {
+          name: ["acl", "access-control-list"],
+          description: "Delete an acl",
+          options: [
+            {
+              name: ["--allow", "-a"],
+              description: "Acl of permissionType 'allow'",
+            },
+            {
+              name: ["--cluster", "-c"],
+              description: "Delete acl for the cluster",
+            },
+            {
+              name: ["--deny", "-d"],
+              description: "Acl of permissionType 'deny'",
+            },
+            {
+              name: ["--groups", "-g"],
+              description: "Delete acl for a consumer group",
+            },
+            {
+              name: ["--operation", "-o"],
+              description: "Operation of acl",
+              args: { name: "operation" },
+              isRequired: true,
+            },
+            {
+              name: "--pattern",
+              description:
+                "Pattern type. one of (any, match, prefixed, literal)",
+              args: { name: "pattern" },
+              isRequired: true,
+            },
+            { name: ["--topics", "-t"], description: "Delete acl for a topic" },
+            { name: ["--validate-only", "-v"], description: "Validate only" },
+          ],
+        },
+        {
+          name: ["consumer-groups", "consumer-group"],
+          description: "Delete a consumer-group",
+        },
+        {
+          name: ["cgo", "offset", "consumer-group-offset"],
+          description: "Delete a consumer-group-offset",
+          options: [
+            {
+              name: ["--partition", "-p"],
+              description:
+                "Delete offset for this partition. -1 stands for all partitions",
+              args: { name: "partition", default: "-1" },
+            },
+            {
+              name: ["--topic", "-t"],
+              description: "Delete offset for this topic",
+              args: { name: "topic" },
+            },
+          ],
+        },
+        { name: "topic", description: "Delete a topic" },
+      ],
+    },
+    {
+      name: "describe",
+      description: "Describe topics, consumerGroups, brokers",
+      subcommands: [
+        {
+          name: "broker",
+          description: "Describe a broker",
+          options: [
+            {
+              name: ["--output", "-o"],
+              description: "Output format. One of: json|yaml|wide",
+              args: { name: "output" },
+            },
+          ],
+        },
+        {
+          name: ["cg", "consumer-group"],
+          description: "Describe a consumerGroup",
+          options: [
+            {
+              name: ["--only-with-lag", "-l"],
+              description: "Show only partitions that have a lag",
+            },
+            {
+              name: ["--output", "-o"],
+              description: "Output format. One of: json|yaml|wide",
+              args: { name: "output" },
+            },
+            {
+              name: ["--print-members", "-m"],
+              description: "Print group members",
+            },
+            {
+              name: ["--print-topics", "-T"],
+              description: "Print topic details",
+            },
+            {
+              name: ["--topic", "-t"],
+              description: "Show group details for given topic only",
+              args: { name: "topic" },
+            },
+          ],
+        },
+        {
+          name: "topic",
+          description: "Describe a topic",
+          options: [
+            {
+              name: ["--output", "-o"],
+              description: "Output format. One of: json|yaml|wide",
+              args: { name: "output" },
+            },
+            { name: ["--print-configs", "-c"], description: "Print configs" },
+            {
+              name: ["--skip-empty", "-s"],
+              description: "Show only partitions that have a messages",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: ["list", "get"],
+      description: "Get info about topics, consumerGroups, acls, brokers",
+      subcommands: [
+        {
+          name: ["acl", "access-control-list"],
+          description: "List available acls",
+          options: [
+            {
+              name: ["--allow", "-a"],
+              description: "Acl of permissionType 'allow'",
+            },
+            {
+              name: ["--cluster", "-c"],
+              description: "List acl for the cluster",
+            },
+            {
+              name: ["--deny", "-d"],
+              description: "Acl of permissionType 'deny'",
+            },
+            {
+              name: ["--groups", "-g"],
+              description: "List acl for consumer groups",
+            },
+            {
+              name: "--operation",
+              description: "Operation of acl",
+              args: { name: "operation", default: "any" },
+            },
+            {
+              name: ["--output", "-o"],
+              description: "Output format. One of: json|yaml",
+              args: { name: "output" },
+            },
+            {
+              name: "--pattern",
+              description:
+                "Pattern type. one of (any, match, prefixed, literal)",
+              args: { name: "pattern", default: "any" },
+            },
+            { name: ["--topics", "-t"], description: "List acl for topics" },
+          ],
+        },
+        {
+          name: "brokers",
+          description: "List brokers",
+          options: [
+            {
+              name: ["--output", "-o"],
+              description: "Output format. One of: json|yaml|compact",
+              args: { name: "output" },
+            },
+          ],
+        },
+        {
+          name: ["cg", "consumer-groups"],
+          description: "List available consumerGroups",
+          options: [
+            {
+              name: ["--output", "-o"],
+              description: "Output format. One of: json|yaml|wide|compact",
+              args: { name: "output" },
+            },
+            {
+              name: ["--topic", "-t"],
+              description: "Show groups for given topic only",
+              args: { name: "topic" },
+            },
+          ],
+        },
+        {
+          name: "topics",
+          description: "List available topics",
+          options: [
+            {
+              name: ["--output", "-o"],
+              description: "Output format. One of: json|yaml|wide|compact",
+              args: { name: "output" },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "produce",
+      description: "Produce messages to a topic",
+      options: [
+        {
+          name: ["--file", "-f"],
+          description: "File to read input from",
+          args: { name: "file" },
+        },
+        {
+          name: ["--header", "-H"],
+          description: "Headers in format `key:value`",
+          isRepeatable: true,
+          args: { name: "header" },
+        },
+        {
+          name: ["--key", "-k"],
+          description: "Key to use for all messages",
+          args: { name: "key" },
+        },
+        {
+          name: "--key-encoding",
+          description:
+            "Key encoding (none by default). One of: none|hex|base64",
+          args: { name: "key-encoding" },
+        },
+        {
+          name: "--key-proto-type",
+          description: "Key protobuf message type",
+          args: { name: "key-proto-type" },
+        },
+        {
+          name: ["--key-schema-version", "-K"],
+          description:
+            "Avro schema version that should be used for key serialization (default is latest)",
+          args: { name: "key-schema-version", default: "-1" },
+        },
+        {
+          name: ["--lineSeparator", "-L"],
+          description:
+            "Separator to split multiple messages from stdin or file",
+          args: { name: "lineSeparator", default: "" },
+        },
+        {
+          name: "--max-message-bytes",
+          description:
+            "The maximum permitted size of a message (defaults to 1000000)",
+          args: { name: "max-message-bytes", default: "0" },
+        },
+        {
+          name: "--null-value",
+          description:
+            "Produce a null value (can be used instead of providing a value with --value)",
+        },
+        {
+          name: ["--partition", "-p"],
+          description: "Partition to produce to",
+          args: { name: "partition", default: "-1" },
+        },
+        {
+          name: ["--partitioner", "-P"],
+          description:
+            "The partitioning scheme to use. Can be `murmur2`, `hash`, `hash-ref` `manual`, or `random`. (default is murmur2)",
+          args: { name: "partitioner" },
+        },
+        {
+          name: "--proto-file",
+          description:
+            "Additional protobuf description file for searching message description",
+          isRepeatable: true,
+          args: {
+            name: "proto-file",
+            template: "filepaths",
+          },
+        },
+        {
+          name: "--proto-import-path",
+          description:
+            "Additional path to search files listed in proto 'import' directive",
+          isRepeatable: true,
+          args: {
+            name: "proto-import-path",
+            template: "folders",
+          },
+        },
+        {
+          name: "--protoset-file",
+          description:
+            "Additional compiled protobuf description file for searching message description",
+          isRepeatable: true,
+          args: {
+            name: "protoset-file",
+            template: "filepaths",
+          },
+        },
+        {
+          name: ["--rate", "-r"],
+          description: "Amount of messages per second to produce on the topic",
+          args: { name: "rate", default: "-1" },
+        },
+        {
+          name: "--required-acks",
+          description:
+            "Required acks. One of `NoResponse`, `WaitForLocal`, `WaitForAll`. (default is WaitForLocal)",
+          args: { name: "required-acks" },
+        },
+        {
+          name: ["--separator", "-S"],
+          description: "Separator to split key and value from stdin or file",
+          args: { name: "separator" },
+        },
+        {
+          name: ["--silent", "-s"],
+          description: "Do not write to standard output",
+        },
+        {
+          name: ["--value", "-v"],
+          description: "Value to produce",
+          args: { name: "value" },
+        },
+        {
+          name: "--value-encoding",
+          description:
+            "Value encoding (none by default). One of: none|hex|base64",
+          args: { name: "value-encoding" },
+        },
+        {
+          name: "--value-proto-type",
+          description: "Value protobuf message type",
+          args: { name: "value-proto-type" },
+        },
+        {
+          name: ["--value-schema-version", "-i"],
+          description:
+            "Avro schema version that should be used for value serialization (default is latest)",
+          args: { name: "value-schema-version", default: "-1" },
+        },
+      ],
+    },
+    {
+      name: "reset",
+      description: "Reset consumerGroupsOffset",
+      subcommands: [
+        {
+          name: ["cgo", "offset", "consumer-group-offset"],
+          description: "Reset a consumer group offset",
+          options: [
+            {
+              name: "--all-topics",
+              description:
+                "Do the operation for all topics in the consumer group",
+            },
+            {
+              name: ["--execute", "-e"],
+              description:
+                "Execute the reset (as default only the results are displayed for validation)",
+            },
+            {
+              name: "--newest",
+              description:
+                "Set the offset to newest offset (for all partitions or the specified partition)",
+            },
+            {
+              name: "--offset",
+              description:
+                "Set offset to this value. offset with value -1 is ignored",
+              args: { name: "offset", default: "-1" },
+            },
+            {
+              name: "--oldest",
+              description:
+                "Set the offset to oldest offset (for all partitions or the specified partition)",
+            },
+            {
+              name: ["--output", "-o"],
+              description: "Output format. One of: json|yaml",
+              args: { name: "output" },
+            },
+            {
+              name: ["--partition", "-p"],
+              description:
+                "Partition to apply the offset. -1 stands for all partitions",
+              args: { name: "partition", default: "-1" },
+            },
+            {
+              name: ["--topic", "-t"],
+              description: "One ore more topics to change offset for",
+              isRepeatable: true,
+              args: { name: "topic" },
+            },
+          ],
+        },
+      ],
+    },
+    { name: "version", description: "Print the version of kafkactl" },
+    {
+      name: "help",
+      description: "Help about any command",
+      subcommands: [
+        {
+          name: ["edit", "alter"],
+          description: "Alter topics, partitions",
+          subcommands: [
+            { name: "partition", description: "Alter a partition" },
+            { name: "topic", description: "Alter a topic" },
+          ],
+        },
+        {
+          name: "attach",
+          description: "Run kafkactl pod in kubernetes and attach to it",
+        },
+        {
+          name: "clone",
+          description: "Clone topics, consumerGroups",
+          subcommands: [
+            {
+              name: ["cg", "consumer-group"],
+              description: "Clone existing consumerGroup with all offsets",
+            },
+            {
+              name: "topic",
+              description:
+                "Clone existing topic (number of partitions, replication factor, config entries) to new one",
+            },
+          ],
+        },
+        {
+          name: "completion",
+          description: "Generate shell auto-completion file",
+        },
+        {
+          name: "config",
+          description: "Show and edit configurations",
+          subcommands: [
+            {
+              name: ["currentContext", "current-context"],
+              description: "Show current context",
+            },
+            {
+              name: ["getContexts", "get-contexts"],
+              description: "List configured contexts",
+            },
+            {
+              name: ["useContext", "use-context"],
+              description: "Switch active context",
+            },
+            { name: "view", description: "Show contents of config file" },
+          ],
+        },
+        { name: "consume", description: "Consume messages from a topic" },
+        {
+          name: "create",
+          description: "Create topics, consumerGroups, acls",
+          subcommands: [
+            {
+              name: ["acl", "access-control-list"],
+              description: "Create an acl",
+            },
+            {
+              name: ["cg", "consumer-group"],
+              description: "Create a consumerGroup",
+            },
+            { name: "topic", description: "Create a topic" },
+          ],
+        },
+        {
+          name: "delete",
+          description:
+            "Delete topics, consumerGroups, consumer-group-offset, acls",
+          subcommands: [
+            {
+              name: ["acl", "access-control-list"],
+              description: "Delete an acl",
+            },
+            {
+              name: ["consumer-groups", "consumer-group"],
+              description: "Delete a consumer-group",
+            },
+            {
+              name: ["cgo", "offset", "consumer-group-offset"],
+              description: "Delete a consumer-group-offset",
+            },
+            { name: "topic", description: "Delete a topic" },
+          ],
+        },
+        {
+          name: "describe",
+          description: "Describe topics, consumerGroups, brokers",
+          subcommands: [
+            { name: "broker", description: "Describe a broker" },
+            {
+              name: ["cg", "consumer-group"],
+              description: "Describe a consumerGroup",
+            },
+            { name: "topic", description: "Describe a topic" },
+          ],
+        },
+        {
+          name: ["list", "get"],
+          description: "Get info about topics, consumerGroups, acls, brokers",
+          subcommands: [
+            {
+              name: ["acl", "access-control-list"],
+              description: "List available acls",
+            },
+            { name: "brokers", description: "List brokers" },
+            {
+              name: ["cg", "consumer-groups"],
+              description: "List available consumerGroups",
+            },
+            { name: "topics", description: "List available topics" },
+          ],
+        },
+        { name: "produce", description: "Produce messages to a topic" },
+        {
+          name: "reset",
+          description: "Reset consumerGroupsOffset",
+          subcommands: [
+            {
+              name: ["cgo", "offset", "consumer-group-offset"],
+              description: "Reset a consumer group offset",
+            },
+          ],
+        },
+        { name: "version", description: "Print the version of kafkactl" },
+      ],
+    },
+  ],
+  options: [
+    {
+      name: ["--config-file", "-C"],
+      description:
+        "Config file. one of: [$HOME/.config/kafkactl $HOME/.kafkactl $SNAP_REAL_HOME/.config/kafkactl $SNAP_DATA/kafkactl /etc/kafkactl]",
+      isPersistent: true,
+      args: {
+        name: "config-file",
+        template: "filepaths",
       },
-      {
-        name: ["attach"],
-        description: "run kafkactl pod in kubernetes and attach to it",
-      },
-      {
-        name: ["clone"],
-        description: "clone topics, consumerGroups",
-        subcommands: [
-          {
-            name: ["cg", "consumer-group"],
-            description: "clone existing consumerGroup with all offsets",
-          },
-          {
-            name: ["topic"],
-            description:
-              "clone existing topic (number of partitions, replication factor, config entries) to new one",
-          },
-        ],
-      },
-      {
-        name: ["completion"],
-        description: "generate shell auto-completion file",
-      },
-      {
-        name: ["config"],
-        description: "show and edit configurations",
-        subcommands: [
-          {
-            name: ["currentContext", "current-context"],
-            description: "show current context",
-          },
-          {
-            name: ["getContexts", "get-contexts"],
-            description: "list configured contexts",
-            options: [
-              {
-                name: ["--output", "-o"],
-                description: "output format. One of: compact",
-                args: [{ name: "output" }],
-              },
-            ],
-          },
-          {
-            name: ["useContext", "use-context"],
-            description: "switch active context",
-          },
-          { name: ["view"], description: "show contents of config file" },
-        ],
-      },
-      {
-        name: ["consume"],
-        description: "consume messages from a topic",
-        options: [
-          {
-            name: ["--exit", "-e"],
-            description: "stop consuming when latest offset is reached",
-          },
-          {
-            name: ["--from-beginning", "-b"],
-            description: "set offset for consumer to the oldest offset",
-          },
-          {
-            name: ["--group", "-g"],
-            description: "consumer group to join",
-            args: [{ name: "group" }],
-          },
-          {
-            name: ["--key-encoding"],
-            description:
-              "key encoding (auto-detected by default). One of: none|hex|base64",
-            args: [{ name: "key-encoding" }],
-          },
-          {
-            name: ["--key-proto-type"],
-            description: "key protobuf message type",
-            args: [{ name: "key-proto-type" }],
-          },
-          {
-            name: ["--max-messages"],
-            description: "stop consuming after n messages have been read",
-            args: [{ name: "max-messages", default: "-1" }],
-          },
-          {
-            name: ["--offset"],
-            description:
-              "offsets in format `partition=offset (for partitions not specified, other parameters apply)`",
-            isRepeatable: true,
-            args: [{ name: "offset" }],
-          },
-          {
-            name: ["--output", "-o"],
-            description: "output format. One of: json|yaml",
-            args: [{ name: "output" }],
-          },
-          {
-            name: ["--partitions", "-p"],
-            description:
-              "partitions to consume. The default is to consume from all partitions.",
-            isRepeatable: true,
-            args: [{ name: "partitions" }],
-          },
-          { name: ["--print-headers"], description: "print message headers" },
-          { name: ["--print-keys", "-k"], description: "print message keys" },
-          {
-            name: ["--print-schema", "-a"],
-            description: "print details about avro schema used for decoding",
-          },
-          {
-            name: ["--print-timestamps", "-t"],
-            description: "print message timestamps",
-          },
-          {
-            name: ["--proto-file"],
-            description:
-              "additional protobuf description file for searching message description",
-            isRepeatable: true,
-            args: [{ name: "proto-file" }],
-          },
-          {
-            name: ["--proto-import-path"],
-            description:
-              "additional path to search files listed in proto 'import' directive",
-            isRepeatable: true,
-            args: [{ name: "proto-import-path" }],
-          },
-          {
-            name: ["--protoset-file"],
-            description:
-              "additional compiled protobuf description file for searching message description",
-            isRepeatable: true,
-            args: [{ name: "protoset-file" }],
-          },
-          {
-            name: ["--separator", "-s"],
-            description: "separator to split key and value",
-            args: [{ name: "separator", default: "#" }],
-          },
-          {
-            name: ["--tail"],
-            description: "show only the last n messages on the topic",
-            args: [{ name: "tail", default: "-1" }],
-          },
-          {
-            name: ["--value-encoding"],
-            description:
-              "value encoding (auto-detected by default). One of: none|hex|base64",
-            args: [{ name: "value-encoding" }],
-          },
-          {
-            name: ["--value-proto-type"],
-            description: "value protobuf message type",
-            args: [{ name: "value-proto-type" }],
-          },
-        ],
-      },
-      {
-        name: ["create"],
-        description: "create topics, consumerGroups, acls",
-        subcommands: [
-          {
-            name: ["acl", "access-control-list"],
-            description: "create an acl",
-            options: [
-              {
-                name: ["--allow", "-a"],
-                description:
-                  "acl of permissionType 'allow' (choose this or 'deny')",
-              },
-              {
-                name: ["--cluster", "-c"],
-                description: "create acl for the cluster",
-              },
-              {
-                name: ["--deny", "-d"],
-                description:
-                  "acl of permissionType 'deny' (choose this or 'allow')",
-              },
-              {
-                name: ["--group", "-g"],
-                description: "create acl for a consumer group",
-                args: [{ name: "group" }],
-              },
-              {
-                name: ["--host"],
-                description: "hosts to allow",
-                isRepeatable: true,
-                args: [{ name: "host" }],
-              },
-              {
-                name: ["--operation", "-o"],
-                description: "operations of acl",
-                isRepeatable: true,
-                args: [{ name: "operation" }],
-                isRequired: true,
-              },
-              {
-                name: ["--pattern"],
-                description: "pattern type. one of (match, prefixed, literal)",
-                args: [{ name: "pattern", default: "literal" }],
-              },
-              {
-                name: ["--principal", "-p"],
-                description: "principal to be authenticated",
-                args: [{ name: "principal" }],
-                isRequired: true,
-              },
-              {
-                name: ["--topic", "-t"],
-                description: "create acl for a topic",
-                args: [{ name: "topic" }],
-              },
-              { name: ["--validate-only", "-v"], description: "validate only" },
-            ],
-          },
-          {
-            name: ["cg", "consumer-group"],
-            description: "create a consumerGroup",
-            options: [
-              {
-                name: ["--newest"],
-                description:
-                  "set the offset to newest offset (for all partitions or the specified partition)",
-              },
-              {
-                name: ["--offset"],
-                description:
-                  "set offset to this value. offset with value -1 is ignored",
-                args: [{ name: "offset", default: "-1" }],
-              },
-              {
-                name: ["--oldest"],
-                description:
-                  "set the offset to oldest offset (for all partitions or the specified partition)",
-              },
-              {
-                name: ["--partition", "-p"],
-                description:
-                  "partition to create group for. -1 stands for all partitions",
-                args: [{ name: "partition", default: "-1" }],
-              },
-              {
-                name: ["--topic", "-t"],
-                description: "one or more topics to create group for",
-                isRepeatable: true,
-                args: [{ name: "topic" }],
-              },
-            ],
-          },
-          {
-            name: ["topic"],
-            description: "create a topic",
-            options: [
-              {
-                name: ["--config", "-c"],
-                description: "configs in format `key=value`",
-                isRepeatable: true,
-                args: [{ name: "config" }],
-              },
-              {
-                name: ["--partitions", "-p"],
-                description: "number of partitions",
-                args: [{ name: "partitions", default: "1" }],
-              },
-              {
-                name: ["--replication-factor", "-r"],
-                description: "replication factor",
-                args: [{ name: "replication-factor", default: "1" }],
-              },
-              { name: ["--validate-only", "-v"], description: "validate only" },
-            ],
-          },
-        ],
-      },
-      {
-        name: ["delete"],
-        description: "delete topics, consumerGroups, consumer-group-offset, acls",
-        subcommands: [
-          {
-            name: ["acl", "access-control-list"],
-            description: "delete an acl",
-            options: [
-              {
-                name: ["--allow", "-a"],
-                description: "acl of permissionType 'allow'",
-              },
-              {
-                name: ["--cluster", "-c"],
-                description: "delete acl for the cluster",
-              },
-              {
-                name: ["--deny", "-d"],
-                description: "acl of permissionType 'deny'",
-              },
-              {
-                name: ["--groups", "-g"],
-                description: "delete acl for a consumer group",
-              },
-              {
-                name: ["--operation", "-o"],
-                description: "operation of acl",
-                args: [{ name: "operation" }],
-                isRequired: true,
-              },
-              {
-                name: ["--pattern"],
-                description:
-                  "pattern type. one of (any, match, prefixed, literal)",
-                args: [{ name: "pattern" }],
-                isRequired: true,
-              },
-              { name: ["--topics", "-t"], description: "delete acl for a topic" },
-              { name: ["--validate-only", "-v"], description: "validate only" },
-            ],
-          },
-          {
-            name: ["consumer-groups", "consumer-group"],
-            description: "delete a consumer-group",
-          },
-          {
-            name: ["cgo", "offset", "consumer-group-offset"],
-            description: "delete a consumer-group-offset",
-            options: [
-              {
-                name: ["--partition", "-p"],
-                description:
-                  "delete offset for this partition. -1 stands for all partitions",
-                args: [{ name: "partition", default: "-1" }],
-              },
-              {
-                name: ["--topic", "-t"],
-                description: "delete offset for this topic",
-                args: [{ name: "topic" }],
-              },
-            ],
-          },
-          { name: ["topic"], description: "delete a topic" },
-        ],
-      },
-      {
-        name: ["describe"],
-        description: "describe topics, consumerGroups, brokers",
-        subcommands: [
-          {
-            name: ["broker"],
-            description: "describe a broker",
-            options: [
-              {
-                name: ["--output", "-o"],
-                description: "output format. One of: json|yaml|wide",
-                args: [{ name: "output" }],
-              },
-            ],
-          },
-          {
-            name: ["cg", "consumer-group"],
-            description: "describe a consumerGroup",
-            options: [
-              {
-                name: ["--only-with-lag", "-l"],
-                description: "show only partitions that have a lag",
-              },
-              {
-                name: ["--output", "-o"],
-                description: "output format. One of: json|yaml|wide",
-                args: [{ name: "output" }],
-              },
-              {
-                name: ["--print-members", "-m"],
-                description: "print group members",
-              },
-              {
-                name: ["--print-topics", "-T"],
-                description: "print topic details",
-              },
-              {
-                name: ["--topic", "-t"],
-                description: "show group details for given topic only",
-                args: [{ name: "topic" }],
-              },
-            ],
-          },
-          {
-            name: ["topic"],
-            description: "describe a topic",
-            options: [
-              {
-                name: ["--output", "-o"],
-                description: "output format. One of: json|yaml|wide",
-                args: [{ name: "output" }],
-              },
-              { name: ["--print-configs", "-c"], description: "print configs" },
-              {
-                name: ["--skip-empty", "-s"],
-                description: "show only partitions that have a messages",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        name: ["list", "get"],
-        description: "get info about topics, consumerGroups, acls, brokers",
-        subcommands: [
-          {
-            name: ["acl", "access-control-list"],
-            description: "list available acls",
-            options: [
-              {
-                name: ["--allow", "-a"],
-                description: "acl of permissionType 'allow'",
-              },
-              {
-                name: ["--cluster", "-c"],
-                description: "list acl for the cluster",
-              },
-              {
-                name: ["--deny", "-d"],
-                description: "acl of permissionType 'deny'",
-              },
-              {
-                name: ["--groups", "-g"],
-                description: "list acl for consumer groups",
-              },
-              {
-                name: ["--operation"],
-                description: "operation of acl",
-                args: [{ name: "operation", default: "any" }],
-              },
-              {
-                name: ["--output", "-o"],
-                description: "output format. One of: json|yaml",
-                args: [{ name: "output" }],
-              },
-              {
-                name: ["--pattern"],
-                description:
-                  "pattern type. one of (any, match, prefixed, literal)",
-                args: [{ name: "pattern", default: "any" }],
-              },
-              { name: ["--topics", "-t"], description: "list acl for topics" },
-            ],
-          },
-          {
-            name: ["brokers"],
-            description: "list brokers",
-            options: [
-              {
-                name: ["--output", "-o"],
-                description: "output format. One of: json|yaml|compact",
-                args: [{ name: "output" }],
-              },
-            ],
-          },
-          {
-            name: ["cg", "consumer-groups"],
-            description: "list available consumerGroups",
-            options: [
-              {
-                name: ["--output", "-o"],
-                description: "output format. One of: json|yaml|wide|compact",
-                args: [{ name: "output" }],
-              },
-              {
-                name: ["--topic", "-t"],
-                description: "show groups for given topic only",
-                args: [{ name: "topic" }],
-              },
-            ],
-          },
-          {
-            name: ["topics"],
-            description: "list available topics",
-            options: [
-              {
-                name: ["--output", "-o"],
-                description: "output format. One of: json|yaml|wide|compact",
-                args: [{ name: "output" }],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        name: ["produce"],
-        description: "produce messages to a topic",
-        options: [
-          {
-            name: ["--file", "-f"],
-            description: "file to read input from",
-            args: [{ name: "file" }],
-          },
-          {
-            name: ["--header", "-H"],
-            description: "headers in format `key:value`",
-            isRepeatable: true,
-            args: [{ name: "header" }],
-          },
-          {
-            name: ["--key", "-k"],
-            description: "key to use for all messages",
-            args: [{ name: "key" }],
-          },
-          {
-            name: ["--key-encoding"],
-            description:
-              "key encoding (none by default). One of: none|hex|base64",
-            args: [{ name: "key-encoding" }],
-          },
-          {
-            name: ["--key-proto-type"],
-            description: "key protobuf message type",
-            args: [{ name: "key-proto-type" }],
-          },
-          {
-            name: ["--key-schema-version", "-K"],
-            description:
-              "avro schema version that should be used for key serialization (default is latest)",
-            args: [{ name: "key-schema-version", default: "-1" }],
-          },
-          {
-            name: ["--lineSeparator", "-L"],
-            description:
-              "separator to split multiple messages from stdin or file",
-            args: [{ name: "lineSeparator", default: "" }],
-          },
-          {
-            name: ["--max-message-bytes"],
-            description:
-              "the maximum permitted size of a message (defaults to 1000000)",
-            args: [{ name: "max-message-bytes", default: "0" }],
-          },
-          {
-            name: ["--null-value"],
-            description:
-              "produce a null value (can be used instead of providing a value with --value)",
-          },
-          {
-            name: ["--partition", "-p"],
-            description: "partition to produce to",
-            args: [{ name: "partition", default: "-1" }],
-          },
-          {
-            name: ["--partitioner", "-P"],
-            description:
-              "the partitioning scheme to use. Can be `murmur2`, `hash`, `hash-ref` `manual`, or `random`. (default is murmur2)",
-            args: [{ name: "partitioner" }],
-          },
-          {
-            name: ["--proto-file"],
-            description:
-              "additional protobuf description file for searching message description",
-            isRepeatable: true,
-            args: [{ name: "proto-file" }],
-          },
-          {
-            name: ["--proto-import-path"],
-            description:
-              "additional path to search files listed in proto 'import' directive",
-            isRepeatable: true,
-            args: [{ name: "proto-import-path" }],
-          },
-          {
-            name: ["--protoset-file"],
-            description:
-              "additional compiled protobuf description file for searching message description",
-            isRepeatable: true,
-            args: [{ name: "protoset-file" }],
-          },
-          {
-            name: ["--rate", "-r"],
-            description: "amount of messages per second to produce on the topic",
-            args: [{ name: "rate", default: "-1" }],
-          },
-          {
-            name: ["--required-acks"],
-            description:
-              "required acks. One of `NoResponse`, `WaitForLocal`, `WaitForAll`. (default is WaitForLocal)",
-            args: [{ name: "required-acks" }],
-          },
-          {
-            name: ["--separator", "-S"],
-            description: "separator to split key and value from stdin or file",
-            args: [{ name: "separator" }],
-          },
-          {
-            name: ["--silent", "-s"],
-            description: "do not write to standard output",
-          },
-          {
-            name: ["--value", "-v"],
-            description: "value to produce",
-            args: [{ name: "value" }],
-          },
-          {
-            name: ["--value-encoding"],
-            description:
-              "value encoding (none by default). One of: none|hex|base64",
-            args: [{ name: "value-encoding" }],
-          },
-          {
-            name: ["--value-proto-type"],
-            description: "value protobuf message type",
-            args: [{ name: "value-proto-type" }],
-          },
-          {
-            name: ["--value-schema-version", "-i"],
-            description:
-              "avro schema version that should be used for value serialization (default is latest)",
-            args: [{ name: "value-schema-version", default: "-1" }],
-          },
-        ],
-      },
-      {
-        name: ["reset"],
-        description: "reset consumerGroupsOffset",
-        subcommands: [
-          {
-            name: ["cgo", "offset", "consumer-group-offset"],
-            description: "reset a consumer group offset",
-            options: [
-              {
-                name: ["--all-topics"],
-                description:
-                  "do the operation for all topics in the consumer group",
-              },
-              {
-                name: ["--execute", "-e"],
-                description:
-                  "execute the reset (as default only the results are displayed for validation)",
-              },
-              {
-                name: ["--newest"],
-                description:
-                  "set the offset to newest offset (for all partitions or the specified partition)",
-              },
-              {
-                name: ["--offset"],
-                description:
-                  "set offset to this value. offset with value -1 is ignored",
-                args: [{ name: "offset", default: "-1" }],
-              },
-              {
-                name: ["--oldest"],
-                description:
-                  "set the offset to oldest offset (for all partitions or the specified partition)",
-              },
-              {
-                name: ["--output", "-o"],
-                description: "output format. One of: json|yaml",
-                args: [{ name: "output" }],
-              },
-              {
-                name: ["--partition", "-p"],
-                description:
-                  "partition to apply the offset. -1 stands for all partitions",
-                args: [{ name: "partition", default: "-1" }],
-              },
-              {
-                name: ["--topic", "-t"],
-                description: "one ore more topics to change offset for",
-                isRepeatable: true,
-                args: [{ name: "topic" }],
-              },
-            ],
-          },
-        ],
-      },
-      { name: ["version"], description: "print the version of kafkactl" },
-      {
-        name: ["help"],
-        description: "Help about any command",
-        subcommands: [
-          {
-            name: ["edit", "alter"],
-            description: "alter topics, partitions",
-            subcommands: [
-              { name: ["partition"], description: "alter a partition" },
-              { name: ["topic"], description: "alter a topic" },
-            ],
-          },
-          {
-            name: ["attach"],
-            description: "run kafkactl pod in kubernetes and attach to it",
-          },
-          {
-            name: ["clone"],
-            description: "clone topics, consumerGroups",
-            subcommands: [
-              {
-                name: ["cg", "consumer-group"],
-                description: "clone existing consumerGroup with all offsets",
-              },
-              {
-                name: ["topic"],
-                description:
-                  "clone existing topic (number of partitions, replication factor, config entries) to new one",
-              },
-            ],
-          },
-          {
-            name: ["completion"],
-            description: "generate shell auto-completion file",
-          },
-          {
-            name: ["config"],
-            description: "show and edit configurations",
-            subcommands: [
-              {
-                name: ["currentContext", "current-context"],
-                description: "show current context",
-              },
-              {
-                name: ["getContexts", "get-contexts"],
-                description: "list configured contexts",
-              },
-              {
-                name: ["useContext", "use-context"],
-                description: "switch active context",
-              },
-              { name: ["view"], description: "show contents of config file" },
-            ],
-          },
-          { name: ["consume"], description: "consume messages from a topic" },
-          {
-            name: ["create"],
-            description: "create topics, consumerGroups, acls",
-            subcommands: [
-              {
-                name: ["acl", "access-control-list"],
-                description: "create an acl",
-              },
-              {
-                name: ["cg", "consumer-group"],
-                description: "create a consumerGroup",
-              },
-              { name: ["topic"], description: "create a topic" },
-            ],
-          },
-          {
-            name: ["delete"],
-            description:
-              "delete topics, consumerGroups, consumer-group-offset, acls",
-            subcommands: [
-              {
-                name: ["acl", "access-control-list"],
-                description: "delete an acl",
-              },
-              {
-                name: ["consumer-groups", "consumer-group"],
-                description: "delete a consumer-group",
-              },
-              {
-                name: ["cgo", "offset", "consumer-group-offset"],
-                description: "delete a consumer-group-offset",
-              },
-              { name: ["topic"], description: "delete a topic" },
-            ],
-          },
-          {
-            name: ["describe"],
-            description: "describe topics, consumerGroups, brokers",
-            subcommands: [
-              { name: ["broker"], description: "describe a broker" },
-              {
-                name: ["cg", "consumer-group"],
-                description: "describe a consumerGroup",
-              },
-              { name: ["topic"], description: "describe a topic" },
-            ],
-          },
-          {
-            name: ["list", "get"],
-            description: "get info about topics, consumerGroups, acls, brokers",
-            subcommands: [
-              {
-                name: ["acl", "access-control-list"],
-                description: "list available acls",
-              },
-              { name: ["brokers"], description: "list brokers" },
-              {
-                name: ["cg", "consumer-groups"],
-                description: "list available consumerGroups",
-              },
-              { name: ["topics"], description: "list available topics" },
-            ],
-          },
-          { name: ["produce"], description: "produce messages to a topic" },
-          {
-            name: ["reset"],
-            description: "reset consumerGroupsOffset",
-            subcommands: [
-              {
-                name: ["cgo", "offset", "consumer-group-offset"],
-                description: "reset a consumer group offset",
-              },
-            ],
-          },
-          { name: ["version"], description: "print the version of kafkactl" },
-        ],
-      },
-    ],
-    options: [
-      {
-        name: ["--config-file", "-C"],
-        description:
-          "config file. one of: [$HOME/.config/kafkactl $HOME/.kafkactl $SNAP_REAL_HOME/.config/kafkactl $SNAP_DATA/kafkactl /etc/kafkactl]",
-        isPersistent: true,
-        args: [{ name: "config-file" }],
-      },
-      {
-        name: ["--verbose", "-V"],
-        description: "verbose output",
-        isPersistent: true,
-      },
-      { name: ["--help", "-h"], description: "Display help", isPersistent: true },
-    ],
-  };
-  export default completionSpec;
+    },
+    {
+      name: ["--verbose", "-V"],
+      description: "Verbose output",
+      isPersistent: true,
+    },
+    { name: ["--help", "-h"], description: "Display help", isPersistent: true },
+  ],
+};
+export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

New autocomplete spec for [`kafkactl`](https://github.com/deviceinsight/kafkactl)

**What is the current behavior? (You can also link to an open issue here)**

No autocomplete

**What is the new behavior (if this is a feature change)?**

Autocomplete

**Additional info:**

Generated with the cobra integration

```diff
diff --git a/cmd/root.go b/cmd/root.go
index 8338d38..d14f459 100644
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/deviceinsight/kafkactl/internal/env"
+	cobracompletefig "github.com/withfig/autocomplete-tools/integrations/cobra"
 
 	"github.com/deviceinsight/kafkactl/cmd/alter"
 	"github.com/deviceinsight/kafkactl/cmd/attach"
@@ -57,6 +58,7 @@ func NewKafkactlCommand(streams output.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(newCompletionCmd())
 	rootCmd.AddCommand(newVersionCmd())
 	rootCmd.AddCommand(newDocsCmd())
+	rootCmd.AddCommand(cobracompletefig.CreateCompletionSpecCommand())
 
 	// use upper-case letters for shorthand params to avoid conflicts with local flags
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config-file", "C", "", fmt.Sprintf("config file. one of: %v", configPaths))

```

Had to manually clean up the generated code: https://gist.github.com/mwarkentin/bceba273eadbca827a52b8dcd85ecf9b