### PR TITLE
feat: add hyperfine completion spec

### DIFF
--- a/src/hyperfine.ts
+++ b/src/hyperfine.ts
@@ -1,0 +1,70 @@
+const completionSpec: Fig.Spec = {
+  name: "hyperfine",
+  description: "A command-line benchmarking tool",
+
+  options: [
+    {
+      name: ["--warmup", "-w"],
+      description:
+        "Perform warmupruns (number) before the actual benchmarking starts",
+      args: {
+        name: "NUM",
+      },
+    },
+    {
+      name: ["--min-runs", "-m"],
+      description: "Perform at least NUM runs for each command",
+      args: {
+        name: "NUM",
+        default: "10",
+      },
+    },
+    {
+      name: ["--max-runs", "-M"],
+      description:
+        "Perform at most NUM runs for each command. Default: no limit",
+      args: {
+        name: "NUM",
+      },
+    },
+    {
+      name: ["--runs", "-r"],
+      description: "Perform exactly NUM runs for each command",
+      args: {
+        name: "NUM",
+      },
+    },
+    {
+      name: ["--setup", "-s"],
+      description: "Execute cmd once before each set of timing runs",
+      args: {
+        name: "CMD",
+      },
+      isRepeatable: false,
+    },
+    {
+      name: ["--prepare", "-p"],
+      description:
+        "Execute cmd before each timing run. This is useful for clearing disk caches, for example",
+      args: {
+        name: "CMD ...",
+        isVariadic: true,
+      },
+    },
+    {
+      name: ["--cleanup", "-c"],
+      description:
+        "Execute cmd after the completion of all benchmarking runs for each individual command to be benchmarked",
+      args: {
+        name: "CMD",
+      },
+    },
+  ],
+  // Only uncomment if hyperfine takes an argument
+  args: {
+    name: "CMD",
+    description: "Command to benchmark",
+    isCommand: true,
+  },
+};
+export default completionSpec;

--- a/src/hyperfine.ts
+++ b/src/hyperfine.ts
@@ -59,6 +59,60 @@ const completionSpec: Fig.Spec = {
         name: "CMD",
       },
     },
+    {
+      name: ["--parameter-scan", "-P"],
+      description:
+        "Perform benchmark runs for each value in the range min..max",
+      args: [
+        {
+          name: "VAR",
+        },
+        {
+          name: "MIN",
+        },
+        {
+          name: "MAX",
+        },
+
+        {
+          name: "CMD",
+          description: "Command to benchmark",
+          isOptional: true,
+        },
+      ],
+    },
+    {
+      name: ["--parameter-step-size", "-D"],
+      description:
+        "This argument requires --parameter-scan to be specified as well. Traverse the range min..max in steps of delta",
+      args: [
+        {
+          name: "delta",
+        },
+        {
+          name: "CMD",
+          description: "Command to benchmark",
+        },
+      ],
+      dependsOn: ["--parameter-scan", "-P"],
+    },
+    {
+      name: ["--parameter-list", "-L"],
+      description:
+        "Perform benchmark runs for each value in the comma-separated list of values",
+      args: [
+        {
+          name: "VAR",
+        },
+        {
+          name: "VALS",
+        },
+        {
+          name: "CMD",
+          description: "Command to benchmark",
+        },
+      ],
+    },
   ],
   // Only uncomment if hyperfine takes an argument
   args: {

--- a/src/hyperfine.ts
+++ b/src/hyperfine.ts
@@ -74,27 +74,15 @@ const completionSpec: Fig.Spec = {
         {
           name: "MAX",
         },
-
-        {
-          name: "CMD",
-          description: "Command to benchmark",
-          isOptional: true,
-        },
       ],
     },
     {
       name: ["--parameter-step-size", "-D"],
       description:
         "This argument requires --parameter-scan to be specified as well. Traverse the range min..max in steps of delta",
-      args: [
-        {
-          name: "delta",
-        },
-        {
-          name: "CMD",
-          description: "Command to benchmark",
-        },
-      ],
+      args: {
+        name: "delta",
+      },
       dependsOn: ["--parameter-scan", "-P"],
     },
     {
@@ -243,16 +231,10 @@ const completionSpec: Fig.Spec = {
       name: "--export-markdown",
       description:
         "Export the timing summary statistics as a Markdown table to the given file",
-      args: [
-        {
-          name: "FILE",
-          template: "filepaths",
-        },
-        {
-          name: "CMD ...",
-          isVariadic: true,
-        },
-      ],
+      args: {
+        name: "FILE",
+        template: "filepaths",
+      },
     },
     {
       name: "--show-output",

--- a/src/hyperfine.ts
+++ b/src/hyperfine.ts
@@ -39,6 +39,7 @@ const completionSpec: Fig.Spec = {
       description: "Execute cmd once before each set of timing runs",
       args: {
         name: "CMD",
+        isCommand: true,
       },
       isRepeatable: false,
     },

--- a/src/hyperfine.ts
+++ b/src/hyperfine.ts
@@ -113,6 +113,69 @@ const completionSpec: Fig.Spec = {
         },
       ],
     },
+    {
+      name: "--style",
+      description: "Set output style type",
+      args: {
+        name: "STYLE",
+        suggestions: [
+          {
+            name: "basic",
+            description: "Disable output coloring and interactive elements",
+          },
+          {
+            name: "full",
+            description:
+              "Enable all effects even if no interactive terminal was detected",
+          },
+          {
+            name: "nocolor",
+            description: "Keep the interactive output without any colors",
+          },
+          {
+            name: "color",
+            description: "Keep the colors without any interactive output",
+          },
+          {
+            name: "none",
+            description: "Disable all the output of the tool",
+          },
+        ],
+      },
+    },
+    {
+      name: ["--shell", "-S"],
+      description: "Set the shell to use for executing benchmarked commands",
+      args: {
+        name: "SHELL",
+        suggestions: [
+          {
+            name: "bash",
+            description: "Use bash as the shell",
+          },
+          {
+            name: "zsh",
+            description: "Use zsh as the shell",
+          },
+          {
+            name: "sh",
+            description: "Use sh as the shell",
+          },
+          {
+            name: "fish",
+            description: "Use fish as the shell",
+          },
+          {
+            name: "pwsh",
+            description: "Use pwsh as the shell",
+          },
+          {
+            name: "powershell",
+            description: "Use powershell as the shell",
+          },
+        ],
+      },
+    },
   ],
   // Only uncomment if hyperfine takes an argument
   args: {

--- a/src/hyperfine.ts
+++ b/src/hyperfine.ts
@@ -49,7 +49,7 @@ const completionSpec: Fig.Spec = {
         "Execute cmd before each timing run. This is useful for clearing disk caches, for example",
       args: {
         name: "CMD ...",
-        isVariadic: true,
+        isCommand: true,
       },
     },
     {
@@ -58,6 +58,7 @@ const completionSpec: Fig.Spec = {
         "Execute cmd after the completion of all benchmarking runs for each individual command to be benchmarked",
       args: {
         name: "CMD",
+        isCommand: true,
       },
     },
     {
@@ -95,10 +96,6 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "VALS",
-        },
-        {
-          name: "CMD",
-          description: "Command to benchmark",
         },
       ],
     },
@@ -168,10 +165,6 @@ const completionSpec: Fig.Spec = {
     {
       name: ["--ignore-failure", "-i"],
       description: "Ignore non-zero exit codes of the benchmarked commands",
-      args: {
-        name: "CMD ...",
-        isVariadic: true,
-      },
     },
     {
       name: ["--time-unit", "-u"],
@@ -186,46 +179,28 @@ const completionSpec: Fig.Spec = {
       name: "--export-asciidoc",
       description:
         "Export the timing summary statistics as an AsciiDoc table to the given file",
-      args: [
-        {
-          name: "FILE",
-          template: "filepaths",
-        },
-        {
-          name: "CMD ...",
-          isVariadic: true,
-        },
-      ],
+      args: {
+        name: "FILE",
+        template: "filepaths",
+      },
     },
     {
       name: "--export-csv",
       description:
         "Export the timing summary statistics as CSV to the given file",
-      args: [
-        {
-          name: "FILE",
-          template: "filepaths",
-        },
-        {
-          name: "CMD ...",
-          isVariadic: true,
-        },
-      ],
+      args: {
+        name: "FILE",
+        template: "filepaths",
+      },
     },
     {
       name: "--export-json",
       description:
         "Export the timing summary statistics and timings of individual runs as JSON to the given file",
-      args: [
-        {
-          name: "FILE",
-          template: "filepaths",
-        },
-        {
-          name: "CMD ...",
-          isVariadic: true,
-        },
-      ],
+      args: {
+        name: "FILE",
+        template: "filepaths",
+      },
     },
     {
       name: "--export-markdown",
@@ -240,23 +215,13 @@ const completionSpec: Fig.Spec = {
       name: "--show-output",
       description:
         "Print the stdout and stderr of the benchmark instead of suppressing it",
-      args: {
-        name: "CMD ...",
-        isVariadic: true,
-      },
     },
     {
       name: "--command-name",
       description: "Identify a command with the given name",
-      args: [
-        {
-          name: "NAME",
-        },
-        {
-          name: "CMD ...",
-          isVariadic: true,
-        },
-      ],
+      args: {
+        name: "NAME",
+      },
     },
     {
       name: "--help",

--- a/src/hyperfine.ts
+++ b/src/hyperfine.ts
@@ -284,7 +284,6 @@ const completionSpec: Fig.Spec = {
       description: "Shows version information",
     },
   ],
-  // Only uncomment if hyperfine takes an argument
   args: {
     name: "CMD",
     description: "Command to benchmark",

--- a/src/hyperfine.ts
+++ b/src/hyperfine.ts
@@ -176,6 +176,113 @@ const completionSpec: Fig.Spec = {
         ],
       },
     },
+    {
+      name: ["--ignore-failure", "-i"],
+      description: "Ignore non-zero exit codes of the benchmarked commands",
+      args: {
+        name: "CMD ...",
+        isVariadic: true,
+      },
+    },
+    {
+      name: ["--time-unit", "-u"],
+      description: "Set the time unit to use for the benchmark results",
+      args: {
+        name: "UNIT",
+        suggestions: ["millisecond", "second"],
+        default: "second",
+      },
+    },
+    {
+      name: "--export-asciidoc",
+      description:
+        "Export the timing summary statistics as an AsciiDoc table to the given file",
+      args: [
+        {
+          name: "FILE",
+          template: "filepaths",
+        },
+        {
+          name: "CMD ...",
+          isVariadic: true,
+        },
+      ],
+    },
+    {
+      name: "--export-csv",
+      description:
+        "Export the timing summary statistics as CSV to the given file",
+      args: [
+        {
+          name: "FILE",
+          template: "filepaths",
+        },
+        {
+          name: "CMD ...",
+          isVariadic: true,
+        },
+      ],
+    },
+    {
+      name: "--export-json",
+      description:
+        "Export the timing summary statistics and timings of individual runs as JSON to the given file",
+      args: [
+        {
+          name: "FILE",
+          template: "filepaths",
+        },
+        {
+          name: "CMD ...",
+          isVariadic: true,
+        },
+      ],
+    },
+    {
+      name: "--export-markdown",
+      description:
+        "Export the timing summary statistics as a Markdown table to the given file",
+      args: [
+        {
+          name: "FILE",
+          template: "filepaths",
+        },
+        {
+          name: "CMD ...",
+          isVariadic: true,
+        },
+      ],
+    },
+    {
+      name: "--show-output",
+      description:
+        "Print the stdout and stderr of the benchmark instead of suppressing it",
+      args: {
+        name: "CMD ...",
+        isVariadic: true,
+      },
+    },
+    {
+      name: "--command-name",
+      description: "Identify a command with the given name",
+      args: [
+        {
+          name: "NAME",
+        },
+        {
+          name: "CMD ...",
+          isVariadic: true,
+        },
+      ],
+    },
+    {
+      name: "--help",
+      description: "Prints help message",
+    },
+    {
+      name: "--version",
+      description: "Shows version information",
+    },
   ],
   // Only uncomment if hyperfine takes an argument
   args: {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fixes https://github.com/withfig/autocomplete/issues/1549 to add new autocompletion spec for `hyperfine`

**What is the current behavior? (You can also link to an open issue here)**
Currently, fig does not have support to autocomplete hyperfine

**What is the new behavior (if this is a feature change)?**
Autocomplete for `hyperfine`

**Additional info:**
First contribution to Fig :)

I have read the CLA Document and I hereby sign the CLA