### PR TITLE
fix(git): add new option to handle shorthand dash

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -4885,6 +4885,10 @@ const completionSpec: Fig.Spec = {
       description: "Reapply commits on top of another base tip",
       options: [
         {
+          name: "-",
+          description: "Rebase on the last checked out branch",
+        },
+        {
           name: "--onto",
           description:
             "Starting point at which to create the new commits. If the --onto option is not specified, the starting point is <upstream>. May be any valid commit, and not just an existing branch name. As a special case, you may use 'A...B' as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD",


### PR DESCRIPTION
## What does this PR introduces?
This PR adds support for shorthand `-` in git rebase command.

Fixes: #1942