### PR TITLE
fix(nextflow): `stub-run` option typo

### DIFF
--- a/src/nextflow.ts
+++ b/src/nextflow.ts
@@ -445,7 +445,7 @@ const completionSpec: Fig.Spec = {
           },
         },
         {
-          name: ["-stub-ru", "-stub"],
+          name: ["-stub-run", "-stub"],
           description:
             "Execute the workflow replacing process scripts with command stubs (Default: false)",
         },


### PR DESCRIPTION
- feat(nextflow): Fix stub-run option typo

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
It fixes a typo in the -stub-run option for the run command.

**What is the current behavior? (You can also link to an open issue here)**
The autocomplete is incorrect due to a typo.

**What is the new behavior (if this is a feature change)?**
The autocomplete works as expected.
