### PR TITLE
fix(aws-ec2): `associate-route-table` `subnet-id` param

### DIFF
--- a/src/aws/ec2.ts
+++ b/src/aws/ec2.ts
@@ -1129,19 +1129,12 @@ const completionSpec: Fig.Spec = {
           },
         },
         {
-          name: "--subnet-ids",
+          name: "--subnet-id",
           description:
-            "The IDs of the subnets to associate with the transit gateway multicast domain",
-          args: [
-            {
-              generators: awsGenerators.subnet_ids,
-            },
-            {
-              generators: awsGenerators.subnet_ids,
-              isVariadic: true,
-              isOptional: true,
-            },
-          ],
+            "The ID of the subnet to associate with the route table",
+          args: {
+            name: "string",
+          },
         },
         {
           name: "--gateway-id",

--- a/src/aws/ec2.ts
+++ b/src/aws/ec2.ts
@@ -1132,9 +1132,11 @@ const completionSpec: Fig.Spec = {
           name: "--subnet-id",
           description:
             "The ID of the subnet to associate with the route table",
-          args: {
-            name: "string",
-          },
+          args: [
+            {
+              generators: awsGenerators.subnet_ids,
+            },
+          ],
         },
         {
           name: "--gateway-id",

--- a/src/aws/ec2.ts
+++ b/src/aws/ec2.ts
@@ -1136,6 +1136,11 @@ const completionSpec: Fig.Spec = {
             {
               generators: awsGenerators.subnet_ids,
             },
+            {
+              generators: awsGenerators.subnet_ids,
+              isVariadic: true,
+              isOptional: true,
+            },
           ],
         },
         {

--- a/src/aws/ec2.ts
+++ b/src/aws/ec2.ts
@@ -1130,8 +1130,7 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "--subnet-id",
-          description:
-            "The ID of the subnet to associate with the route table",
+          description: "The ID of the subnet to associate with the route table",
           args: [
             {
               generators: awsGenerators.subnet_ids,


### PR DESCRIPTION
No param named `subnet-ids` exists for this command, it is called `subnet-id`.
Docs: https://docs.aws.amazon.com/cli/latest/reference/ec2/associate-route-table.html