### PR TITLE
fix(yarn): Suggest subcommands with bin only 

### DIFF
--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -28,21 +28,14 @@ export const nodeClis = new Set([
   "typeorm",
   "babel",
   "remotion",
-  "@withfig/autocomplete-tools",
-  "@redwoodjs/core",
+  "autocomplete-tools",
+  "redwood",
+  "rw",
   "create-completion-spec",
-  "@fig/publish-spec-to-team",
+  "publish-spec-to-team",
   "capacitor",
   "cap",
 ]);
-
-type SearchResult = {
-  package: {
-    name: string;
-    description: string;
-  };
-  searchScore: number;
-};
 
 // generate global package list from global package.json file
 const getGlobalPackagesGenerator: Fig.Generator = {
@@ -359,14 +352,6 @@ const completionSpec: Fig.Spec = {
   name: "yarn",
   description: "Manage packages and run scripts",
   generateSpec: async (tokens, executeShellCommand) => {
-    const { script, postProcess } = dependenciesGenerator;
-
-    const packages = new Set(
-      postProcess(await executeShellCommand(script as string), tokens).map(
-        ({ name }) => name as string
-      )
-    );
-
     const binaries = (
       await executeShellCommand(
         `until [[ -d node_modules/ ]] || [[ $PWD = '/' ]]; do cd ..; done; ls -1 node_modules/.bin/`
@@ -374,12 +359,10 @@ const completionSpec: Fig.Spec = {
     ).split("\n");
 
     const subcommands = binaries
-      .filter((name) => packages.has(name))
+      .filter((name) => nodeClis.has(name))
       .map((name) => ({
-        name: name === "@redwoodjs/core" ? ["redwood", "rw"] : name,
-        ...(nodeClis.has(name) && {
-          loadSpec: name === "@redwoodjs/core" ? "redwood" : name,
-        }),
+        name: name,
+        loadSpec: name === "rw" ? "redwood" : name,
         icon: "fig://icon?type=package",
       }));
 


### PR DESCRIPTION
A member of RedwoodJS community notice that Fig don't autocomplete redwood CLI anymore. 
After looking into recent changes, I see that suggestions are now base by the binaries. #1211 #1215 
Is also take packages from package.json into consideration for suggestion, problem is package name is not always the same as binary name. 

My suggestion is to only go with the binaries, since is more accurate of what is available. 
Whatever, I think we should only suggest subcommand from the list, otherwise this creates a lot a noise by irrelevant suggestion.

cc @fedeci 