### PR TITLE
feat: add `elm-json` completion spec

### DIFF
--- a/src/elm-json.ts
+++ b/src/elm-json.ts
@@ -2,7 +2,7 @@ const packageList: Fig.Generator = {
   script:
     "curl -sH 'accept-encoding: gzip' --compressed https://package.elm-lang.org/search.json",
   cache: {
-    ttl: 100 * 24 * 60 * 60 * 3, // 3 days
+    ttl: 1000 * 24 * 60 * 60 * 3, // 3 days
   },
   postProcess: (output) => {
     return JSON.parse(output).map((package_) => ({

--- a/src/elm-json.ts
+++ b/src/elm-json.ts
@@ -162,6 +162,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "INPUT",
         description: "The elm.json file to upgrade [default: elm.json]",
+        generators: [filepaths({ extensions: ["json"] })]
       },
     },
   ],

--- a/src/elm-json.ts
+++ b/src/elm-json.ts
@@ -1,3 +1,5 @@
+import { filepaths } from "@fig/autocomplete-generators";
+
 const packageList: Fig.Generator = {
   script:
     "curl -sH 'accept-encoding: gzip' --compressed https://package.elm-lang.org/search.json",

--- a/src/elm-json.ts
+++ b/src/elm-json.ts
@@ -164,7 +164,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "INPUT",
         description: "The elm.json file to upgrade [default: elm.json]",
-        generators: filepaths({ extensions: ["json"] })
+        generators: filepaths({ extensions: ["json"] }),
       },
     },
   ],

--- a/src/elm-json.ts
+++ b/src/elm-json.ts
@@ -1,6 +1,6 @@
 const packageList: Fig.Generator = {
   script:
-    "curl -sH 'accept-encoding: gzip' https://package.elm-lang.org/search.json | gunzip",
+    "curl -sH 'accept-encoding: gzip' --compressed https://package.elm-lang.org/search.json",
   cache: {
     ttl: 100 * 24 * 60 * 60 * 3, // 3 days
   },

--- a/src/elm-json.ts
+++ b/src/elm-json.ts
@@ -164,7 +164,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "INPUT",
         description: "The elm.json file to upgrade [default: elm.json]",
-        generators: [filepaths({ extensions: ["json"] })]
+        generators: filepaths({ extensions: ["json"] })
       },
     },
   ],

--- a/src/elm-json.ts
+++ b/src/elm-json.ts
@@ -18,173 +18,180 @@ const packageList: Fig.Generator = {
  * Based on [elm-json](https://github.com/zwilias/elm-json), version 0.2.13. Cli tool for working with your elm.json file.
  */
 const completionSpec: Fig.Spec = {
-  name: "elm-json",
-  description: "Deal with your elm.json",
+  name: 'elm-json',
+  description: 'Deal with your elm.json',
   subcommands: [
     {
-      name: "help",
+      name: 'help',
       description:
-        "Prints help information or the help of the given subcommand(s)",
+        'Prints help information or the help of the given subcommand(s)',
       args: {
-        name: "subcommand",
-        suggestions: ["help", "install", "new", "tree", "uninstall", "upgrade"],
+        name: 'subcommand',
+        template: "help"
       },
     },
     {
-      name: "install",
-      description: "Install a package",
+      name: 'install',
+      description: 'Install a package',
       options: [
         {
-          name: ["--help", "-h"],
-          description: "Prints help information",
+          name: ['--help', '-h'],
+          description: 'Prints help information',
         },
         {
-          name: "--test",
-          description: "Install as a test-dependency",
+          name: '--test',
+          description: 'Install as a test-dependency',
         },
         {
-          name: ["--version", "-V"],
-          description: "Prints version information",
+          name: ['--version', '-V'],
+          description: 'Prints version information',
         },
         {
-          name: "--yes",
+          name: '--yes',
           description: 'Answer "yes" to all questions',
         },
       ],
       args: [
         {
-          name: "PACKAGE",
+          name: 'PACKAGE',
           description:
-            "Package to install, e.g. elm/core or elm/core@1.0.2 or elm/core@1",
+            'Package to install, e.g. elm/core or elm/core@1.0.2 or elm/core@1',
           debounce: true,
           generators: packageList,
         },
         {
-          name: "-- INPUT",
-          description: "The elm.json file to upgrade [default: elm.json]",
+          name: '-- INPUT',
+          isOptional: true,
+          description: 'The elm.json file to upgrade [default: elm.json]',
+          generators: filepaths({ extensions: ['json'] }),
         },
       ],
     },
     {
-      name: "new",
-      description: "Create a new elm.json file",
+      name: 'new',
+      description: 'Create a new elm.json file',
       options: [
         {
-          name: ["--help", "-h"],
-          description: "Prints help information",
+          name: ['--help', '-h'],
+          description: 'Prints help information',
         },
         {
-          name: ["--version", "-V"],
-          description: "Prints version information",
+          name: ['--version', '-V'],
+          description: 'Prints version information',
         },
       ],
     },
     {
-      name: "tree",
-      description: "List entire dependency graph as a tree",
+      name: 'tree',
+      description: 'List entire dependency graph as a tree',
       options: [
         {
-          name: ["--help", "-h"],
-          description: "Prints help information",
+          name: ['--help', '-h'],
+          description: 'Prints help information',
         },
         {
-          name: "--test",
-          description: "Promote test-dependencies to top-level dependencies",
+          name: '--test',
+          description: 'Promote test-dependencies to top-level dependencies',
         },
         {
-          name: ["--version", "-V"],
-          description: "Prints version information",
+          name: ['--version', '-V'],
+          description: 'Prints version information',
         },
       ],
       args: [
         {
-          name: "PACKAGE",
+          name: 'PACKAGE',
           description:
-            "Limit output to show path to some (indirect) dependency",
+            'Limit output to show path to some (indirect) dependency',
           debounce: true,
           generators: packageList,
         },
         {
-          name: "-- INPUT",
-          description: "The elm.json file to solve [default: elm.json]",
+          name: '-- INPUT',
+          isOptional: true,
+          description: 'The elm.json file to solve [default: elm.json]',
+          generators: filepaths({ extensions: ['json'] }),
         },
       ],
     },
     {
-      name: "uninstall",
-      description: "Uninstall a package",
+      name: 'uninstall',
+      description: 'Uninstall a package',
       options: [
         {
-          name: ["--help", "-h"],
-          description: "Prints help information",
+          name: ['--help', '-h'],
+          description: 'Prints help information',
         },
         {
-          name: ["--version", "-V"],
-          description: "Prints version information",
+          name: ['--version', '-V'],
+          description: 'Prints version information',
         },
         {
-          name: "--yes",
+          name: '--yes',
           description: 'Answer "yes" to all questions',
         },
       ],
       args: [
         {
-          name: "PACKAGE",
-          description: "Package to uninstall, e.g. elm/html",
+          name: 'PACKAGE',
+          description: 'Package to uninstall, e.g. elm/html',
           debounce: true,
           generators: packageList,
         },
         {
-          name: "-- INPUT",
-          description: "The elm.json file to upgrade [default: elm.json]",
+          name: '-- INPUT',
+          isOptional: true,
+          description: 'The elm.json file to upgrade [default: elm.json]',
+          generators: filepaths({ extensions: ['json'] }),
         },
       ],
     },
     {
-      name: "upgrade",
-      description: "Bring your dependencies up to date",
+      name: 'upgrade',
+      description: 'Bring your dependencies up to date',
       options: [
         {
-          name: ["--help", "-h"],
-          description: "Prints help information",
+          name: ['--help', '-h'],
+          description: 'Prints help information',
         },
         {
-          name: "--unsafe",
-          description: "Allow major versions bumps",
+          name: '--unsafe',
+          description: 'Allow major versions bumps',
         },
         {
-          name: ["--version", "-V"],
-          description: "Prints version information",
+          name: ['--version', '-V'],
+          description: 'Prints version information',
         },
         {
-          name: "--yes",
+          name: '--yes',
           description: 'Answer "yes" to all questions',
         },
       ],
       args: {
-        name: "INPUT",
-        description: "The elm.json file to upgrade [default: elm.json]",
-        generators: filepaths({ extensions: ["json"] }),
+        name: 'INPUT',
+        description: 'The elm.json file to upgrade [default: elm.json]',
+        isOptional: true,
+        generators: filepaths({ extensions: ['json'] }),
       },
     },
   ],
   options: [
     {
-      name: ["--help", "-h"],
-      description: "Prints help information",
+      name: ['--help', '-h'],
+      description: 'Prints help information',
     },
     {
-      name: "--offline",
+      name: '--offline',
       description:
-        "Enable offline mode, which means no HTTP traffic will happen",
+        'Enable offline mode, which means no HTTP traffic will happen',
     },
     {
-      name: ["--version", "-V"],
-      description: "Prints version information",
+      name: ['--version', '-V'],
+      description: 'Prints version information',
     },
     {
-      name: ["--verbose", "-v"],
-      description: "Sets the level of verbosity",
+      name: ['--verbose', '-v'],
+      description: 'Sets the level of verbosity',
     },
   ],
 };

--- a/src/elm-json.ts
+++ b/src/elm-json.ts
@@ -1,0 +1,188 @@
+const packageList: Fig.Generator = {
+  script:
+    "curl -sH 'accept-encoding: gzip' https://package.elm-lang.org/search.json | gunzip",
+  cache: {
+    ttl: 100 * 24 * 60 * 60 * 3, // 3 days
+  },
+  postProcess: (output) => {
+    return JSON.parse(output).map((package_) => ({
+      name: package_.name,
+      description: package_.summary,
+    }));
+  },
+};
+
+/**
+ * Based on [elm-json](https://github.com/zwilias/elm-json), version 0.2.13. Cli tool for working with your elm.json file.
+ */
+const completionSpec: Fig.Spec = {
+  name: "elm-json",
+  description: "Deal with your elm.json",
+  subcommands: [
+    {
+      name: "help",
+      description:
+        "Prints help information or the help of the given subcommand(s)",
+      args: {
+        name: "subcommand",
+        suggestions: ["help", "install", "new", "tree", "uninstall", "upgrade"],
+      },
+    },
+    {
+      name: "install",
+      description: "Install a package",
+      options: [
+        {
+          name: ["--help", "-h"],
+          description: "Prints help information",
+        },
+        {
+          name: "--test",
+          description: "Install as a test-dependency",
+        },
+        {
+          name: ["--version", "-V"],
+          description: "Prints version information",
+        },
+        {
+          name: "--yes",
+          description: 'Answer "yes" to all questions',
+        },
+      ],
+      args: [
+        {
+          name: "PACKAGE",
+          description:
+            "Package to install, e.g. elm/core or elm/core@1.0.2 or elm/core@1",
+          debounce: true,
+          generators: packageList,
+        },
+        {
+          name: "-- INPUT",
+          description: "The elm.json file to upgrade [default: elm.json]",
+        },
+      ],
+    },
+    {
+      name: "new",
+      description: "Create a new elm.json file",
+      options: [
+        {
+          name: ["--help", "-h"],
+          description: "Prints help information",
+        },
+        {
+          name: ["--version", "-V"],
+          description: "Prints version information",
+        },
+      ],
+    },
+    {
+      name: "tree",
+      description: "List entire dependency graph as a tree",
+      options: [
+        {
+          name: ["--help", "-h"],
+          description: "Prints help information",
+        },
+        {
+          name: "--test",
+          description: "Promote test-dependencies to top-level dependencies",
+        },
+        {
+          name: ["--version", "-V"],
+          description: "Prints version information",
+        },
+      ],
+      args: [
+        {
+          name: "PACKAGE",
+          description:
+            "Limit output to show path to some (indirect) dependency",
+          debounce: true,
+          generators: packageList,
+        },
+        {
+          name: "-- INPUT",
+          description: "The elm.json file to solve [default: elm.json]",
+        },
+      ],
+    },
+    {
+      name: "uninstall",
+      description: "Uninstall a package",
+      options: [
+        {
+          name: ["--help", "-h"],
+          description: "Prints help information",
+        },
+        {
+          name: ["--version", "-V"],
+          description: "Prints version information",
+        },
+        {
+          name: "--yes",
+          description: 'Answer "yes" to all questions',
+        },
+      ],
+      args: [
+        {
+          name: "PACKAGE",
+          description: "Package to uninstall, e.g. elm/html",
+          debounce: true,
+          generators: packageList,
+        },
+        {
+          name: "-- INPUT",
+          description: "The elm.json file to upgrade [default: elm.json]",
+        },
+      ],
+    },
+    {
+      name: "upgrade",
+      description: "Bring your dependencies up to date",
+      options: [
+        {
+          name: ["--help", "-h"],
+          description: "Prints help information",
+        },
+        {
+          name: "--unsafe",
+          description: "Allow major versions bumps",
+        },
+        {
+          name: ["--version", "-V"],
+          description: "Prints version information",
+        },
+        {
+          name: "--yes",
+          description: 'Answer "yes" to all questions',
+        },
+      ],
+      args: {
+        name: "INPUT",
+        description: "The elm.json file to upgrade [default: elm.json]",
+      },
+    },
+  ],
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Prints help information",
+    },
+    {
+      name: "--offline",
+      description:
+        "Enable offline mode, which means no HTTP traffic will happen",
+    },
+    {
+      name: ["--version", "-V"],
+      description: "Prints version information",
+    },
+    {
+      name: ["--verbose", "-v"],
+      description: "Sets the level of verbosity",
+    },
+  ],
+};
+export default completionSpec;

--- a/src/elm.ts
+++ b/src/elm.ts
@@ -2,7 +2,7 @@ const packageList: Fig.Generator = {
   script:
     "curl -sH 'accept-encoding: gzip' --compressed https://package.elm-lang.org/search.json",
   cache: {
-    ttl: 100 * 24 * 60 * 60 * 3, // 3 days
+    ttl: 1000 * 24 * 60 * 60 * 3, // 3 days
   },
   postProcess: (output) => {
     return JSON.parse(output).map((package_) => ({

--- a/src/elm.ts
+++ b/src/elm.ts
@@ -1,6 +1,6 @@
 const packageList: Fig.Generator = {
   script:
-    "curl -sH 'accept-encoding: gzip' https://package.elm-lang.org/search.json | gunzip",
+    "curl -sH 'accept-encoding: gzip' --compressed https://package.elm-lang.org/search.json",
   cache: {
     ttl: 100 * 24 * 60 * 60 * 3, // 3 days
   },


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

**Feature**: Support for [elm-json](https://github.com/zwilias/elm-json)

### What is the new behavior (if this is a feature change)?

Support all of the publicly shown elm-json commands as of version 0.2.13.