### PR TITLE
fix(dbt): remove non-existent `--models` option

### DIFF
--- a/src/dbt.ts
+++ b/src/dbt.ts
@@ -207,7 +207,7 @@ const completionSpec: Fig.Spec = {
           description: "Bypass the cache",
         },
         {
-          name: ["-m", "--models"],
+          name: ["-s", "--select"],
           description: "Subset of models",
           args: {
             name: "Model inclusions subset",
@@ -338,7 +338,7 @@ const completionSpec: Fig.Spec = {
       description: "Executes tests defined in a project",
       options: [
         {
-          name: ["-m", "--models"],
+          name: ["-s", "--select"],
           description: "Subset of models to include",
           args: {
             name: "Model inclusions subset",
@@ -753,7 +753,7 @@ const completionSpec: Fig.Spec = {
           },
         },
         {
-          name: ["-m", "--models"],
+          name: ["-s", "--select"],
           description:
             "Like the --select flag, this flag is used to select nodes. It implies --resource-type=model, and will only return models in the results of the dbt ls command",
           args: {

--- a/src/dbt.ts
+++ b/src/dbt.ts
@@ -56,7 +56,7 @@ const completionSpec: Fig.Spec = {
           args: { name: "THREADS" },
         },
         {
-          name: "--select",
+          name: ["-s", "--select"],
           description: "Select subset of models",
           args: {
             name: "subset",
@@ -90,22 +90,6 @@ const completionSpec: Fig.Spec = {
         {
           name: "--bypass-cache",
           description: "Bypass the cache",
-        },
-        {
-          name: ["-s", "--select"],
-          description: "Subset of models",
-          args: {
-            name: "Model inclusions subset",
-            description: "Subset of models to include",
-            isVariadic: true,
-            suggestions: [
-              "path:",
-              "tag:",
-              "config:",
-              "test_type:",
-              "test_name:",
-            ],
-          },
         },
       ],
     },
@@ -171,7 +155,7 @@ const completionSpec: Fig.Spec = {
           args: { name: "threads" },
         },
         {
-          name: "--select",
+          name: ["-s", "--select"],
           description: "Select subset of models",
           args: {
             name: "subset",
@@ -205,22 +189,6 @@ const completionSpec: Fig.Spec = {
         {
           name: "--bypass-cache",
           description: "Bypass the cache",
-        },
-        {
-          name: ["-s", "--select"],
-          description: "Subset of models",
-          args: {
-            name: "Model inclusions subset",
-            description: "Subset of models to include",
-            isVariadic: true,
-            suggestions: [
-              "path:",
-              "tag:",
-              "config:",
-              "test_type:",
-              "test_name:",
-            ],
-          },
         },
       ],
     },
@@ -338,22 +306,6 @@ const completionSpec: Fig.Spec = {
       description: "Executes tests defined in a project",
       options: [
         {
-          name: ["-s", "--select"],
-          description: "Subset of models to include",
-          args: {
-            name: "Model inclusions subset",
-            description: "Subset of models to include",
-            isVariadic: true,
-            suggestions: [
-              "path:",
-              "tag:",
-              "config:",
-              "test_type:",
-              "test_name:",
-            ],
-          },
-        },
-        {
           name: ["-x", "--fail-fast"],
           description: "Exit immediately if a single model fails to build",
         },
@@ -385,7 +337,7 @@ const completionSpec: Fig.Spec = {
           description: "Run only schema tests",
         },
         {
-          name: "--select",
+          name: ["-s", "--select"],
           description: "Select subset of models",
           args: {
             name: "subset",
@@ -737,7 +689,7 @@ const completionSpec: Fig.Spec = {
           },
         },
         {
-          name: "--select",
+          name: ["-s", "--select"],
           description:
             "This flag specifies one or more selection-type arguments used to filter the nodes returned by the dbt ls command",
           args: {

--- a/src/dbt.ts
+++ b/src/dbt.ts
@@ -753,22 +753,6 @@ const completionSpec: Fig.Spec = {
           },
         },
         {
-          name: ["-s", "--select"],
-          description:
-            "Like the --select flag, this flag is used to select nodes. It implies --resource-type=model, and will only return models in the results of the dbt ls command",
-          args: {
-            name: "SELECTOR",
-            isVariadic: true,
-            suggestions: [
-              "path:",
-              "tag:",
-              "config:",
-              "test_type:",
-              "test_name:",
-            ],
-          },
-        },
-        {
           name: "--exclude",
           description:
             "Specify selectors that should be excluded from the list of returned nodes",

--- a/src/dbt.ts
+++ b/src/dbt.ts
@@ -92,7 +92,7 @@ const completionSpec: Fig.Spec = {
           description: "Bypass the cache",
         },
         {
-          name: ["-m", "--models"],
+          name: ["-s", "--select"],
           description: "Subset of models",
           args: {
             name: "Model inclusions subset",


### PR DESCRIPTION
dbt replaced the `--models/-m` option with `--select/-s`. See their docs here: https://docs.getdbt.com/reference/node-selection/syntax

Example showing `--models/-m` is not compatible with `dbt run`
```shell
❯ dbt build -m dim_users
usage: dbt [-h] [--version] [-r RECORD_TIMING_INFO] [-d] [--log-format {text,json,default}] [--no-write-json]
           [--use-colors | --no-use-colors] [--printer-width PRINTER_WIDTH]
           [--warn-error | --warn-error-options WARN_ERROR_OPTIONS] [--no-version-check] [--partial-parse | --no-partial-parse]
           [--use-experimental-parser] [--no-static-parser] [--profiles-dir PROFILES_DIR] [--no-anonymous-usage-stats] [-x] [-q]
           [--no-print] [--cache-selected-only | --no-cache-selected-only]
           {docs,source,init,clean,debug,deps,list,ls,build,snapshot,run,compile,parse,test,seed,run-operation} ...
dbt: error: unrecognized arguments: -m dim_users
```

Whereas, `--select/-s` works (some output redacted for privacy/brevity)
```shell
❯ dbt build -s dim_users
21:54:41  Running with dbt=1.4.5
...
21:54:46  1 of 6 START sql table model dbt_greg.dim_users ................................ [RUN]
...
21:55:09  Finished running 1 table model, 5 tests, 3 hooks in 0 hours 0 minutes and 26.11 seconds (26.11s).
21:55:10
21:55:10  Completed successfully
21:55:10
21:55:10  Done. PASS=6 WARN=0 ERROR=0 SKIP=0 TOTAL=6
```

