### PR TITLE
feat: add `iconv` completion spec.

### DIFF
--- a/src/iconv.ts
+++ b/src/iconv.ts
@@ -1,0 +1,99 @@
+const encodingGenerator: Fig.Generator = {
+  script: "iconv -l | command tr ' ' '\\n' | sort",
+  postProcess: (out) =>
+    out.split("\n").map((encoding) => ({
+      name: encoding,
+      description: encoding,
+      type: "arg",
+    })),
+};
+
+const completionSpec: Fig.Spec = {
+  name: "iconv",
+  description: "Character set conversion",
+  options: [
+    {
+      name: "--help",
+      description: "Show help for iconv",
+    },
+    {
+      name: "--version",
+      description: "Output version information and exit",
+    },
+    {
+      name: ["-f", "--from-code"],
+      description: "Specifies the encoding of the input",
+      exclusiveOn: ["-l", "--list"],
+      args: {
+        name: "encoding",
+        generators: encodingGenerator,
+      },
+    },
+    {
+      name: ["-t", "---to-code"],
+      description: "Specifies the encoding of the output",
+      exclusiveOn: ["-l", "--list"],
+      args: {
+        name: "encoding",
+        generators: encodingGenerator,
+      },
+    },
+    {
+      name: "-c",
+      description: "Discard unconvertible characters",
+      exclusiveOn: ["-l", "--list"],
+    },
+    {
+      name: ["-l", "--list"],
+      description: "List the supported encodings",
+      exclusiveOn: [
+        "-f",
+        "--from-code",
+        "-t",
+        "---to-code",
+        "--unicode-subst",
+        "--byte-subst",
+        "--widechar-subst",
+      ],
+    },
+    {
+      name: "--unicode-subst",
+      description: "Substitution for unconvertible Unicode characters",
+      exclusiveOn: ["-l", "--list"],
+      requiresSeparator: true,
+      args: {
+        name: "FORMATSTRING",
+        description:
+          "The formatstring must be a format string in the same format as for the printf command",
+      },
+    },
+    {
+      name: "--byte-subst",
+      description: "Substitution for unconvertible bytes",
+      exclusiveOn: ["-l", "--list"],
+      requiresSeparator: true,
+      args: {
+        name: "FORMATSTRING",
+        description:
+          "The formatstring must be a format string in the same format as for the printf command",
+      },
+    },
+    {
+      name: "--widechar-subst",
+      description: "Substitution for unconvertible wide characters",
+      exclusiveOn: ["-l", "--list"],
+      requiresSeparator: true,
+      args: {
+        name: "FORMATSTRING",
+        description:
+          "The formatstring must be a format string in the same format as for the printf command",
+      },
+    },
+  ],
+  args: {
+    name: "inputfile",
+    isVariadic: true,
+    template: "filepaths",
+  },
+};
+export default completionSpec;

--- a/src/iconv.ts
+++ b/src/iconv.ts
@@ -30,7 +30,7 @@ const completionSpec: Fig.Spec = {
       },
     },
     {
-      name: ["-t", "---to-code"],
+      name: ["-t", "--to-code"],
       description: "Specifies the encoding of the output",
       exclusiveOn: ["-l", "--list"],
       args: {
@@ -50,7 +50,7 @@ const completionSpec: Fig.Spec = {
         "-f",
         "--from-code",
         "-t",
-        "---to-code",
+        "--to-code",
         "--unicode-subst",
         "--byte-subst",
         "--widechar-subst",


### PR DESCRIPTION
This PR adds completion spec for `iconv` command.

Usage of `iconv`

```shell
$ iconv --help                                                                                                                                          
Usage: iconv [OPTION...] [-f ENCODING] [-t ENCODING] [INPUTFILE...]
or:    iconv -l

Converts text from one encoding to another encoding.

Options controlling the input and output format:
  -f ENCODING, --from-code=ENCODING
                              the encoding of the input
  -t ENCODING, --to-code=ENCODING
                              the encoding of the output

Options controlling conversion problems:
  -c                          discard unconvertible characters
  --unicode-subst=FORMATSTRING
                              substitution for unconvertible Unicode characters
  --byte-subst=FORMATSTRING   substitution for unconvertible bytes
  --widechar-subst=FORMATSTRING
                              substitution for unconvertible wide characters

Options controlling error output:
  -s, --silent                suppress error messages about conversion problems

Informative output:
  -l, --list                  list the supported encodings
  --help                      display this help and exit
  --version                   output version information and exit

Report bugs to <bug-gnu-libiconv@gnu.org>.
```