### PR TITLE
feat: add completion for `@wordpress/create-block`

### DIFF
--- a/src/@wordpress/create-block.ts
+++ b/src/@wordpress/create-block.ts
@@ -1,0 +1,82 @@
+const completionSpec: Fig.Spec = {
+  name: "@wordpress/create-block",
+  description:
+    "Generates PHP, JS and CSS code for registering a WordPress plugin with blocks",
+  args: {
+    name: "slug",
+    description:
+      "The block slug used for identification, output location, and plugin name",
+    isOptional: true,
+  },
+  options: [
+    {
+      name: ["-V", "--version"],
+      description: "Output the version number",
+    },
+    {
+      name: ["-t", "--template"],
+      description: "Project template type name",
+      args: {
+        name: "name",
+        suggestions: ["standard", "es5"],
+      },
+    },
+    {
+      name: "--namespace",
+      description: "Internal namespace for the block name",
+      args: {
+        name: "value",
+      },
+    },
+    {
+      name: "--title",
+      description: "Display title for the block and the WordPress plugin",
+      args: {
+        name: "value",
+      },
+    },
+    {
+      name: "--short-description",
+      description: "Short description for the block and the WordPress plugin",
+      args: {
+        name: "value",
+      },
+    },
+    {
+      name: "--category",
+      description: "Category name for the block",
+      args: {
+        name: "name",
+      },
+    },
+    {
+      name: "--wp-scripts",
+      description: "Enable integration with `@wordpress/scripts` package",
+    },
+    {
+      name: "--no-wp-scripts",
+      description: "Disable integration with `@wordpress/scripts` package",
+    },
+    {
+      name: "--wp-env",
+      description: "Enable integration with `@wordpress/env` package",
+    },
+    {
+      name: "--no-plugin",
+      description: "Scaffold only block files",
+    },
+    {
+      name: "--variant",
+      description: "The variant of the template to use",
+      args: {
+        name: "variant",
+      },
+    },
+    {
+      name: ["-h", "--help"],
+      description: "Display help for command",
+    },
+  ],
+};
+
+export default completionSpec;

--- a/src/npx.ts
+++ b/src/npx.ts
@@ -141,6 +141,10 @@ const suggestions: Fig.Suggestion[] = [
     name: "sta",
     icon: "https://static1.smartbear.co/swagger/media/assets/swagger_fav.png",
   },
+  {
+    name: "@wordpress/create-block",
+    icon: "https://s1.wp.com/i/webclip.png",
+  },
 ];
 
 const completionSpec: Fig.Spec = {


### PR DESCRIPTION
Adds completion for `npx @wordpress/create-block`:


```
➜ npx @wordpress/create-block --help
Usage: wp-create-block [options] [slug]

Generates PHP, JS and CSS code for registering a WordPress plugin with blocks.

[slug] is optional. When provided, it triggers the quick mode where it is used as the block slug used for its identification, the output location for scaffolded files, and the name of the WordPress plugin.The rest of the configuration is set to all default values unless overridden with some options listed below.

Options:
  -V, --version                output the version number
  -t, --template <name>        project template type name; allowed values: "standard", "es5",
                               the name of an external npm package, or the path to a local
                               directory (default: "standard")
  --namespace <value>          internal namespace for the block name
  --title <value>              display title for the block and the WordPress plugin
  --short-description <value>  short description for the block and the WordPress plugin
  --category <name>            category name for the block
  --wp-scripts                 enable integration with `@wordpress/scripts` package
  --no-wp-scripts              disable integration with `@wordpress/scripts` package
  --wp-env                     enable integration with `@wordpress/env` package
  --no-plugin                  scaffold only block files
  --variant <variant>          the variant of the template to use
  -h, --help                   display help for command

Examples:
  $ wp-create-block
  $ wp-create-block todo-list
  $ wp-create-block todo-list --template es5 --title "TODO List"
```