### PR TITLE
feat: add generate spec for serverless compose

### DIFF
--- a/src/serverless.ts
+++ b/src/serverless.ts
@@ -1,4 +1,4 @@
-// To learn more about Fig's autocomplete standard visit: https://fig.io/docs/concepts/cli-skeleton
+import YAML from "yaml";
 
 const options: Record<string, Fig.Option> = {
   awsProfile: {
@@ -403,6 +403,32 @@ const completionSpec: Fig.Spec = {
       description: "Enable or disable stats",
     },
   ],
+  generateSpec: async (tokens, executeShellCommand) => {
+    const serverlessCompose = await executeShellCommand(
+      "cat serverless-compose.yml"
+    );
+    const servicesObject = YAML.parse(serverlessCompose).services;
+    const services: string[] = Object.keys(servicesObject);
+    // Avoid infinite recursion of generated subcommands
+    if (services.includes(tokens[0])) {
+      return;
+    }
+
+    const subcommands: Fig.Subcommand[] = services.map((service) => ({
+      name: service,
+      description: tokens.join(","),
+      priority: 100,
+      loadSpec: "serverless",
+      icon: "fig://icon?type=box",
+    }));
+
+    if (subcommands.length > 0) {
+      return {
+        name: "serverless",
+        subcommands,
+      };
+    }
+  },
 };
 
 export default completionSpec;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
`serverless` compose commands are currently not-supported

**What is the new behavior (if this is a feature change)?**
 Autocompletion support for `serverless` compose commands

**Additional info:**

- [x] Create a generateSpec to suggest services defined in serverless-compose.yml