### PR TITLE
feat(cdk): add some subcommand specs

### DIFF
--- a/src/cdk.ts
+++ b/src/cdk.ts
@@ -29,7 +29,7 @@ const completionSpec: Fig.Spec = {
       description:
         "Synthesizes and prints the CloudFormation template for this stack",
     },
-    { name: "ls", description: "List all stacks in the app" },
+    { name: ["ls", "list"], description: "List all stacks in the app" },
   ],
   options: [
     {

--- a/src/cdk.ts
+++ b/src/cdk.ts
@@ -30,6 +30,30 @@ const completionSpec: Fig.Spec = {
         "Synthesizes and prints the CloudFormation template for this stack",
     },
     { name: ["ls", "list"], description: "List all stacks in the app" },
+    {
+      name: "import",
+      description: "Import existing resource(s) into the given STACK",
+    },
+    {
+      name: "watch",
+      description: "Shortcut for 'deploy --watch'",
+    },
+    {
+      name: ["ack", "acknowledge"],
+      description: "Acknowledge a notice so that it does not show up anymore",
+    },
+    {
+      name: "notices",
+      description: "Returns a list of relevant notices",
+    },
+    {
+      name: "context",
+      description: "Manage cached context values",
+    },
+    {
+      name: ["doc", "docs"],
+      description: "Opens the reference documentation in a browser",
+    },
   ],
   options: [
     {

--- a/src/cdk.ts
+++ b/src/cdk.ts
@@ -25,7 +25,7 @@ const completionSpec: Fig.Spec = {
       description: "Deploys the CDK toolkit stack into an AWS environment",
     },
     {
-      name: "synth",
+      name: ["synth", "synthesize"],
       description:
         "Synthesizes and prints the CloudFormation template for this stack",
     },


### PR DESCRIPTION
We have added some additional AWS CDK subcommands compared to the current implementation.
Here is the latest list of subcommands.

```sh
cdk -h
Usage: cdk -a <cdk-app> COMMAND

Commands:
  cdk list [STACKS..]             Lists all stacks in the app      [aliases: ls]
  cdk synthesize [STACKS..]       Synthesizes and prints the CloudFormation
                                  template for this stack       [aliases: synth]
  cdk bootstrap [ENVIRONMENTS..]  Deploys the CDK toolkit stack into an AWS
                                  environment
  cdk deploy [STACKS..]           Deploys the stack(s) named STACKS into your
                                  AWS account
  cdk import [STACK]              Import existing resource(s) into the given
                                  STACK
  cdk watch [STACKS..]            Shortcut for 'deploy --watch'
  cdk destroy [STACKS..]          Destroy the stack(s) named STACKS
  cdk diff [STACKS..]             Compares the specified stack with the deployed
                                  stack or a local template file, and returns
                                  with status 1 if any difference is found
  cdk metadata [STACK]            Returns all metadata associated with this
                                  stack
  cdk acknowledge [ID]            Acknowledge a notice so that it does not show
                                  up anymore                      [aliases: ack]
  cdk notices                     Returns a list of relevant notices
  cdk init [TEMPLATE]             Create a new, empty CDK project from a
                                  template.
  cdk context                     Manage cached context values
  cdk docs                        Opens the reference documentation in a browser
                                                                  [aliases: doc]
  cdk doctor                      Check your set-up for potential problems

```