### PR TITLE
feat(brew): add `developer` subcommand.

### DIFF
--- a/src/brew.ts
+++ b/src/brew.ts
@@ -1621,6 +1621,16 @@ const completionSpec: Fig.Spec = {
         isOptional: true,
       },
     },
+    {
+      name: "developer",
+      description: "Display the current state of Homebrew's developer mode",
+      args: {
+        name: "state",
+        description: "Turn Homebrew's developer mode on or off respectively",
+        suggestions: ["on", "off"],
+        isOptional: true,
+      },
+    },
   ],
   options: [
     {


### PR DESCRIPTION
This PR adds the `developer` subcommand to the `brew` spec.

Control Homebrew's developer mode. When developer mode is enabled, brew update will update Homebrew to the latest commit on the master branch instead of the latest stable version, along with other behavior changes.

Signed-off-by: Karthikeyan Vaithilingam <seenukarthi@gmail.com>