### PR TITLE
feat(kitty): link ssh kitten spec

### DIFF
--- a/src/kitty.ts
+++ b/src/kitty.ts
@@ -120,7 +120,10 @@ const kittenCommands: Fig.Subcommand[] = [
     name: "hyperlinked_grep",
     loadSpec: "rg",
   },
-  { name: "ssh" },
+  {
+    name: "ssh",
+    loadSpec: "ssh",
+  },
   { name: "choose" },
   { name: "ask" },
   {


### PR DESCRIPTION
This links the ssh spec to ssh kitten completion. The ssh kitten is a thin wrapper around the ssh command (using the same flags/arguments), so it should use the same completion.