### PR TITLE
fix(@usermn/sdc): remove v in version 0.0.7

### DIFF
--- a/src/@usermn/sdc/0.0.0.ts
+++ b/src/@usermn/sdc/0.0.0.ts
@@ -39,7 +39,7 @@ const versions: Fig.VersionDiffMap = {};
 
 versions["0.0.4"] = {};
 
-versions["v0.0.7"] = {
+versions["0.0.7"] = {
   options: [
     {
       name: "--debug-options",


### PR DESCRIPTION
Looks like I forgot to update the workflow to remove the v. Oops.