### PR TITLE
chore: update `elm-review` completion spec

### DIFF
--- a/src/elm-review.ts
+++ b/src/elm-review.ts
@@ -18,7 +18,7 @@ const reportType: Fig.Generator = {
 };
 
 /**
- * Based on the [elm-review](https://github.com/jfmengels/node-elm-review), version 2.7.0, cli tool for reviewing Elm code.
+ * Based on [elm-review](https://github.com/jfmengels/node-elm-review), version 2.9.1. Cli tool for reviewing Elm code.
  */
 const completionSpec: Fig.Spec = {
   name: "elm-review",
@@ -242,6 +242,28 @@ const completionSpec: Fig.Spec = {
         name: "<path-to-elm-format>",
         template: "filepaths",
       },
+    },
+    {
+      name: "--fix-limit",
+      description: "Limit the number of fixes applied in a single batch to N",
+      args: {
+        name: "N",
+        description: "The number of fixes to apply before prompting the user",
+      },
+    },
+    {
+      name: "--extract",
+      description:
+        'Enable extracting data from the project for the rules that have a data extractor. Requires running with --report=json. Learn more by reading the section about "Extracting information" at https://bit.ly/3UmNr0V',
+    },
+    {
+      name: "--benchmark-info",
+      description:
+        "Print out how much time it took for rules and phases of the process to run. This is meant for benchmarking purposes",
+    },
+    {
+      name: "--no-color",
+      description: "Disable colors in the output",
     },
   ],
   args: {


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

**Chore**: Update to the latest version of [elm-review](https://github.com/jfmengels/node-elm-review)

### What is the new behavior (if this is a feature change)?

**Added:** The following flags/options
- `--fix-limit=N`
- `--extract`
- `--benchmark-info`
- `--no-color`
