### PR TITLE
feat(remotion): add new flags

### DIFF
--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -493,6 +493,13 @@ const completionSpec: Fig.Spec = {
         {
           name: "regions",
           description: "Prints list of supported regions",
+          options: [
+            {
+              name: "--default-only",
+              description:
+                "Only print the regions enabled by default in a new AWS account",
+            },
+          ],
         },
         {
           name: "render",

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -18,14 +18,58 @@ const alwaysOptions: Fig.Option[] = [
   },
 ];
 
-const localRenderAndStillOptions: Fig.Option[] = [
+const propsOption: Fig.Option = {
+  name: "--props",
+  description: "Pass input props as filename or as JSON",
+  args: {
+    template: ["filepaths"],
+    suggestions: [
+      {
+        type: "arg",
+        displayName: "[json string]",
+        insertValue: "'{cursor}'",
+      },
+    ],
+  },
+};
+
+const envOption: Fig.Option = {
+  name: "--env-file",
+  description: "Specify a location for a dotenv file",
+  args: {
+    template: "filepaths",
+  },
+};
+
+const chromeOptions: Fig.Option[] = [
   {
-    name: "--env-file",
-    description: "Specify a location for a dotenv file",
+    name: "--disable-headless",
+    description: "Run Chrome in normal mode rather than headless",
+  },
+  {
+    name: "--gl",
+    description: "Which OpenGL renderer to use",
     args: {
-      template: "filepaths",
+      suggestions: ["angle", "egl", "swiftshader", "swangle"],
     },
   },
+  {
+    name: "--ignore-certificate-errors",
+    description: "Ignore SSL errors",
+  },
+  {
+    name: "--disable-web-security",
+    description: "Disable CORS and other web security features",
+  },
+];
+const compositionsOptions: Fig.Option[] = [
+  propsOption,
+  envOption,
+  ...chromeOptions,
+];
+
+const localRenderAndStillOptions: Fig.Option[] = [
+  envOption,
   {
     name: "--overwrite",
     description: "Overwrite if file exists, default true",
@@ -64,10 +108,6 @@ const localRenderAndStillOptions: Fig.Option[] = [
     },
   },
   {
-    name: "--disable-headless",
-    description: "Run Chrome in normal mode rather than headless",
-  },
-  {
     name: "--config",
     description: "Custom location for a Remotion config file",
     args: {
@@ -81,6 +121,8 @@ const localRenderAndStillOptions: Fig.Option[] = [
       template: "folders",
     },
   },
+  propsOption,
+  ...chromeOptions,
 ];
 
 const lambdaRenderAndStillOptions: Fig.Option[] = [
@@ -107,6 +149,7 @@ const lambdaRenderAndStillOptions: Fig.Option[] = [
       name: "framesPerLambda",
     },
   },
+  ...chromeOptions,
 ];
 
 const lambdaRenderOptions: Fig.Option[] = [
@@ -161,39 +204,11 @@ const stillOptions: Fig.Option[] = [
 ];
 
 const renderOptions: Fig.Option[] = [
-  {
-    name: "--gl",
-    description: "Which OpenGL renderer to use",
-    args: {
-      suggestions: ["angle", "egl", "swiftshader", "swangle"],
-    },
-  },
+  ...chromeOptions,
   {
     name: "--timeout",
     description:
       "The time in milisecond that a delayRender() may take before it times out",
-  },
-  {
-    name: "--ignore-certificate-errors",
-    description: "Ignore SSL errors",
-  },
-  {
-    name: "--disable-web-security",
-    description: "Disable CORS and other web security features",
-  },
-  {
-    name: "--props",
-    description: "Pass input props as filename or as JSON",
-    args: {
-      template: ["filepaths"],
-      suggestions: [
-        {
-          type: "arg",
-          displayName: "[json string]",
-          insertValue: "'{cursor}'",
-        },
-      ],
-    },
   },
   {
     name: "--quality",
@@ -434,6 +449,7 @@ const completionSpec: Fig.Spec = {
         description: "The entry point of your Remotion app",
         template: ["filepaths"],
       },
+      options: compositionsOptions,
     },
     {
       name: "lambda",
@@ -518,6 +534,21 @@ const completionSpec: Fig.Spec = {
             ...globalLambdaOptions,
             ...alwaysOptions,
           ],
+        },
+        {
+          name: "compositions",
+          description: "Get the list of available compositions on Lambda",
+          args: {
+            name: "serve-url",
+            description: "URL or name of the site",
+            suggestions: [
+              {
+                type: "arg",
+                displayName: "[serve-url]",
+              },
+            ],
+          },
+          options: [...globalLambdaOptions, ...compositionsOptions],
         },
         {
           name: "still",
@@ -780,30 +811,18 @@ const completionSpec: Fig.Spec = {
         template: ["filepaths"],
       },
       options: [
-        {
-          name: "--props",
-          description: "Pass input props as filename or as JSON",
-          args: {
-            template: ["filepaths"],
-            suggestions: [
-              {
-                type: "arg",
-                displayName: "[json string]",
-                insertValue: "'{cursor}'",
-              },
-            ],
-          },
-        },
+        propsOption,
         {
           name: "--disable-keyboard-shortcuts",
           description: "Disable all keyboard shortcuts",
         },
         {
           name: "--number-of-shared-audio-tags",
-          description: "Set the number of shared audio tags to prevent autoplay issues",
-            args: {
-              name: "numberOfSharedAudioTags",
-            },        
+          description:
+            "Set the number of shared audio tags to prevent autoplay issues",
+          args: {
+            name: "numberOfSharedAudioTags",
+          },
         },
       ],
     },

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -82,6 +82,10 @@ const localRenderAndStillOptions: Fig.Option[] = [
     },
   },
   {
+    name: "--enable-extensions",
+    description: "Enable Chrome browser extensions while rendering",
+  },
+  {
     name: "--ffmpeg-executable",
     description: "Custom path for FFMPEG executable",
     args: {

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -798,6 +798,13 @@ const completionSpec: Fig.Spec = {
           name: "--disable-keyboard-shortcuts",
           description: "Disable all keyboard shortcuts",
         },
+        {
+          name: "--number-of-shared-audio-tags",
+          description: "Set the number of shared audio tags to prevent autoplay issues",
+            args: {
+              name: "numberOfSharedAudioTags",
+            },        
+        },
       ],
     },
     {

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -820,6 +820,14 @@ const completionSpec: Fig.Spec = {
       description: "Try different render configurations and compare them",
       options: benchmarkOptions,
     },
+    {
+      name: "install",
+      description: "Ensure Remotion dependencies",
+      args: {
+        name: "dependency",
+        suggestions: [{ name: "ffmpeg" }, { name: "ffprobe" }],
+      },
+    },
   ],
   options: [
     {

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -148,6 +148,16 @@ const stillOptions: Fig.Option[] = [
     description: "Which frame to render (default 0)",
     args: { name: "frame", default: "0" },
   },
+  {
+    name: "--height",
+    description: "Override the composition height",
+    args: { name: "height" },
+  },
+  {
+    name: "--width",
+    description: "Override the composition width",
+    args: { name: "height" },
+  },
 ];
 
 const renderOptions: Fig.Option[] = [
@@ -301,6 +311,16 @@ const renderOptions: Fig.Option[] = [
   {
     name: "--muted",
     description: "Outputs no audio",
+  },
+  {
+    name: "--height",
+    description: "Override the composition height",
+    args: { name: "height" },
+  },
+  {
+    name: "--width",
+    description: "Override the composition width",
+    args: { name: "height" },
   },
 ];
 

--- a/src/remotion.ts
+++ b/src/remotion.ts
@@ -817,6 +817,14 @@ const completionSpec: Fig.Spec = {
           description: "Disable all keyboard shortcuts",
         },
         {
+          name: "--webpack-poll",
+          description: "Enable webpack polling instead of file system watchers",
+          args: {
+            name: "polling-interval",
+            description: "Polling interval in milliseconds",
+          },
+        },
+        {
           name: "--number-of-shared-audio-tags",
           description:
             "Set the number of shared audio tags to prevent autoplay issues",


### PR DESCRIPTION
We periodically send a PR with all the new options added to Remotion. Incomplete list of new options:

- `--height` and `--width` flags
- `npx remotion install` commands
- `--number-of-shared-audio-tags` flag
- `npx remotion lambda compositions` command
- `--webpack-poll` flag
- `--enable-extensions`