### PR TITLE
Fix `associate-route-table` options

### DIFF
--- a/src/aws/ec2.ts
+++ b/src/aws/ec2.ts
@@ -1129,19 +1129,12 @@ const completionSpec: Fig.Spec = {
           },
         },
         {
-          name: "--subnet-ids",
+          name: "--subnet-id",
           description:
-            "The IDs of the subnets to associate with the transit gateway multicast domain",
-          args: [
-            {
-              generators: awsGenerators.subnet_ids,
-            },
-            {
-              generators: awsGenerators.subnet_ids,
-              isVariadic: true,
-              isOptional: true,
-            },
-          ],
+            "The ID of the subnet to associate with the transit gateway multicast domain",
+          args: {
+            name: "string",
+          },
         },
         {
           name: "--gateway-id",


### PR DESCRIPTION
No param named `subnet-ids` exists for this command, instead it is `subnet-id`.
Docs: https://docs.aws.amazon.com/cli/latest/reference/ec2/associate-route-table.html