### PR TITLE
feat(brew): add alias subcommand

### DIFF
--- a/src/brew.ts
+++ b/src/brew.ts
@@ -67,26 +67,19 @@ const generateAllCasks: Fig.Generator = {
     }));
   },
 };
-
-const generatorAlias: Fig.Generator = {
-  custom: async (tokens, executeShellCommand) => {
-    const targets = await executeShellCommand(
-      "brew alias | cut -d '=' -f 1 | cut -d ' ' -f 3"
-    );
-    const targetSuggestions = new Map<string, Fig.Suggestion>();
-    for (const target of targets.split("\n")) {
-      if (target && target.trim() !== "") {
-        targetSuggestions.set(target, {
-          name: target,
-          description: "Run " + target + " command",
-          icon: "fig://icon?type=command",
-        });
-      }
-    }
-
-    return [...targetSuggestions.values()];
+const generatorAlias = (): Fig.Generator => ({
+  script: 'find ~/.brew-aliases/ -type f ! -name "*.*" -d 1 | sed "s/.*\\///"',
+  postProcess: function (out) {
+    return out
+      .split("\n")
+      .filter((line) => line && line.trim() !== "")
+      .map((line) => ({
+        name: line,
+        icon: "fig://icon?type=command",
+        description: `Execute alias ${line}`,
+      }));
   },
-};
+});
 
 const commonOptions: Fig.Option[] = [
   {
@@ -1605,7 +1598,9 @@ const completionSpec: Fig.Spec = {
   ],
   args: {
     name: "alias",
-    generators: generatorAlias,
+    generators: generatorAlias(),
+    description: "Custom user defined brew alias",
+    isOptional: true,
   },
 };
 

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -1589,6 +1589,38 @@ const completionSpec: Fig.Spec = {
         },
       ],
     },
+    {
+      name: "alias",
+      description: "Manage custom user created brew aliases",
+      options: [
+        {
+          name: "--edit",
+          description: "Edit aliases in a text editor",
+        },
+        {
+          name: ["-d", "--debug"],
+          description: "Display any debugging information",
+        },
+        {
+          name: ["-q", "--quiet"],
+          description: "Make some output more quiet",
+        },
+        {
+          name: ["-v", "--verbose"],
+          description: "Make some output more verbose",
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Show help message",
+        },
+      ],
+      args: {
+        name: "alias",
+        generators: generatorAlias(),
+        description: "Display the alias command",
+        isOptional: true,
+      },
+    },
   ],
   options: [
     {

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -67,7 +67,7 @@ const generateAllCasks: Fig.Generator = {
     }));
   },
 };
-const generatorAlias = (): Fig.Generator => ({
+const generatorAlias: Fig.Generator = {
   script: 'find ~/.brew-aliases/ -type f ! -name "*.*" -d 1 | sed "s/.*\\///"',
   postProcess: function (out) {
     return out
@@ -79,7 +79,7 @@ const generatorAlias = (): Fig.Generator => ({
         description: `Execute alias ${line}`,
       }));
   },
-});
+};
 
 const commonOptions: Fig.Option[] = [
   {

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -67,7 +67,7 @@ const generateAllCasks: Fig.Generator = {
     }));
   },
 };
-const generatorAlias: Fig.Generator = {
+const generateAliases: Fig.Generator = {
   script: 'find ~/.brew-aliases/ -type f ! -name "*.*" -d 1 | sed "s/.*\\///"',
   postProcess: function (out) {
     return out
@@ -1616,7 +1616,7 @@ const completionSpec: Fig.Spec = {
       ],
       args: {
         name: "alias",
-        generators: generatorAlias,
+        generators: generateAliases,
         description: "Display the alias command",
         isOptional: true,
       },
@@ -1630,7 +1630,7 @@ const completionSpec: Fig.Spec = {
   ],
   args: {
     name: "alias",
-    generators: generatorAlias,
+    generators: generateAliases,
     description: "Custom user defined brew alias",
     isOptional: true,
   },

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -1616,7 +1616,7 @@ const completionSpec: Fig.Spec = {
       ],
       args: {
         name: "alias",
-        generators: generatorAlias(),
+        generators: generatorAlias,
         description: "Display the alias command",
         isOptional: true,
       },

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -1630,7 +1630,7 @@ const completionSpec: Fig.Spec = {
   ],
   args: {
     name: "alias",
-    generators: generatorAlias(),
+    generators: generatorAlias,
     description: "Custom user defined brew alias",
     isOptional: true,
   },

--- a/src/brew.ts
+++ b/src/brew.ts
@@ -68,6 +68,26 @@ const generateAllCasks: Fig.Generator = {
   },
 };
 
+const generatorAlias: Fig.Generator = {
+  custom: async (tokens, executeShellCommand) => {
+    const targets = await executeShellCommand(
+      "brew alias | cut -d '=' -f 1 | cut -d ' ' -f 3"
+    );
+    const targetSuggestions = new Map<string, Fig.Suggestion>();
+    for (const target of targets.split("\n")) {
+      if (target && target.trim() !== "") {
+        targetSuggestions.set(target, {
+          name: target,
+          description: "Run " + target + " command",
+          icon: "fig://icon?type=command",
+        });
+      }
+    }
+
+    return [...targetSuggestions.values()];
+  },
+};
+
 const commonOptions: Fig.Option[] = [
   {
     name: ["-d", "--debug"],
@@ -1583,6 +1603,10 @@ const completionSpec: Fig.Spec = {
       description: "The current Homebrew version",
     },
   ],
+  args: {
+    name: "alias",
+    generators: generatorAlias,
+  },
 };
 
 export default completionSpec;


### PR DESCRIPTION
This PR adds `alias` subcommand to brew.

Closes #1790 