### PR TITLE
feat(k6): add missing flags

### DIFF
--- a/src/k6.ts
+++ b/src/k6.ts
@@ -1,5 +1,3 @@
-import { describe } from "node:test";
-
 const completionSpec: Fig.Spec = {
   name: "k6",
   description:
@@ -464,10 +462,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "scale",
       description: "Scale a running test",
-      args: {
-        name: "scale",
-        description: "Scale a running test",
-      },
       subcommands: [
         {
           name: "-h, --help",
@@ -475,10 +469,10 @@ const completionSpec: Fig.Spec = {
         },
         {
           name: "-m --max",
-          description: "Max avalible virtual users",
+          description: "Max available virtual users",
           args: {
             name: "max",
-            description: "Max avalible virtual users",
+            description: "Max available virtual users",
           },
         },
         {
@@ -494,10 +488,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "stats",
       description: "Show test metrics",
-      args: {
-        name: "stats",
-        description: "Show test metrics",
-      },
       subcommands: [
         {
           name: "-h, --help",
@@ -508,10 +498,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "status",
       description: "Show test status",
-      args: {
-        name: "status",
-        description: "Show test status",
-      },
       subcommands: [
         {
           name: "-h, --help",
@@ -522,10 +508,6 @@ const completionSpec: Fig.Spec = {
     {
       name: "version",
       description: "Show the application version and exit",
-      args: {
-        name: "version",
-        description: "Show the application version and exit",
-      },
       subcommands: [
         {
           name: "-h, --help",

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -498,7 +498,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "status",
       description: "Show test status",
-      subcommands: [
+      options: [
         {
           name: "-h, --help",
           description: "Help for status",

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -1,3 +1,5 @@
+import { describe } from "node:test";
+
 const completionSpec: Fig.Spec = {
   name: "k6",
   description:
@@ -456,6 +458,78 @@ const completionSpec: Fig.Spec = {
             name: "no-usage-report",
             description: "Don't send anonymous stats to the developers",
           },
+        },
+      ],
+    },
+    {
+      name: "scale",
+      description: "Scale a running test",
+      args: {
+        name: "scale",
+        description: "Scale a running test",
+      },
+      subcommands: [
+        {
+          name: "-h, --help",
+          description: "Help for scale",
+        },
+        {
+          name: "-m --max",
+          description: "Max avalible virtual users",
+          args: {
+            name: "max",
+            description: "Max avalible virtual users",
+          },
+        },
+        {
+          name: "-u --vus",
+          description: "Number of virtual users (default 1)",
+          args: {
+            name: "vus",
+            description: "Number of virtual users (default 1)",
+          },
+        },
+      ],
+    },
+    {
+      name: "stats",
+      description: "Show test metrics",
+      args: {
+        name: "stats",
+        description: "Show test metrics",
+      },
+      subcommands: [
+        {
+          name: "-h, --help",
+          description: "Help for stats",
+        },
+      ],
+    },
+    {
+      name: "status",
+      description: "Show test status",
+      args: {
+        name: "status",
+        description: "Show test status",
+      },
+      subcommands: [
+        {
+          name: "-h, --help",
+          description: "Help for status",
+        },
+      ],
+    },
+    {
+      name: "version",
+      description: "Show the application version and exit",
+      args: {
+        name: "version",
+        description: "Show the application version and exit",
+      },
+      subcommands: [
+        {
+          name: "-h, --help",
+          description: "Help for version",
         },
       ],
     },

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -488,7 +488,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "stats",
       description: "Show test metrics",
-      subcommands: [
+      options: [
         {
           name: "-h, --help",
           description: "Help for stats",

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -462,7 +462,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "scale",
       description: "Scale a running test",
-      subcommands: [
+      options: [
         {
           name: "-h, --help",
           description: "Help for scale",

--- a/src/k6.ts
+++ b/src/k6.ts
@@ -508,7 +508,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "version",
       description: "Show the application version and exit",
-      subcommands: [
+      options: [
         {
           name: "-h, --help",
           description: "Help for version",


### PR DESCRIPTION
Fix #1921 missing version flag, along that version missing, saw three more that were missing and added them.

-  Scale
-  Stats
- Status 
- Version

I didn't make this one from scratch, just followed the pattern that was created before.
Hope everything is correct, any issues, please let me know.
