### PR TITLE
feat: add sls completion spec

### DIFF
--- a/src/sls.ts
+++ b/src/sls.ts
@@ -1,5 +1,6 @@
+import serverless from "./serverless";
 const completionSpec: Fig.Spec = {
+  ...serverless,
   name: "sls",
-  loadSpec: "serverless",
 };
 export default completionSpec;

--- a/src/sls.ts
+++ b/src/sls.ts
@@ -1,0 +1,5 @@
+const completionSpec: Fig.Spec = {
+  name: "sls",
+  loadSpec: "serverless",
+};
+export default completionSpec;


### PR DESCRIPTION
This PR adds `sls` completion spec.
`sls` is a shorthand for the same [serverless](https://github.com/withfig/autocomplete/blob/master/src/serverless.ts).