### PR TITLE
feat: add taplo completion spec

### DIFF
--- a/src/taplo.ts
+++ b/src/taplo.ts
@@ -4,7 +4,7 @@ const completionSpec: Fig.Spec = {
     "Tool for validation, formatting, and querying TOML documents with a jq-like fashion",
   subcommands: [
     {
-      name: "config",
+      name: ["config", "cfg"],
       description: "Operations with the Taplo config file",
       options: [
         {
@@ -47,7 +47,8 @@ const completionSpec: Fig.Spec = {
     },
 
     {
-      name: "format",
+      name: ["format", "fmt"],
+
       description: "Format TOML documents",
 
       args: {
@@ -57,6 +58,93 @@ const completionSpec: Fig.Spec = {
         suggestCurrentToken: true,
         isOptional: true,
       },
+      options: [
+        {
+          name: ["--config", "-c"],
+          description: "Path to the Taplo configuration file",
+          args: {
+            name: "CONFIG",
+            template: "filepaths",
+            suggestCurrentToken: true,
+          },
+        },
+        {
+          name: "--cache-path",
+          description: "Set a cache path",
+          args: {
+            name: "CACHE_PATH",
+            template: "filepaths",
+            suggestCurrentToken: true,
+          },
+        },
+        {
+          name: "--check",
+          description: "Report any files that are not correctly formatted",
+          args: {
+            name: "CACHE_PATH",
+            template: "filepaths",
+            suggestCurrentToken: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: "--colors",
+          args: {
+            name: "COLORS",
+            default: "auto",
+            suggestions: ["auto", "always", "never"],
+          },
+        },
+        {
+          name: "--diff",
+          description: "Print the differences in patch formatting to `stdout`",
+        },
+        {
+          name: ["f", "--force"],
+          description: "Force formatting of files",
+          args: {
+            name: "FILES ...",
+            template: "filepaths",
+            suggestCurrentToken: true,
+            isOptional: true,
+          },
+        },
+        {
+          name: ["--help", "-h"],
+          description: "Print help information for format",
+        },
+        {
+          name: "--log-spans",
+          description: "Enable logging spans",
+        },
+        {
+          name: "--no-auto-config",
+          description: "Do not search for a configuration file",
+        },
+        {
+          name: ["--option", "-o"],
+          description:
+            "A formatter option given as a 'key=value', can be set multiple times",
+          args: {
+            name: "OPTIONS",
+            suggestions: ["indent_tables=true", "indent_tables=false"],
+          },
+        },
+        {
+          name: "--stdin-filepath",
+          description:
+            "A path to the file that the taplo will treat like stdin",
+          args: {
+            name: "STDIN_FILEPATH",
+            template: "filepaths",
+            suggestCurrentToken: true,
+          },
+        },
+        {
+          name: "--verbose",
+          description: "Enable verbose logging format",
+        },
+      ],
     },
 
     {
@@ -99,34 +187,6 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "URL",
             template: "history",
-          },
-        },
-      ],
-    },
-    {
-      name: "fmt",
-      description: "Format files in-place or via standard i/o",
-      args: {
-        name: "file",
-        description: "The TOML file to validate",
-        template: "filepaths",
-        suggestCurrentToken: true,
-        isOptional: true,
-      },
-      options: [
-        {
-          name: "--option",
-          description: "Formatter options are read from the configuration file",
-          args: {
-            suggestions: ["indent_tables=true", "indent_tables=false"],
-          },
-        },
-        {
-          name: "--check",
-          description:
-            "Check whether the given files are properly formatted. When this flag is supplied, no formatting will be done",
-          args: {
-            suggestions: ["indent_tables=true", "indent_tables=false"],
           },
         },
       ],

--- a/src/taplo.ts
+++ b/src/taplo.ts
@@ -182,7 +182,7 @@ const completionSpec: Fig.Spec = {
     },
 
     {
-      name: "lint",
+      name: ["lint", "check", "validate"],
       description: "Lint a TOML documents",
       args: {
         name: "FILES ...",
@@ -270,29 +270,6 @@ const completionSpec: Fig.Spec = {
         },
         logSpansOption,
         verboseOption,
-      ],
-    },
-
-    {
-      name: "check",
-      description:
-        "Validate a TOML file , by default looks for syntax and semantic errors",
-      args: {
-        name: "file",
-        description: "The TOML file to validate",
-        template: "filepaths",
-        suggestCurrentToken: true,
-        isOptional: true,
-      },
-      options: [
-        {
-          name: "--schema",
-          description: "The JSON schema to validate against",
-          args: {
-            name: "URL",
-            template: "history",
-          },
-        },
       ],
     },
   ],

--- a/src/taplo.ts
+++ b/src/taplo.ts
@@ -1,0 +1,162 @@
+const completionSpec: Fig.Spec = {
+  name: "taplo",
+  description:
+    "Tool for validation, formatting, and querying TOML documents with a jq-like fashion",
+  subcommands: [
+    {
+      name: "config",
+      description: "Operations with the Taplo config file",
+      options: [
+        {
+          name: "--colors",
+          args: {
+            name: "COLORS",
+            default: "auto",
+            suggestions: ["auto", "always", "never"],
+          },
+        },
+        {
+          name: ["--help", "-h"],
+          description: "Print help information for config",
+        },
+        {
+          name: "--log-spans",
+          description: "Enable logging spans",
+        },
+        {
+          name: "--verbose",
+          description: "Enable verbose logging format",
+        },
+      ],
+      subcommands: [
+        {
+          name: "default",
+          description: "Print the default `.taplo.toml` configuration file",
+        },
+        {
+          name: "help",
+          description:
+            "Print this message or the help of the given subcommand(s)",
+        },
+        {
+          name: "schema",
+          description:
+            "Print the JSON schema of the `.taplo.toml` configuration file",
+        },
+      ],
+    },
+
+    {
+      name: "format",
+      description: "Format TOML documents",
+
+      args: {
+        name: "FILES ...",
+        description: "Paths or glob patterns to TOML documents",
+        template: "filepaths",
+        suggestCurrentToken: true,
+        isOptional: true,
+      },
+    },
+
+    {
+      name: "get",
+      description: "Extract a value from the given TOML document",
+    },
+    {
+      name: "help",
+      description: "Print help information for taplo",
+    },
+    {
+      name: "lint",
+      description: "Lint a TOML documents",
+      args: {
+        name: "TOML file",
+        template: "filepaths",
+        suggestCurrentToken: true,
+        isOptional: true,
+      },
+    },
+    {
+      name: "lsp",
+      description: "Language server operations",
+    },
+    {
+      name: "check",
+      description:
+        "Validate a TOML file , by default looks for syntax and semantic errors",
+      args: {
+        name: "file",
+        description: "The TOML file to validate",
+        template: "filepaths",
+        suggestCurrentToken: true,
+        isOptional: true,
+      },
+      options: [
+        {
+          name: "--schema",
+          description: "The JSON schema to validate against",
+          args: {
+            name: "URL",
+            template: "history",
+          },
+        },
+      ],
+    },
+    {
+      name: "fmt",
+      description: "Format files in-place or via standard i/o",
+      args: {
+        name: "file",
+        description: "The TOML file to validate",
+        template: "filepaths",
+        suggestCurrentToken: true,
+        isOptional: true,
+      },
+      options: [
+        {
+          name: "--option",
+          description: "Formatter options are read from the configuration file",
+          args: {
+            suggestions: ["indent_tables=true", "indent_tables=false"],
+          },
+        },
+        {
+          name: "--check",
+          description:
+            "Check whether the given files are properly formatted. When this flag is supplied, no formatting will be done",
+          args: {
+            suggestions: ["indent_tables=true", "indent_tables=false"],
+          },
+        },
+      ],
+    },
+  ],
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Print help information for taplo",
+    },
+    {
+      name: ["--version", "-V"],
+      description: "Print version information for taplo",
+    },
+    {
+      name: "--verbose",
+      description: "Enable verbose logging format",
+    },
+    {
+      name: [
+        "--colors <COLORS>",
+        "[default: auto] [possible values: auto, always, never]",
+      ],
+    },
+    {
+      name: "--log-spans",
+      description: "Enable logging of spans",
+    },
+  ],
+  // Only uncomment if taplo takes an argument
+  // args: {}
+};
+export default completionSpec;

--- a/src/taplo.ts
+++ b/src/taplo.ts
@@ -184,16 +184,73 @@ const completionSpec: Fig.Spec = {
       name: "help",
       description: "Print help information for taplo",
     },
+
     {
       name: "lint",
       description: "Lint a TOML documents",
       args: {
-        name: "TOML file",
+        name: "FILES ...",
         template: "filepaths",
         suggestCurrentToken: true,
         isOptional: true,
       },
+      options: [
+        {
+          name: ["--config", "-c"],
+          description: "Path to the Taplo configuration file",
+          args: {
+            name: "CONFIG",
+            template: "filepaths",
+            suggestCurrentToken: true,
+          },
+        },
+        {
+          name: "--cache-path",
+          description: "Set a cache path",
+          args: {
+            name: "CACHE_PATH",
+            template: "filepaths",
+            suggestCurrentToken: true,
+          },
+        },
+        colorOptions,
+        {
+          name: "--default-schema-catalogs",
+          description: "Use the default online catalogs for schemas",
+        },
+        {
+          name: ["--help", "-h"],
+          description: "Print help information for lint",
+        },
+        {
+          name: "--log-spans",
+          description: "Enable logging spans",
+        },
+        {
+          name: "--no-schema",
+          description: "Disable all schema validation",
+        },
+        {
+          name: "--schema",
+          description: "URL to the schema to be used for validation",
+          args: {
+            name: "SCHEMA",
+            template: "history",
+          },
+        },
+        {
+          name: "--schema-catalog",
+          description: "URL to the schema catalog to be used for validation",
+          isRepeatable: true,
+          args: {
+            name: "SCHEMA_CATALOG",
+            template: "history",
+          },
+        },
+        verboseOption,
+      ],
     },
+
     {
       name: "lsp",
       description: "Language server operations",

--- a/src/taplo.ts
+++ b/src/taplo.ts
@@ -44,6 +44,9 @@ const completionSpec: Fig.Spec = {
           name: "help",
           description:
             "Print this message or the help of the given subcommand(s)",
+          args: {
+            template: "help",
+          },
         },
         {
           name: "schema",
@@ -62,6 +65,7 @@ const completionSpec: Fig.Spec = {
         template: "filepaths",
         suggestCurrentToken: true,
         isOptional: true,
+        isVariadic: true,
       },
       options: [
         {
@@ -104,6 +108,7 @@ const completionSpec: Fig.Spec = {
             name: "FILES ...",
             template: "filepaths",
             suggestCurrentToken: true,
+            isVariadic: true,
             isOptional: true,
           },
         },
@@ -187,6 +192,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "FILES ...",
         template: "filepaths",
+        isVariadic: true,
         suggestCurrentToken: true,
         isOptional: true,
       },
@@ -284,10 +290,10 @@ const completionSpec: Fig.Spec = {
     },
     verboseOption,
     {
-      name: [
-        "--colors <COLORS>",
-        "[default: auto] [possible values: auto, always, never]",
-      ],
+      name: "--colors",
+      args: {
+        suggestions: ["auto", "always", "never"],
+      },
     },
     logSpansOption,
   ],

--- a/src/taplo.ts
+++ b/src/taplo.ts
@@ -1,3 +1,18 @@
+const colorOptions: Fig.Option = {
+  name: "--colors",
+  args: {
+    name: "COLORS",
+    default: "auto",
+    suggestions: ["auto", "always", "never"],
+  },
+  description: "Set color values for the output",
+};
+
+const verboseOption: Fig.Option = {
+  name: "--verbose",
+  description: "Enable verbose logging format",
+};
+
 const completionSpec: Fig.Spec = {
   name: "taplo",
   description:
@@ -8,14 +23,6 @@ const completionSpec: Fig.Spec = {
       description: "Operations with the Taplo config file",
       options: [
         {
-          name: "--colors",
-          args: {
-            name: "COLORS",
-            default: "auto",
-            suggestions: ["auto", "always", "never"],
-          },
-        },
-        {
           name: ["--help", "-h"],
           description: "Print help information for config",
         },
@@ -23,10 +30,8 @@ const completionSpec: Fig.Spec = {
           name: "--log-spans",
           description: "Enable logging spans",
         },
-        {
-          name: "--verbose",
-          description: "Enable verbose logging format",
-        },
+        verboseOption,
+        colorOptions,
       ],
       subcommands: [
         {
@@ -48,9 +53,7 @@ const completionSpec: Fig.Spec = {
 
     {
       name: ["format", "fmt"],
-
       description: "Format TOML documents",
-
       args: {
         name: "FILES ...",
         description: "Paths or glob patterns to TOML documents",
@@ -87,14 +90,7 @@ const completionSpec: Fig.Spec = {
             isOptional: true,
           },
         },
-        {
-          name: "--colors",
-          args: {
-            name: "COLORS",
-            default: "auto",
-            suggestions: ["auto", "always", "never"],
-          },
-        },
+        colorOptions,
         {
           name: "--diff",
           description: "Print the differences in patch formatting to `stdout`",
@@ -140,17 +136,50 @@ const completionSpec: Fig.Spec = {
             suggestCurrentToken: true,
           },
         },
-        {
-          name: "--verbose",
-          description: "Enable verbose logging format",
-        },
+        verboseOption,
       ],
     },
 
     {
       name: "get",
       description: "Extract a value from the given TOML document",
+      options: [
+        {
+          name: ["--file-path", "-f"],
+          description: "Path to the TOML document",
+          args: {
+            name: "FILE_PATH",
+            template: "filepaths",
+            suggestCurrentToken: true,
+          },
+          isRequired: true,
+        },
+        colorOptions,
+        {
+          name: ["--help", "-h"],
+          description: "Print help information for get",
+        },
+        {
+          name: "--log-spans",
+          description: "Enable logging spans",
+        },
+        {
+          name: ["-o", "--output-format"],
+          description: "The format specifying how the output is printed",
+          args: {
+            name: "OUTPUT_FORMAT",
+            default: "value",
+            suggestions: ["value", "json", "toml"],
+          },
+        },
+        {
+          name: ["--strip-newline", "-s"],
+          description: "Strip the trailing newline from the output",
+        },
+        verboseOption,
+      ],
     },
+
     {
       name: "help",
       description: "Print help information for taplo",
@@ -201,10 +230,7 @@ const completionSpec: Fig.Spec = {
       name: ["--version", "-V"],
       description: "Print version information for taplo",
     },
-    {
-      name: "--verbose",
-      description: "Enable verbose logging format",
-    },
+    verboseOption,
     {
       name: [
         "--colors <COLORS>",

--- a/src/taplo.ts
+++ b/src/taplo.ts
@@ -13,6 +13,11 @@ const verboseOption: Fig.Option = {
   description: "Enable verbose logging format",
 };
 
+const logSpansOption: Fig.Option = {
+  name: "--log-spans",
+  description: "Enable logging spans",
+};
+
 const completionSpec: Fig.Spec = {
   name: "taplo",
   description:
@@ -26,10 +31,7 @@ const completionSpec: Fig.Spec = {
           name: ["--help", "-h"],
           description: "Print help information for config",
         },
-        {
-          name: "--log-spans",
-          description: "Enable logging spans",
-        },
+        logSpansOption,
         verboseOption,
         colorOptions,
       ],
@@ -109,10 +111,7 @@ const completionSpec: Fig.Spec = {
           name: ["--help", "-h"],
           description: "Print help information for format",
         },
-        {
-          name: "--log-spans",
-          description: "Enable logging spans",
-        },
+        logSpansOption,
         {
           name: "--no-auto-config",
           description: "Do not search for a configuration file",
@@ -159,10 +158,7 @@ const completionSpec: Fig.Spec = {
           name: ["--help", "-h"],
           description: "Print help information for get",
         },
-        {
-          name: "--log-spans",
-          description: "Enable logging spans",
-        },
+        logSpansOption,
         {
           name: ["-o", "--output-format"],
           description: "The format specifying how the output is printed",
@@ -222,10 +218,7 @@ const completionSpec: Fig.Spec = {
           name: ["--help", "-h"],
           description: "Print help information for lint",
         },
-        {
-          name: "--log-spans",
-          description: "Enable logging spans",
-        },
+        logSpansOption,
         {
           name: "--no-schema",
           description: "Disable all schema validation",
@@ -254,7 +247,32 @@ const completionSpec: Fig.Spec = {
     {
       name: "lsp",
       description: "Language server operations",
+      subcommands: [
+        {
+          name: "help",
+          description: "Print help information for lsp",
+        },
+        {
+          name: "stdio",
+          description:
+            "Run the language server over the standard input and output",
+        },
+        {
+          name: "tcp",
+          description: "Run the language server and listen on a TCP address",
+        },
+      ],
+      options: [
+        colorOptions,
+        {
+          name: ["--help", "-h"],
+          description: "Print help information for lsp",
+        },
+        logSpansOption,
+        verboseOption,
+      ],
     },
+
     {
       name: "check",
       description:
@@ -294,10 +312,7 @@ const completionSpec: Fig.Spec = {
         "[default: auto] [possible values: auto, always, never]",
       ],
     },
-    {
-      name: "--log-spans",
-      description: "Enable logging of spans",
-    },
+    logSpansOption,
   ],
   // Only uncomment if taplo takes an argument
   // args: {}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes https://github.com/withfig/autocomplete/issues/1532 

**What is the current behavior? (You can also link to an open issue here)**
The completion spec does not exist for taplo 

**What is the new behavior (if this is a feature change)?**
autocomplete will be supported for taplo 

**Additional info:**
I used `taplo --help` as reference to work with all the subcommands and options. Also used the 
`taplo <subcommand> --help` which produces different manual for each corresponding subcommands and option(s) in taplo.

Autocompletion for `taplo` in action;
<img width="458" alt="CleanShot 2022-11-20 at 03 47 35@2x" src="https://user-images.githubusercontent.com/71259399/202893414-799bac54-3bab-49ba-a947-74c0c573c3aa.png">
