### PR TITLE
feat: search namespace for k9s

### DIFF
--- a/src/k9s.ts
+++ b/src/k9s.ts
@@ -1,3 +1,20 @@
+const namespaces: Fig.Generator = {
+  script: () => {
+    return `kubectl get namespaces`;
+  },
+  postProcess: (out) => {
+    return out
+      .split("\n")
+      .slice(1)
+      .map((line) => {
+        return {
+          name: line.split(" ").shift(),
+          description: "Kubernetes namespace",
+        };
+      });
+  },
+};
+
 const completionSpec: Fig.Spec = {
   name: "k9s",
   description:
@@ -146,6 +163,8 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "string",
         description: "The namespace",
+        generators: namespaces,
+        debounce: true,
       },
     },
     {

--- a/src/k9s.ts
+++ b/src/k9s.ts
@@ -1,7 +1,5 @@
 const namespaces: Fig.Generator = {
-  script: () => {
-    return `kubectl get namespaces`;
-  },
+  script: "kubectl get namespaces",
   postProcess: (out) => {
     return out
       .split("\n")


### PR DESCRIPTION
# Summary
It is convenient for users to list all namespaces when using the `--namespace` option in the `k9s` command.
![截圖 2023-02-14 上午11 44 49](https://user-images.githubusercontent.com/33183531/218634569-5aa47502-24c4-497c-a681-bbdd3f8f8717.png)


# Issue
Closes https://github.com/withfig/autocomplete/issues/1755