### PR TITLE
feat(docker-compose): add `--profile` suggestion

### DIFF
--- a/src/docker-compose.ts
+++ b/src/docker-compose.ts
@@ -1,15 +1,21 @@
+const getComposeCommand = (tokens: string[]) =>
+  tokens[0] === "docker" ? "docker compose" : "docker-compose";
+
+const extractFileArgs = (tokens: string[]): string => {
+  const files: string[] = [];
+  for (let i = 0; i < tokens.length - 1; i++) {
+    if (tokens[i] === "-f") {
+      files.push(tokens[i + 1]);
+      i += 1;
+    }
+  }
+  return files.map((f) => `-f ${f}`).join(" ");
+};
+
 const servicesGenerator: Fig.Generator = {
   script: (tokens) => {
-    const compose =
-      tokens[0] === "docker" ? "docker compose" : "docker-compose";
-    const files: string[] = [];
-    for (let i = 0; i < tokens.length - 1; i++) {
-      if (tokens[i] === "-f") {
-        files.push(tokens[i + 1]);
-        i += 1;
-      }
-    }
-    const fileArgs = files.map((f) => `-f ${f}`).join(" ");
+    const compose = getComposeCommand(tokens);
+    const fileArgs = extractFileArgs(tokens);
     return `${compose} ${fileArgs} config --services`;
   },
   splitOn: "\n",
@@ -17,16 +23,8 @@ const servicesGenerator: Fig.Generator = {
 
 const profilesGenerator: Fig.Generator = {
   script: (tokens) => {
-    const compose =
-      tokens[0] === "docker" ? "docker compose" : "docker-compose";
-    const files: string[] = [];
-    for (let i = 0; i < tokens.length - 1; i++) {
-      if (tokens[i] === "-f") {
-        files.push(tokens[i + 1]);
-        i += 1;
-      }
-    }
-    const fileArgs = files.map((f) => `-f ${f}`).join(" ");
+    const compose = getComposeCommand(tokens);
+    const fileArgs = extractFileArgs(tokens);
     return `${compose} ${fileArgs} config --profiles`;
   },
   splitOn: "\n",

--- a/src/docker-compose.ts
+++ b/src/docker-compose.ts
@@ -15,6 +15,23 @@ const servicesGenerator: Fig.Generator = {
   splitOn: "\n",
 };
 
+const profilesGenerator: Fig.Generator = {
+  script: (tokens) => {
+    const compose =
+      tokens[0] === "docker" ? "docker compose" : "docker-compose";
+    const files: string[] = [];
+    for (let i = 0; i < tokens.length - 1; i++) {
+      if (tokens[i] === "-f") {
+        files.push(tokens[i + 1]);
+        i += 1;
+      }
+    }
+    const fileArgs = files.map((f) => `-f ${f}`).join(" ");
+    return `${compose} ${fileArgs} config --profiles`;
+  },
+  splitOn: "\n",
+};
+
 const completionSpec: Fig.Spec = {
   name: "docker-compose",
   description: "Define and run multi-container applications with Docker",
@@ -998,6 +1015,7 @@ const completionSpec: Fig.Spec = {
       isRepeatable: true,
       args: {
         name: "profile",
+        generators: profilesGenerator,
       },
     },
     {


### PR DESCRIPTION
When using the `--profile` option in the `docker-compose` command, suggestions for the list of profiles are now provided.

In addition, some operations are common to the existing `servicesGenerator`, so they have been extracted into a function.