### PR TITLE
feat: add `goto` completion spec

### DIFF
--- a/src/goto.ts
+++ b/src/goto.ts
@@ -1,0 +1,91 @@
+const listTargets: Fig.Generator = {
+  custom: async (tokens, executeShellCommand) => {
+    const targets = await executeShellCommand("command cat ~/.config/goto");
+
+    const targetSuggestions = new Map<string, Fig.Suggestion>();
+
+    for (const target of targets.split("\n")) {
+      const splits = target.split(" ");
+      targetSuggestions.set(target, {
+        name: splits[0],
+        description: "Goto " + splits[1],
+        icon: "🔖",
+        priority: 80,
+      });
+    }
+
+    return [...targetSuggestions.values()];
+  },
+};
+
+const completionSpec: Fig.Spec = {
+  name: "goto",
+  displayName: "Goto a Folder by alias",
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for goto",
+    },
+    {
+      name: ["--register", "-r"],
+      description: "Registers an alias",
+      isPersistent: true,
+      args: [
+        {
+          name: "alias",
+        },
+        {
+          name: "target",
+          template: "folders",
+        },
+      ],
+    },
+    {
+      name: ["--unregister", "-u"],
+      description: "Unregister an alias",
+      isPersistent: true,
+      args: {
+        name: "alias",
+        isDangerous: true,
+        generators: listTargets,
+        filterStrategy: "prefix",
+      },
+    },
+    {
+      name: ["--push", "-p"],
+      description:
+        "Pushes the current directory onto the stack, then performs goto",
+    },
+    {
+      name: ["--pop", "-o"],
+      description:
+        "Pops the top directory from the stack, then changes to that directory",
+    },
+    {
+      name: ["--list", "-l"],
+      description:
+        "Pops the top directory from the stack, then changes to that directory",
+    },
+    {
+      name: ["--expand", "-x"],
+      description: "Expands an alias",
+      args: {
+        name: "alias",
+        generators: listTargets,
+      },
+    },
+    {
+      name: ["--cleanup", "-c"],
+      description: "Cleans up non existent directory aliases",
+    },
+    {
+      name: ["--version", "-v"],
+      description: "Displays the version of the goto script",
+    },
+  ],
+  args: {
+    name: "alias",
+    generators: listTargets,
+  },
+};
+export default completionSpec;


### PR DESCRIPTION
This PR adds completion spec for [goto](https://github.com/iridakos/goto).

goto: Bash tool for navigation to aliased directories with auto-completion.

*Usage*

```shell
> goto --help                                                                                                                                                                 
usage: goto [<option>] <alias> [<directory>]

default usage:
  goto <alias> - changes to the directory registered for the given alias

OPTIONS:
  -r, --register: registers an alias
    goto -r|--register <alias> <directory>
  -u, --unregister: unregisters an alias
    goto -u|--unregister <alias>
  -p, --push: pushes the current directory onto the stack, then performs goto
    goto -p|--push <alias>
  -o, --pop: pops the top directory from the stack, then changes to that directory
    goto -o|--pop
  -l, --list: lists aliases
    goto -l|--list
  -x, --expand: expands an alias
    goto -x|--expand <alias>
  -c, --cleanup: cleans up non existent directory aliases
    goto -c|--cleanup
  -h, --help: prints this help
    goto -h|--help
  -v, --version: displays the version of the goto script
    goto -v|--version
```

Signed-off-by: Karthikeyan Vaithilingam <seenukarthi@gmail.com>