### PR TITLE
fix: some icons in npx specs now being showed

### DIFF
--- a/src/npx.ts
+++ b/src/npx.ts
@@ -17,7 +17,7 @@ const suggestions: Fig.Suggestion[] = [
   },
   {
     name: "tailwindcss",
-    icon: "https://tailwindcss.com/favicon-32x32.png",
+    icon: "https://tailwindcss.com/favicons/favicon-32x32.png",
   },
   {
     name: "next",
@@ -25,7 +25,7 @@ const suggestions: Fig.Suggestion[] = [
   },
   {
     name: "nuxi",
-    icon: "https://raw.githubusercontent.com/nuxt/framework/main/docs/static/icon.png",
+    icon: "https://raw.githubusercontent.com/nuxt/framework/main/docs/public/icon.png",
   },
   {
     name: "gltfjsx",
@@ -37,7 +37,7 @@ const suggestions: Fig.Suggestion[] = [
   },
   {
     name: "eslint",
-    icon: "https://eslint.org/assets/img/favicon.512x512.png",
+    icon: "https://raw.githubusercontent.com/eslint/eslint.org/main/src/static/icon-512.png",
   },
   {
     name: "prettier",


### PR DESCRIPTION
This PR fixes the wrong urls to the some of the icons (tailwindcss, nuxi, eslint) like it was on the screenshot below.

![CleanShot 2023-01-09 at 11 47 22@2x](https://user-images.githubusercontent.com/38916225/211280730-dfbc703d-ab59-4717-b50c-7a97550f53d8.jpg)
