### PR TITLE
deps: update config to fix dep version for new deps additions

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
 nodeLinker: node-modules
 
+defaultSemverRangePrefix: ""
 yarnPath: .yarn/releases/yarn-3.5.1.cjs


### PR DESCRIPTION
This is just a suggestion that when new packages are added to the repo they are fixed to specific version rather than using the caret (^) and allowing to install different minor versions. 

My reasons are: 

- Dependencies could could mess up semver and introduce breaking changes in minor/patches updates 
- Having fixed dependencies makes sure everyone contributing has the same exact versions, making it easier for everyone to debug
- Avoid constantly update `yarn.lock` when people install deps. Since minor versions are allowed `yarn.lock` changes unless contributors install deps with `--fozen-lockfile` flag (`yarn install --frozen-lockfile`)

**This just changes the behavior for new packages added. `package.json` would still need to be updated to remove the caret from all deps that have it, but first I wanted to introduce the idea of fixed versions before proceding to update `pacakge.json`**

