### PR TITLE
feat(xc): add xc autocomplete

### DIFF
--- a/src/xc.ts
+++ b/src/xc.ts
@@ -1,0 +1,95 @@
+/**
+ * https://github.com/joerdav/xc
+ * xc - Simple, Convenient, Markdown-based task runner.
+ * v0.2.0
+ */
+const completionSpec: Fig.Spec = {
+  name: "xc",
+  description: "List tasks from an xc-compatible markdown file",
+  generateSpec: async (context, executeShellCommand) => {
+    const options: Fig.Option[] = [
+      {
+        name: ["-f", "-file"],
+        args: {
+          name: "path",
+          template: "filepaths",
+        },
+        description:
+          'Specify a markdown file that contains tasks (default: "README.md")',
+      },
+      {
+        name: ["-d", "-display"],
+        description: "Print the markdown code of a task rather than running it",
+      },
+      {
+        name: ["-H", "-heading"],
+        args: {
+          name: "heading",
+          suggestions: ["Tasks", "Usage", "Examples"],
+        },
+        description: 'Specify the heading for xc tasks (default: "Tasks")',
+      },
+    ];
+    const out = await executeShellCommand("xc");
+    const subcommands: Fig.Subcommand[] = out
+      .trim()
+      .split("\n")
+      .map((line) =>
+        line
+          .trim()
+          .split(/^([^ ]* )/)
+          .map((s) => s.trim())
+      )
+      .map(([_, task, desc]) => ({
+        name: task,
+        description: desc,
+        options,
+      }));
+
+    return {
+      name: "xc",
+      subcommands,
+    };
+  },
+  requiresSubcommand: false,
+  options: [
+    {
+      name: ["-s", "-short"],
+      description: "List task names in a short format",
+    },
+    {
+      name: ["-h", "-help"],
+      description: "Print this help text",
+    },
+    {
+      name: ["-f", "-file"],
+      args: {
+        name: "path",
+        template: "filepaths",
+      },
+      description:
+        'Specify a markdown file that contains tasks (default: "README.md")',
+    },
+    {
+      name: ["-H", "-heading"],
+      args: {
+        name: "heading",
+        suggestions: ["Tasks", "Usage", "Examples"],
+      },
+      description: 'Specify the heading for xc tasks (default: "Tasks")',
+    },
+    {
+      name: ["-V", "-version"],
+      description: "Show xc version",
+    },
+    {
+      name: "-complete",
+      description: "Install shell completion for xc",
+    },
+    {
+      name: "-uncomplete",
+      description: "Uninstall shell completion for xc",
+    },
+  ],
+};
+export default completionSpec;

--- a/src/xc.ts
+++ b/src/xc.ts
@@ -51,7 +51,6 @@ const completionSpec: Fig.Spec = {
       subcommands,
     };
   },
-  requiresSubcommand: false,
   options: [
     {
       name: ["-s", "-short"],


### PR DESCRIPTION
Just started using a nifty new tool [xc](https://github.com/joerdav/xc) to run scripts straight from the `README.md`, however, I missed being able to have autocomplete for scripts defined in a `package.json`. 

Thank you Fig for your tool! I can't look back to a terminal without autocomplete, so I guess its time to contribute!

Let me know if there is anything else I can do. I was unsure if I picked the correct pattern for dynamic sub-commands since it has to pick them up from your readme. And I wasn't sure if I applied the options that were command specific in the right location, vs you can run the command with no arguments and it will list what subcommands are available. 