### PR TITLE
feat(go-task): get nested and root tasks

### DIFF
--- a/src/task/go-task.ts
+++ b/src/task/go-task.ts
@@ -14,13 +14,12 @@ const tasksGenerator: Fig.Generator = {
       .filter((task) => task.startsWith("*"))
       .map((task) => {
         const taskInfo = task.slice(2).trim();
-        const [name, ...description] = taskInfo.split(" ");
+        const [name, description] = taskInfo.split(": ");
 
         return {
           name: name.replace(/:$/, ""),
-
-          description: description.join(" ") || "Task",
-          icon: "🎯",
+          description: description?.trim(),
+          icon: "fig://icon?type=command",
           priority: TASKS_PRIORITY,
         };
       });
@@ -39,6 +38,10 @@ const completionSpec: Fig.Spec = {
     isOptional: true,
   },
   options: [
+    {
+      name: ["-a", "--list-all"],
+      description: "Lists tasks with or without a description",
+    },
     {
       name: ["-c", "--color"],
       description:


### PR DESCRIPTION
Current Fig Generator doesn't work when having nested Taskfiles and also doesn't list root tasks. 

### Before

I have my Taskfiles split in different files, and reference them all in one file at the root of my project, current autocompletion doesn't get the tasks in my root as nor the tasks until I get into the directory containing all my Taskfiles.  


https://github.com/withfig/autocomplete/assets/20308945/5bc2d32f-86db-48cf-8eef-4b552df91439

### After

My new approach works as expected with the root tasks while maintaining previous behavior


https://github.com/withfig/autocomplete/assets/20308945/f4661727-458c-42e0-9320-1b01c9382a1c


