### PR TITLE
feat(kitty): add ssh spec to ssh kitten

### DIFF
--- a/src/kitty.ts
+++ b/src/kitty.ts
@@ -120,7 +120,10 @@ const kittenCommands: Fig.Subcommand[] = [
     name: "hyperlinked_grep",
     loadSpec: "rg",
   },
-  { name: "ssh" },
+  {
+    name: "ssh",
+    loadSpec: "ssh",
+  },
   { name: "choose" },
   { name: "ask" },
   {


### PR DESCRIPTION
This makes the ssh kitten from kitty term support autocompletion. It's a thin wrapper around the ssh command, so it can reuse the ssh spec.