### PR TITLE
feat: add `aliases` completion spec

### DIFF
--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -1,0 +1,205 @@
+const helpAndVersionOptions: Fig.Option[] = [
+  {
+    name: ["--help", "-h"],
+    description: "Prints help information",
+  },
+  {
+    name: ["--version", "-V"],
+    description: "Prints version information",
+  },
+];
+
+const completionSpec: Fig.Spec = {
+  name: "aliases",
+  description: "Bash aliases on steroids, dynamic alias functions for bash",
+  subcommands: [
+    {
+      name: "add",
+      description: "Add an alias via the cli",
+      options: [...helpAndVersionOptions],
+      args: [
+        {
+          name: "name",
+          description: "The name of the alias",
+        },
+        {
+          name: "command",
+          description: "The command you want to run",
+        },
+      ],
+    },
+    {
+      name: "clone",
+      description: "Clone external aliases",
+      options: [
+        ...helpAndVersionOptions,
+        {
+          name: ["-E", "--enable"],
+          description:
+            "Whether to enable the user if they are not currently enabled",
+        },
+      ],
+      args: [
+        {
+          name: "username",
+          description: "The username of the aliases you want to clone",
+        },
+        {
+          name: "repo_url",
+          description:
+            "The git repo url of the aliases (defaults to github/<username>/dot-aliases)",
+        },
+      ],
+    },
+    {
+      name: "directories",
+      description: "List all directories initialized with aliases",
+      options: [...helpAndVersionOptions],
+    },
+    {
+      name: "exec",
+      description: "Execute an alias for a given directory",
+      options: [...helpAndVersionOptions],
+      args: [
+        {
+          name: "directory",
+          description: "Directory where the alias is defined",
+          template: "folders",
+        },
+        {
+          name: "name",
+          isVariadic: true,
+          description: "Name of alias",
+        },
+      ],
+    },
+    {
+      name: "help",
+      description: "Prints help information",
+    },
+    {
+      name: "init",
+      description: "Initialize a directory for aliases",
+      options: [
+        ...helpAndVersionOptions,
+        {
+          name: ["-g", "--global"],
+          description: "Returns the global initialization for the app",
+        },
+        {
+          name: ["-u", "--user"],
+          description: "Initialize aliases for a specific user",
+          args: {
+            name: "user",
+          },
+        },
+      ],
+    },
+    {
+      name: "list",
+      description: "List the aliases available",
+      options: [
+        ...helpAndVersionOptions,
+        {
+          name: ["-g", "--global"],
+          description: "List only global aliases",
+        },
+        {
+          name: ["-l", "--local"],
+          description: "List only local aliases",
+        },
+        {
+          name: ["-d", "--directory"],
+          description: "List aliases for a specific directory",
+          args: {
+            name: "directory",
+            template: "folders",
+          },
+        },
+        {
+          name: "name",
+          description: "List aliases for with a specific name",
+          args: {
+            name: "name",
+          },
+        },
+      ],
+    },
+    {
+      name: "pull",
+      description: "Pull a cloned user's aliases",
+      options: [...helpAndVersionOptions],
+      args: {
+        name: "username",
+        description:
+          "The username of the aliases you want to pull, leave blank to pull all user aliases",
+      },
+    },
+    {
+      name: "rehash",
+      description: "Update the aliases",
+      options: [...helpAndVersionOptions],
+    },
+    {
+      name: "remove",
+      description: "Remove an alias via the cli",
+      options: [...helpAndVersionOptions],
+      args: {
+        name: "name",
+        description: "The name of the alias",
+      },
+    },
+    {
+      name: "users",
+      description: "List the users",
+      options: [...helpAndVersionOptions],
+      subcommands: [
+        {
+          name: "disable",
+          description: "Disable a user's aliases",
+          options: [...helpAndVersionOptions],
+          args: {
+            name: "username",
+          },
+        },
+        {
+          name: "enable",
+          description: "Enable a user's aliases",
+          options: [...helpAndVersionOptions],
+          args: {
+            name: "username",
+          },
+        },
+        {
+          name: "help",
+          description:
+            "Prints this message or the help of the given subcommand(s)",
+          options: [...helpAndVersionOptions],
+        },
+        {
+          name: "move",
+          description: "Move a user up or down the prioritization list",
+          options: [...helpAndVersionOptions],
+          args: [
+            {
+              name: "username",
+            },
+            {
+              name: "prioritization",
+            },
+          ],
+        },
+        {
+          name: "use",
+          description: "Assign a user to the top of the priority list",
+          options: [...helpAndVersionOptions],
+          args: {
+            name: "username",
+          },
+        },
+      ],
+    },
+  ],
+  options: [...helpAndVersionOptions],
+};
+export default completionSpec;

--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -2,6 +2,7 @@ const helpAndVersionOptions: Fig.Option[] = [
   {
     name: ["--help", "-h"],
     description: "Prints help information",
+    isPersistent: true,
   },
   {
     name: ["--version", "-V"],

--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -187,6 +187,6 @@ const completionSpec: Fig.Spec = {
       ],
     },
   ],
-  options: [...helpAndVersionOptions],
+  options: helpAndVersionOptions,
 };
 export default completionSpec;

--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -7,6 +7,7 @@ const helpAndVersionOptions: Fig.Option[] = [
   {
     name: ["--version", "-V"],
     description: "Prints version information",
+    isPersistent: true,
   },
 ];
 
@@ -17,7 +18,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "add",
       description: "Add an alias via the cli",
-      options: [...helpAndVersionOptions],
       args: [
         {
           name: "name",
@@ -33,7 +33,6 @@ const completionSpec: Fig.Spec = {
       name: "clone",
       description: "Clone external aliases",
       options: [
-        ...helpAndVersionOptions,
         {
           name: ["-E", "--enable"],
           description:
@@ -55,12 +54,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "directories",
       description: "List all directories initialized with aliases",
-      options: [...helpAndVersionOptions],
     },
     {
       name: "exec",
       description: "Execute an alias for a given directory",
-      options: [...helpAndVersionOptions],
       args: [
         {
           name: "directory",
@@ -82,7 +79,6 @@ const completionSpec: Fig.Spec = {
       name: "init",
       description: "Initialize a directory for aliases",
       options: [
-        ...helpAndVersionOptions,
         {
           name: ["-g", "--global"],
           description: "Returns the global initialization for the app",
@@ -100,7 +96,6 @@ const completionSpec: Fig.Spec = {
       name: "list",
       description: "List the aliases available",
       options: [
-        ...helpAndVersionOptions,
         {
           name: ["-g", "--global"],
           description: "List only global aliases",
@@ -129,7 +124,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "pull",
       description: "Pull a cloned user's aliases",
-      options: [...helpAndVersionOptions],
       args: {
         name: "username",
         description:
@@ -139,12 +133,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "rehash",
       description: "Update the aliases",
-      options: [...helpAndVersionOptions],
     },
     {
       name: "remove",
       description: "Remove an alias via the cli",
-      options: [...helpAndVersionOptions],
       args: {
         name: "name",
         description: "The name of the alias",
@@ -153,12 +145,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "users",
       description: "List the users",
-      options: [...helpAndVersionOptions],
       subcommands: [
         {
           name: "disable",
           description: "Disable a user's aliases",
-          options: [...helpAndVersionOptions],
           args: {
             name: "username",
           },
@@ -166,7 +156,6 @@ const completionSpec: Fig.Spec = {
         {
           name: "enable",
           description: "Enable a user's aliases",
-          options: [...helpAndVersionOptions],
           args: {
             name: "username",
           },
@@ -175,12 +164,10 @@ const completionSpec: Fig.Spec = {
           name: "help",
           description:
             "Prints this message or the help of the given subcommand(s)",
-          options: [...helpAndVersionOptions],
         },
         {
           name: "move",
           description: "Move a user up or down the prioritization list",
-          options: [...helpAndVersionOptions],
           args: [
             {
               name: "username",
@@ -193,7 +180,6 @@ const completionSpec: Fig.Spec = {
         {
           name: "use",
           description: "Assign a user to the top of the priority list",
-          options: [...helpAndVersionOptions],
           args: {
             name: "username",
           },


### PR DESCRIPTION
This PR is to add the `aliases` autocompletion spec.

Closes #1785

Signed-off-by: Karthikeyan Vaithilingam <seenukarthi@gmail.com>