### PR TITLE
pnpm run -C

### DIFF
--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -429,6 +429,14 @@ const SUBCOMMANDS_RUN_SCRIPTS: Fig.Subcommand[] = [
         description:
           "Stream output from child processes immediately, prefixed with the originating package directory. This allows output from different packages to be interleaved",
       },
+      {
+        name: ["-C", "--dir"],
+        description: "Run a script in another directory",
+        args: {
+          name: "directory",
+          template: "folders",
+        },
+      },
       FILTER_OPTION,
     ],
   },


### PR DESCRIPTION
adds `-C` or `--dir` option to `pnpm run`
in theory this should update the autocomplete for the scripts to show from that directory instead, but that was too complicated, especially because it was just being imported from the `npm` script

closes #1734 