### PR TITLE
fix(expo): --dev-client prompting for true or false

### DIFF
--- a/src/expo-cli.ts
+++ b/src/expo-cli.ts
@@ -3221,19 +3221,6 @@ const completionSpec: Fig.Spec = {
           name: "--dev-client",
           description:
             "Experimental: Starts the bundler for use with the expo-development-client",
-          args: {
-            name: "boolean",
-            suggestions: [
-              {
-                name: "true",
-                icon: "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/true.png",
-              },
-              {
-                name: "false",
-                icon: "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/false.png",
-              },
-            ],
-          },
           icon: "https://raw.githubusercontent.com/expo/expo-cli/master/assets/fig/dev.png",
         },
         {


### PR DESCRIPTION
Expo cli `--dev-client` has no args. There is no true/false value for --dev-client, it's a toggle to tell Expo CLI to start the application via the Development Client without building the app like `expo run:android` or `expo run:ios` would.