### PR TITLE
feat(yarn): global upgrade-interactive --latest

### DIFF
--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -950,6 +950,12 @@ const completionSpec: Fig.Spec = {
           name: "upgrade-interactive",
           description:
             "Display the outdated packages before performing any upgrade",
+          options: [
+            {
+              name: "--latest",
+              description: "Use the version tagged latest in the registry",
+            },
+          ],
         },
       ],
       options: [


### PR DESCRIPTION
yarn's `upgrade-interactive` supports `--latest` both in the [local](https://classic.yarnpkg.com/en/docs/cli/upgrade-interactive) and [global](https://classic.yarnpkg.com/lang/en/docs/cli/global/) context, correcting this.

Tested the flag using Fig's dev mode as described in the [Getting Started guide](https://fig.io/docs/getting-started#testing-your-first-completion-spec).