### PR TITLE
feat(defaultbrowser): add generator

### DIFF
--- a/src/defaultbrowser.ts
+++ b/src/defaultbrowser.ts
@@ -1,0 +1,22 @@
+const getBrowsers: Fig.Generator = {
+  script: "defaultbrowser",
+  splitOn: "\n",
+  postProcess: function (out) {
+    const installedBrowsers: Fig.Suggestion[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      var browser_name = lines[i].split(" ")[0];
+      installedBrowsers.push({
+        name: browser_name,
+      });
+    }
+    return installedBrowsers;
+  },
+};
+
+const completionSpec: Fig.Spec = {
+  name: "defaultbrowser",
+  description: "Change your default browser",
+  args: { isOptional: true, generators: getBrowsers },
+};
+
+export default completionSpec;

--- a/src/defaultbrowser.ts
+++ b/src/defaultbrowser.ts
@@ -1,22 +1,23 @@
-const getBrowsers: Fig.Generator = {
+const getInstalledBrowsers: Fig.Generator = {
   script: "defaultbrowser",
-  splitOn: "\n",
   postProcess: function (out) {
-    const installedBrowsers: Fig.Suggestion[] = [];
-    for (let i = 0; i < lines.length; i++) {
-      var browser_name = lines[i].split(" ")[0];
-      installedBrowsers.push({
-        name: browser_name,
-      });
-    }
-    return installedBrowsers;
+    return out.split("\n").map((line) => {
+      /* We ignore the already set browser */
+      if (line.startsWith("*")) {
+        return {};
+      }
+      const browserName = line.trim();
+      return {
+        name: browserName,
+      };
+    });
   },
 };
 
 const completionSpec: Fig.Spec = {
   name: "defaultbrowser",
-  description: "Change your default browser",
-  args: { isOptional: true, generators: getBrowsers },
+  description: "Change your default browser from the CLI",
+  args: { isOptional: true, generators: getInstalledBrowsers },
 };
 
 export default completionSpec;


### PR DESCRIPTION
This is a very basic completion addition for the `defaultbrowser` utility for changing browsers using the command line.

`defaultbrowser` is for macOS, is open source and is available on [GitHub](https://github.com/kerma/defaultbrowser) and is [installable using Homebrew](https://formulae.brew.sh/formula/defaultbrowser#default).

I did [a completion for Bash](https://github.com/jonasbn/bash_completion_defaultbrowser), but now I have changed to Zsh and started using Fig.

This is my first completion for Fig, so any feedback on things I should do differently is most welcome.

