### PR TITLE
fix: update graphite (gt) cli spec

### DIFF
--- a/src/gt.ts
+++ b/src/gt.ts
@@ -1,27 +1,17 @@
-const submitOptions = [
+const submitOptions: Fig.Option[] = [
   {
-    name: ["--draft", "-d"],
+    name: "--always",
     description:
-      "If set, marks PR as draft. If --no-interactive is true, new PRs will be created in draft mode",
+      "Always push updates, even if the branch has not changed. Can be helpful for fixing an inconsistent Graphite stack view on Web/GitHub resulting from downtime/a bug",
   },
   {
-    name: ["--publish", "-p"],
+    name: "--branch",
     description:
-      "If set, publishes PR. If --no-interactive is true, new PRs will be created in draft mode",
-  },
-  {
-    name: ["--edit", "-e"],
-    description:
-      "Edit PR fields inline. If --no-interactive is true, this is automatically set to false",
-  },
-  {
-    name: ["--no-edit", "-n"],
-    description: "Don't edit PR fields inline. Takes precedence over --edit",
-  },
-  {
-    name: "--dry-run",
-    description:
-      "Reports the PRs that would be submitted and terminates. No branches are pushed and no PRs are opened or updated",
+      "Which branch to run this command from. Defaults to the current branch",
+    args: {
+      name: "branch",
+      description: "Name of branch",
+    },
   },
   {
     name: ["--confirm", "-c"],
@@ -29,18 +19,66 @@ const submitOptions = [
       "Reports the PRs that would be submitted and asks for confirmation before pushing branches and opening/updating PRs. If either of --no-interactive or --dry-run is passed, this flag is ignored",
   },
   {
-    name: ["--select", "-s"],
+    name: ["--draft", "-d"],
     description:
-      "Reports the PRs that would be submitted and asks the user to select which should be updated/created. If either of --no-interactive or --dry-run is passed, this flag is ignored",
+      "If set, marks PR as draft. If --no-interactive is true, new PRs will be created in draft mode",
   },
   {
-    name: ["--update-only", "-u"],
-    description: "Only update the PRs that have been already been submitted",
+    name: "--dry-run",
+    description:
+      "Reports the PRs that would be submitted and terminates. No branches are pushed and no PRs are opened or updated",
+  },
+  {
+    name: ["--edit", "-e"],
+    description:
+      "Input metadata for all PRs interactively. If neither --edit nor --no-edit is passed, only prompts for new PRs",
   },
   {
     name: ["--force", "-f"],
     description:
       "Force push: overwrites the remote branch with your local branch. Otherwise defaults to --force-with-lease",
+  },
+  {
+    name: ["--merge-when-ready", "-m"],
+    description:
+      "If set, marks all PRs being submitted as merge when ready, which will let them automatically merge as soon as all merge requirements are met",
+  },
+  {
+    name: ["--no-edit", "-n"],
+    description: "Don't edit PR fields inline. Takes precedence over --edit",
+  },
+  {
+    name: ["--publish", "-p"],
+    description:
+      "If set, publishes PR. If --no-interactive is true, new PRs will be created in draft mode",
+  },
+  {
+    name: "--rerequest-review",
+    description: "Rerequest review from current reviewers",
+  },
+  {
+    name: "--restack",
+    description:
+      "Restack branches before submitting. If there are conflicts, output the branch names that could not be restacked",
+  },
+  {
+    name: ["--reviewers", "-r"],
+    description:
+      "If set without an argument, prompt to manually set reviewers. Alternatively, accepts a comma separated string of reviewers",
+    args: {
+      name: "reviewers",
+      description: "Comma separated string of reviewers",
+      isOptional: true,
+    },
+  },
+  {
+    name: ["--stack", "-s"],
+    description:
+      "Submit descendants of the current branch in addition to its ancestors",
+  },
+  {
+    name: ["--update-only", "-u"],
+    description: "Only update the PRs that have been already been submitted",
   },
 ];
 
@@ -49,281 +87,35 @@ const completionSpec: Fig.Spec = {
   description: "Graphite.dev CLI",
   subcommands: [
     {
+      name: "aliases",
+      description: "Edit your command aliases",
+      options: [
+        {
+          name: "--reset",
+          description: "Reset your alias configuration",
+        },
+      ],
+    },
+    {
       name: "auth",
       description:
         "Add your auth token to enable Graphite CLI to create and update your PRs on GitHub",
       priority: 50,
-    },
-    {
-      name: ["branch", "b"],
-      description: "Commands that operate on your current branch",
-      requiresSubcommand: true,
-      subcommands: [
+      options: [
         {
-          name: ["bottom", "b"],
+          name: ["--token", "-t"],
           description:
-            "Switch to the first branch from trunk in the current stack",
-        },
-        {
-          name: ["checkout", "co"],
-          description:
-            "Switch to a branch. If no branch is provided, opens an interactive selector",
+            "Auth token. Get it from: https://app.graphite.dev/activate",
           args: {
-            name: "branch",
-            description: "Name of branch to checkout",
-            isOptional: true,
+            name: "token",
+            description: "Auth token",
           },
-          options: [
-            {
-              name: ["--show-untracked", "-u"],
-              description:
-                "Include untracked branched in interactive selection",
-            },
-          ],
-        },
-        {
-          name: ["create", "c"],
-          description:
-            "Create a new branch stacked on top of the current branch and commit staged changes. If no branch name is specified but a commit message is passed, generate a branch name from the commit message",
-          args: {
-            name: "name",
-            description: "Branch name",
-            isOptional: true,
-          },
-          options: [
-            {
-              name: ["--message", "-m"],
-              description:
-                "Commit staged changes on the new branch with this message",
-              args: {
-                name: "message",
-                description: "Commit message",
-              },
-            },
-            {
-              name: ["--all", "-a"],
-              description:
-                "Stage all unstaged changes on the new branch with this message",
-            },
-            {
-              name: ["--patch", "-p"],
-              description: "Pick hunks to stage before committing",
-            },
-            {
-              name: ["--insert", "-i"],
-              description:
-                "When true, any existing children of the current branch will become children of the new branch",
-            },
-          ],
-        },
-        {
-          name: ["delete", "dl"],
-          description:
-            "Delete a branch and its corresponding Graphite metadata",
-          args: {
-            name: "name",
-            description: "Branch name",
-          },
-          options: [
-            {
-              name: ["--force", "-f"],
-              description:
-                "Delete the branch even if it is not merged or closed",
-            },
-          ],
-        },
-        {
-          name: ["down", "d"],
-          description: "Switch to the parent of the current branch",
-          args: {
-            name: "steps",
-            description: "The number of levels to traverse downstack",
-            isOptional: true,
-            default: "1",
-          },
-          options: [
-            {
-              name: ["--steps", "-n"],
-              description: "The number of levels to traverse downstack",
-              args: {
-                name: "steps",
-                default: "1",
-              },
-            },
-          ],
-        },
-        {
-          name: ["edit", "e"],
-          description:
-            "Run an interactive rebase on the current branch's commits and restack upstack branches",
-        },
-        {
-          name: ["fold", "f"],
-          description:
-            "Fold a branch's changes into its parent, update dependencies of descendants of the new combined branch, and restack",
-          options: [
-            {
-              name: ["--keep", "-k"],
-              description:
-                "Keeps the name of the current branch instead of using the name of its parent",
-            },
-          ],
-        },
-        {
-          name: ["info", "i"],
-          description: "Display information about the current branch",
-          options: [
-            {
-              name: ["--patch", "-p"],
-              description: "Show the changes made by each commit",
-            },
-            {
-              name: ["--diff", "-d"],
-              description:
-                "Show the diff between this branch and its parent. Takes precedence over patch",
-            },
-            {
-              name: ["--body", "-b"],
-              description: "Show the PR body, if it exists",
-            },
-          ],
-        },
-        {
-          name: ["rename", "rn"],
-          description:
-            "Rename a branch and update metadata referencing it. If no branch name is supplied, you will be prompted for a new branch name. Note that this removes any associated GitHub pull request",
-          args: {
-            name: "name",
-            description: "Branch name",
-          },
-          options: [
-            {
-              name: ["--force", "-f"],
-              description:
-                "Allow renaming a branch that is already associated with an open GitHub pull request",
-            },
-          ],
-        },
-        {
-          name: ["restack", "r"],
-          description:
-            "Ensure the current branch is based on its parent, rebasing if necessary",
-        },
-        {
-          name: ["split", "sp"],
-          description:
-            "Split the current branch into multiple single-commit branches",
-          options: [
-            {
-              name: ["--by-commit", "--commit", "-c"],
-              description:
-                "Split by commit - slice up the history of this branch",
-            },
-            {
-              name: ["--by-hunk", "--hunk", "-h"],
-              description:
-                "Split by hunk - split into new single-commit branches",
-            },
-          ],
-        },
-        {
-          name: ["squash", "sq"],
-          description:
-            "Squash all commits in the current branch and restack upstack branches",
-          options: [
-            {
-              name: ["--message", "-m"],
-              description: "The updated message for the commit",
-              args: {
-                name: "message",
-                description: "Commit message",
-              },
-            },
-            {
-              name: "--edit",
-              description: "Modify the existing commit message",
-            },
-            {
-              name: ["--no-edit", "-n"],
-              description:
-                "Don't modify the existing commit message. Takes precedence over --edit",
-            },
-          ],
-        },
-        {
-          name: ["submit", "s"],
-          description:
-            "Idempotently force push the current branch to GitHub, creating or updating a pull request",
-          options: submitOptions,
-        },
-        {
-          name: ["top", "t"],
-          description:
-            "Switch to the tip branch of the current stack. Prompts if ambiguous",
-        },
-        {
-          name: ["track", "tr"],
-          description:
-            "Start tracking the current (or provided) branch with Graphite by selecting its parent. This command can also be used to fix corrupted Graphite metadata",
-          args: {
-            name: "branch",
-            description: "Branch name",
-          },
-          options: [
-            {
-              name: ["--parent", "-p"],
-              description:
-                "The tracked branch's parent. If unset, prompts for a parent branch",
-              args: {
-                name: "parent",
-                description: "Name of parent branch",
-              },
-            },
-            {
-              name: ["--force", "-f"],
-              description:
-                "Sets the parent to the most recent tracked ancestor of the branch being tracked. Takes precedence over `--parent`",
-            },
-          ],
-        },
-        {
-          name: ["untrack", "ut"],
-          description:
-            "Stop tracking a branch with Graphite. If the branch has children, they will also be untracked. Default to the current branch if none is passed in",
-          args: {
-            name: "branch",
-            description: "Branch name",
-          },
-          options: [
-            {
-              name: ["--force", "-f"],
-              description:
-                "Will not prompt for confirmation before untracking a branch with children",
-            },
-          ],
-        },
-        {
-          name: ["up", "u"],
-          description:
-            "Switch to the child of the current branch. Prompts if ambiguous",
-          args: {
-            name: "steps",
-            description: "The number of levels to traverse upstack",
-            isOptional: true,
-            default: "1",
-          },
-          options: [
-            {
-              name: ["--steps", "-n"],
-              description: "The number of levels to traverse upstack",
-              args: {
-                name: "steps",
-                default: "1",
-              },
-            },
-          ],
         },
       ],
+    },
+    {
+      name: ["bottom", "b"],
+      description: "Switch to the first branch from trunk in the current stack",
     },
     {
       name: "changelog",
@@ -331,67 +123,32 @@ const completionSpec: Fig.Spec = {
       priority: 50,
     },
     {
-      name: ["commit", "c"],
-      description: "Commands that operate on commits",
-      requiresSubcommand: true,
-      subcommands: [
+      name: ["checkout", "co"],
+      description:
+        "Switch to a branch. If no branch is provided, opens an interactive selector",
+      args: {
+        name: "branch",
+        description: "Name of branch to checkout",
+        isOptional: true,
+      },
+      options: [
         {
-          name: ["amend", "a"],
-          description:
-            "Amend the most recent commit and restack upstack branches",
-          options: [
-            {
-              name: ["--all", "-a"],
-              description: "Stage all changes before committing",
-            },
-            {
-              name: ["--message", "-m"],
-              description: "The updated message for the commit",
-              args: {
-                name: "message",
-              },
-            },
-            {
-              name: "--edit",
-              description: "Modify the existing commit message",
-            },
-            {
-              name: ["--patch", "-p"],
-              description: "Pick hunks to stage before amending",
-            },
-            {
-              name: ["--no-edit", "-n"],
-              description:
-                "Don't modify the existing commit message. Takes precedence over --edit",
-            },
-          ],
-        },
-        {
-          name: ["create", "c"],
-          description: "Create a new commit and restack upstack branches",
-          options: [
-            {
-              name: ["--all", "-a"],
-              description: "Stage all changes before committing",
-            },
-            {
-              name: ["--message", "-m"],
-              description: "The updated message for the commit",
-              args: {
-                name: "message",
-              },
-            },
-            {
-              name: ["--patch", "-p"],
-              description: "Pick hunks to stage before amending",
-            },
-          ],
+          name: ["--show-untracked", "-u"],
+          description: "Include untracked branched in interactive selection",
         },
       ],
     },
     {
+      name: "children",
+      description: "Show the children of the current branch",
+    },
+    {
       name: "completion",
       description: "Set up bash or zsh tab completion",
+    },
+    {
+      name: "config",
+      description: "Configure the Graphite CLI",
     },
     {
       name: ["continue", "cont"],
@@ -405,21 +162,55 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["dash", "d"],
-      description: "Open the web dashboard",
-      subcommands: [
+      name: ["create", "c"],
+      description:
+        "Create a new branch stacked on top of the current branch and commit staged changes. If no branch name is specified but a commit message is passed, generate a branch name from the commit message",
+      args: {
+        name: "name",
+        description: "Branch name",
+        isOptional: true,
+      },
+      options: [
         {
-          name: "d",
-          description: "Opens your Graphite dashboard in the web",
+          name: ["--message", "-m"],
+          description:
+            "Commit staged changes on the new branch with this message",
+          args: {
+            name: "message",
+            description: "Commit message",
+          },
         },
         {
-          name: ["pr", "p"],
+          name: ["--all", "-a"],
           description:
-            "Opens the PR page for the current (or provided) branch (or pr number)",
-          args: {
-            name: "pr",
-            isOptional: true,
-          },
+            "Stage all unstaged changes on the new branch with this message",
+        },
+        {
+          name: ["--patch", "-p"],
+          description: "Pick hunks to stage before committing",
+        },
+        {
+          name: ["--insert", "-i"],
+          description:
+            "When true, any existing children of the current branch will become children of the new branch",
+        },
+      ],
+    },
+    {
+      name: "dash",
+      description: "Open the web dashboard",
+    },
+    {
+      name: ["delete", "dl"],
+      description: "Delete a branch and its corresponding Graphite metadata",
+      args: {
+        name: "name",
+        description: "Branch name",
+      },
+      options: [
+        {
+          name: ["--force", "-f"],
+          description: "Delete the branch even if it is not merged or closed",
         },
       ],
     },
@@ -428,74 +219,22 @@ const completionSpec: Fig.Spec = {
       description: "Show the Graphite CLI docs",
     },
     {
-      name: ["downstack", "ds"],
-      description: "Commands that operate on a branch and its ancestors",
-      requiresSubcommand: true,
-      subcommands: [
+      name: ["down", "d"],
+      description: "Switch to the parent of the current branch",
+      args: {
+        name: "steps",
+        description: "The number of levels to traverse downstack",
+        isOptional: true,
+        default: "1",
+      },
+      options: [
         {
-          name: ["edit", "e"],
-          description:
-            "Edit the order of the branches between trunk and the current branch, restacking all of their descendants",
-        },
-        {
-          name: ["get", "g"],
-          description:
-            "Get branches from trunk to the specified branch from remote, prompting the user to resolve conflicts. If no branch is provided, get downstack from the current branch",
+          name: ["--steps", "-n"],
+          description: "The number of levels to traverse downstack",
           args: {
-            name: "branch",
-            description: "Name of branch",
-            isOptional: true,
+            name: "steps",
+            default: "1",
           },
-          options: [
-            {
-              name: ["--force", "-f"],
-              description:
-                "Overwrite all fetched branches with remote source of truth",
-            },
-          ],
-        },
-        {
-          name: ["restack", "r"],
-          description:
-            "From trunk to the current branch, ensure each is based on its parent, rebasing if necessary",
-        },
-        {
-          name: ["submit", "s"],
-          description:
-            "Idempotently force push all branches from trunk to the current branch to GitHub, creating or updating distinct pull requests for each",
-          options: submitOptions,
-        },
-        {
-          name: ["test", "t"],
-          description:
-            "From trunk to the current branch, run the provided command on each branch and aggregate the results",
-          args: {
-            name: "command",
-          },
-          options: [
-            {
-              name: ["--trunk", "-t"],
-              description:
-                "Run the command on the trunk branch in addition to the rest of the stack",
-            },
-          ],
-        },
-        {
-          name: ["track", "tr"],
-          description:
-            "Track a series of untracked branches, by specifying each's parent. Starts at the current (or provided) branch and stops when you reach a tracked branch",
-          args: {
-            name: "branch",
-            description: "Branch name",
-            isOptional: true,
-          },
-          options: [
-            {
-              name: ["--force", "-f"],
-              description:
-                "Sets the parent of each branch to the most recent ancestor without interactive selection",
-            },
-          ],
         },
       ],
     },
@@ -510,34 +249,92 @@ const completionSpec: Fig.Spec = {
       },
       options: [
         {
+          name: "--print-debug-context",
+          description:
+            "Print a debug summary of your repository. Useful for creating bug report details",
+        },
+        {
           name: "--with-debug-context",
           description:
             "Include a blob of json describing your repo's state to help with debugging. Run 'gt feedback debug-context' to see what would be included",
         },
       ],
-      subcommands: [
+    },
+    {
+      name: "fish",
+      description: "Set up 'fish' tab completion",
+    },
+    {
+      name: ["fold", "f"],
+      description:
+        "Fold a branch's changes into its parent, update dependencies of descendants of the new combined branch, and restack",
+      options: [
         {
-          name: "debug-context",
+          name: ["--keep", "-k"],
           description:
-            "Print a debug summary of your repo. Useful for creating bug report details",
-          options: [
-            {
-              name: ["--recreate", "-r"],
-              description:
-                "Accepts a json block created by `gt feedback state`. Recreates a debug repo in a temp folder with a commit tree matching the state JSON",
-              args: {
-                name: "json",
-              },
-            },
-            {
-              name: ["--recreate-from-file", "-f"],
-              description:
-                "Accepts a file containing a json block created by `gt feedback state`. Recreates a debug repo in a temp folder with a commit tree matching the state JSON",
-              args: {
-                name: "file",
-              },
-            },
-          ],
+            "Keeps the name of the current branch instead of using the name of its parent",
+        },
+      ],
+    },
+    {
+      name: "get",
+      description:
+        "Get branches from trunk to the specified branch from remote, prompting the user to resolve conflicts. If no branch is provided, get downstack from the current branch",
+      args: {
+        name: "branch",
+        description: "Branch to get from remote",
+        isOptional: true,
+      },
+      options: [
+        {
+          name: ["--force", "-f"],
+          description:
+            "Overwrite all fetched branches with remote source of truth",
+        },
+      ],
+    },
+    {
+      name: ["info", "i"],
+      description: "Display information about the current branch",
+      options: [
+        {
+          name: ["--patch", "-p"],
+          description: "Show the changes made by each commit",
+        },
+        {
+          name: ["--diff", "-d"],
+          description:
+            "Show the diff between this branch and its parent. Takes precedence over patch",
+        },
+        {
+          name: ["--body", "-b"],
+          description: "Show the PR body, if it exists",
+        },
+        {
+          name: ["--stat", "-s"],
+          description:
+            "Show a diffstat instead of a full diff. Modifies either --patch or --diff. If neither is passed, implies --diff",
+        },
+      ],
+    },
+    {
+      name: "init",
+      description:
+        "Initialize Graphite in this repository by selecting a trunk branch. Can also be used to change the trunk branch of the repository",
+      options: [
+        {
+          name: "--reset",
+          description: "Untrack all branches",
+        },
+        {
+          name: "--trunk",
+          description:
+            "The name of your trunk branch. If no name is passed, you will be prompted to select one interactively",
+          args: {
+            name: "trunk",
+            description: "Name of the trunk branch",
+            isOptional: true,
+          },
         },
       ],
     },
@@ -546,9 +343,18 @@ const completionSpec: Fig.Spec = {
       description: "Commands that log your stacks",
       options: [
         {
+          name: "--classic",
+          description:
+            "Use the old short logging style, which runs out of screen real estate more quickly. Other options will not work in classic mode",
+        },
+        {
           name: ["--reverse", "-r"],
           description:
             "Print the log upside down. Handy when you have a lot of branches",
+        },
+        {
+          name: ["--show-untracked", "-u"],
+          description: "Include untracked branched in interactive selection",
         },
         {
           name: ["--stack", "-s"],
@@ -563,10 +369,6 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "Number of steps",
           },
-        },
-        {
-          name: ["--show-untracked", "-u"],
-          description: "Include untracked branched in interactive selection",
         },
       ],
       subcommands: [
@@ -587,325 +389,310 @@ const completionSpec: Fig.Spec = {
       ],
     },
     {
-      name: ["repo", "r"],
+      name: "merge",
       description:
-        "Read or write Graphite's configuration settings for the current repo",
-      requiresSubcommand: true,
-      subcommands: [
+        "Merge the pull requests associated with all branches from trunk to the current branch via Graphite",
+      options: [
         {
-          name: ["init", "i"],
-          description: "Create or regenerate a `.graphite_repo_config` file",
-          options: [
-            {
-              name: "--trunk",
-              description: "The name of your trunk branch",
-              args: {
-                name: "name",
-              },
-            },
-            {
-              name: "--reset",
-              description: "Untrack all branches",
-            },
-          ],
-        },
-        {
-          name: "name",
-          description: "The current repo's name stored in Graphite",
-          options: [
-            {
-              name: ["--set", "-s"],
-              description:
-                "Override the value of the repo's name in the Graphite config. This is expected to match the name of the repo on GitHub and should only be set in cases where Graphite is incorrectly inferring the repo name",
-              args: {
-                name: "name",
-              },
-            },
-          ],
-        },
-        {
-          name: "owner",
-          description: "The current repo owner's name stored in Graphite",
-          options: [
-            {
-              name: ["--set", "-s"],
-              description:
-                "Override the value of the repo owner's name in the Graphite config. This is expected to match the name of the repo owner on GitHub and should only be set in cases where Graphite is incorrectly inferring the repo owner's name",
-              args: {
-                name: "name",
-              },
-            },
-          ],
-        },
-        {
-          name: "pr-templates",
+          name: ["--confirm", "-c"],
           description:
-            "A list of your GitHub PR templates. These are used to pre-fill the bodies of your PRs created using the submit command",
+            "Asks for confirmation before merging branches. Prompts for confirmation if the local branches differ from remote, regardless of the value of this flag",
         },
         {
-          name: "remote",
+          name: "--dry-run",
           description:
-            "Specifies the remote that graphite pushes to/pulls from (defaults to 'origin')",
-          options: [
-            {
-              name: ["--set", "-s"],
-              description:
-                "Override the name of the remote repository. Only set this if you are using a remote other than 'origin'",
-              args: {
-                name: "name",
-              },
-            },
-          ],
-        },
-        {
-          name: ["sync", "s"],
-          description:
-            "Pull the trunk branch from remote and delete any branches that have been merged",
-          options: [
-            {
-              name: ["--pull", "-p"],
-              description: "Pull the trunk branch from remote",
-            },
-            {
-              name: ["--delete", "-d"],
-              description: "Delete branches which have been merged",
-            },
-            {
-              name: "--show-delete-progress",
-              description: "Show progress through merged branches",
-            },
-            {
-              name: ["--force", "-f"],
-              description:
-                "Don't prompt for confirmation before deleting a branch",
-            },
-            {
-              name: ["--restack", "-r"],
-              description:
-                "Restack the current stack and any stacks with deleted branches",
-            },
-          ],
+            "Reports the PRs that would be merged and terminates. No branches are merged",
         },
       ],
     },
     {
-      name: ["stack", "s"],
-      description: "Commands that operate on your current stack of branches",
-      requiresSubcommand: true,
-      subcommands: [
+      name: ["modify", "m"],
+      description:
+        "Modify the current branch by amending its commit or creating a new commit. Automatically restacks descendants. If you have any unstaged changes, you will be asked whether you'd like to stage them",
+      options: [
         {
-          name: ["restack", "r", "fix", "f"],
-          description:
-            "Ensure each branch in the current stack is based on its parent, rebasing if necessary",
+          name: ["--all", "-a"],
+          description: "Stage all changes before committing",
         },
         {
-          name: ["submit", "s"],
+          name: ["--commit", "-c"],
           description:
-            "Idempotently force push all branches in the current stack to GitHub, creating or updating distinct pull requests for each",
-          options: submitOptions,
+            "Create a new commit instead of amending the current commit. If this branch has no commits, this command always creates a new commit",
         },
         {
-          name: ["test", "t"],
+          name: ["--edit", "-e"],
           description:
-            "Run the provided command on each branch in the current stack and aggregate the results",
+            "If passed, open an editor to edit the commit message. When creating a new commit, this flag is ignored",
+        },
+        {
+          name: "--interactive-rebase",
+          description:
+            "Ignore all other flags and start a git interactive rebase on the commits in this branch",
+        },
+        {
+          name: ["--message", "-m"],
+          description:
+            "The message for the new or amended commit. If passed, no editor is opened",
           args: {
-            name: "command",
+            name: "message",
+            description: "Commit message",
           },
-          options: [
-            {
-              name: ["--trunk", "-t"],
-              description:
-                "Run the command on the trunk branch in addition to the rest of the stack",
-            },
-          ],
+        },
+        {
+          name: ["--patch", "-p"],
+          description: "Pick hunks to stage before committing",
         },
       ],
     },
     {
-      name: ["upstack", "us"],
-      description: "Commands that operate on a branch and its descendants",
-      requiresSubcommand: true,
-      subcommands: [
+      name: "move",
+      description:
+        "Rebase the current branch onto the target branch and restack all of its descendants. If no branch is passed in, opens an interactive selector",
+      options: [
         {
-          name: ["onto", "o"],
-          description:
-            "Rebase the current branch onto the latest commit of the target branch and restack all of its descendants. If no branch is passed in, opens an interactive selector",
+          name: ["--onto", "-o"],
+          description: "Branch to move the current branch onto",
           args: {
             name: "branch",
-            description: "Name of branch",
-            isOptional: true,
+            description: "Branch to move",
           },
         },
         {
-          name: ["restack", "r", "fix", "f"],
-          description:
-            "Ensure each branch in the current stack is based on its parent, rebasing if necessary",
-        },
-        {
-          name: ["submit", "s"],
-          description:
-            "Idempotently force push all branches in the current stack to GitHub, creating or updating distinct pull requests for each",
-          options: submitOptions,
-        },
-        {
-          name: ["test", "t"],
-          description:
-            "Run the provided command on each branch in the current stack and aggregate the results",
+          name: "--source",
+          description: "Branch to move (defaults to current branch)",
           args: {
-            name: "command",
+            name: "branch",
+            description: "Branch to move",
           },
-          options: [
-            {
-              name: ["--trunk", "-t"],
-              description:
-                "Run the command on the trunk branch in addition to the rest of the stack",
-            },
-          ],
         },
       ],
     },
     {
-      name: "user",
-      description: "Read or write Graphite's user configuration settings",
-      requiresSubcommand: true,
-      subcommands: [
+      name: "parent",
+      description: "Show the parent of the current branch",
+    },
+    {
+      name: "pop",
+      description:
+        "Delete the current branch but reaint the state of files in the working tree",
+    },
+    {
+      name: "pr",
+      description:
+        "Opens the pull request page for a branch or PR number. If no branch is passed, the current branch's PR is opened",
+      args: {
+        name: "branch",
+        description: "A branch name or PR number to open",
+      },
+    },
+    {
+      name: ["rename", "rn"],
+      description:
+        "Rename a branch and update metadata referencing it. If no branch name is supplied, you will be prompted for a new branch name. Note that this removes any associated GitHub pull request",
+      args: {
+        name: "name",
+        description: "Branch name",
+      },
+      options: [
         {
-          name: "branch-date",
+          name: ["--force", "-f"],
           description:
-            "Toggle prepending date to auto-generated branch names on branch creation",
-          options: [
-            {
-              name: "--enable",
-              description: "Enable date in auto-generated branch names",
-            },
-            {
-              name: "--disable",
-              description: "Disable date in auto-generated branch names",
-            },
-          ],
+            "Allow renaming a branch that is already associated with an open GitHub pull request",
         },
+      ],
+    },
+    {
+      name: "reorder",
+      description:
+        "Reorder branches between trunk and the current branch, restacking all of their descendants. Opens an editor where you can reorder branches by moving around a line corresponding to each branch",
+    },
+    {
+      name: ["restack", "r"],
+      description:
+        "Ensure the current branch is based on its parent, rebasing if necessary. If conflicts are encountered, you will be prompted to resolve them via an interactive Git rebase",
+      options: [
         {
-          name: "branch-prefix",
+          name: "--branch",
           description:
-            "The prefix which Graphite will prepend to generated branch names",
-          options: [
-            {
-              name: ["--set", "-s"],
-              description: "Set a new prefix for branch names",
-              args: {
-                name: "value",
-              },
-            },
-            {
-              name: ["--reset", "-r"],
-              description:
-                "Turn off branch prefixing. Takes precendence over --set",
-            },
-          ],
+            "Which branch to run this command from. Defaults to the current branch",
+          args: {
+            name: "branch",
+            description: "Name of the branch",
+          },
         },
         {
-          name: "branch-replacement",
+          name: "--downstack",
+          description: "Only restack this branch and its ancestors",
+        },
+        {
+          name: "--only",
+          description: "Only restack this branch",
+        },
+        {
+          name: "--upstack",
+          description: "Only restack this branch and its descendants",
+        },
+      ],
+    },
+    {
+      name: "revert",
+      description:
+        "Create a branch that reverts a commit on the trunk branch. Currently experimental",
+      args: {
+        name: "sha",
+        description: "The commit to revert",
+      },
+      options: [
+        {
+          name: ["--edit", "-e"],
+          description: "Edit the commit message",
+        },
+      ],
+    },
+    {
+      name: ["split", "sp"],
+      description:
+        "Split the current branch into multiple single-commit branches",
+      options: [
+        {
+          name: ["--by-commit", "--commit", "-c"],
+          description: "Split by commit - slice up the history of this branch",
+        },
+        {
+          name: ["--by-hunk", "--hunk", "-h"],
+          description: "Split by hunk - split into new single-commit branches",
+        },
+      ],
+    },
+    {
+      name: ["squash", "sq"],
+      description:
+        "Squash all commits in the current branch and restack upstack branches",
+      options: [
+        {
+          name: ["--message", "-m"],
+          description: "The updated message for the commit",
+          args: {
+            name: "message",
+            description: "Commit message",
+          },
+        },
+        {
+          name: "--edit",
+          description: "Modify the existing commit message",
+        },
+        {
+          name: ["--no-edit", "-n"],
           description:
-            "The character that will replace unsupported characters in generated branch names",
-          options: [
-            {
-              name: "--set-underscore",
-              description: "Use underscore (_) as the replacement character",
-            },
-            {
-              name: "--set-dash",
-              description: "Use dash (-) as the replacement character",
-            },
-            {
-              name: "--set-empty",
-              description:
-                "Remove invalid characters from the branch name without replacing them",
-            },
-          ],
+            "Don't modify the existing commit message. Takes precedence over --edit",
         },
+      ],
+    },
+    {
+      name: ["submit", "s"],
+      description:
+        "Idempotently force push the current branch to GitHub, creating or updating a pull request.  Opens an interactive prompt that allows you to input pull request metadata. 'gt ss' is a default alias for 'gt submit --stack'",
+      options: submitOptions,
+    },
+    {
+      name: "sync",
+      description:
+        "Pull the trunk branch from remote and prompt to delete any branches that have been merged. Restacks all branches in your repository that can be restacked without conflicts. If trunk cannot be fast-forwarded to match remote, overwrites trunk with the remote version",
+      options: [
         {
-          name: "editor",
-          description: "The editor opened by Graphite",
-          options: [
-            {
-              name: "--set",
-              description: "Set default editor for Graphite. eg --set vim",
-              args: {
-                name: "value",
-                default: "",
-                isOptional: true,
-              },
-            },
-            {
-              name: "--unset",
-              description: "Unset default editor for Graphite",
-            },
-          ],
-        },
-        {
-          name: "pager",
-          description: "The pager opened by Graphite",
-          options: [
-            {
-              name: "--set",
-              description:
-                'Set default pager for Graphite. e.g. --set "less -FRX"',
-              args: {
-                name: "value",
-              },
-            },
-            {
-              name: "--disable",
-              description: "Disable pager for Graphite",
-            },
-            {
-              name: "--unset",
-              description:
-                "Unset default pager for Graphite and default to git pager",
-            },
-          ],
-        },
-        {
-          name: "restack-date",
+          name: "--delete",
           description:
-            "Configure how committer date is handled by restack internal rebases",
-          options: [
-            {
-              name: "--use-author-date",
-              description:
-                "Passes `--committer-date-is-author-date` to the internal git rebase for restack operations. Instead of using the current time as the committer date, use the author date of the commit being rebased as the committer date. To return to default behavior, pass in `--no-use-author-date`",
-            },
-          ],
+            "Delete merged branches (true by default; skip with --no-delete)",
         },
         {
-          name: "submit-body",
-          description: "Options for default PR descriptions",
-          options: [
-            {
-              name: "--include-commit-messages",
-              description:
-                "Include commit messages in PR body by default. Disable with --no-include-commit-messages",
-            },
-            {
-              name: "--no-include-commit-messages",
-              description:
-                "Disable include commit messages in PR body by default",
-            },
-          ],
+          name: ["--force", "-f"],
+          description:
+            "Don't prompt for confirmation before deleting a branch or overwriting trunk to match remote if it can't be fast-forwarded",
         },
         {
-          name: "tips",
-          description: "Show tips while using Graphite",
-          options: [
-            {
-              name: "--enable",
-              description: "Enable tips",
-            },
-            {
-              name: "--disable",
-              description: "Disable tips",
-            },
-          ],
+          name: "--pull",
+          description:
+            "Pull the trunk branch from remote (true by default; skip with --no-pull)",
+        },
+        {
+          name: "--restack",
+          description:
+            "Restack any branches that can be restacked without conflicts (true by default; skip with --no-restack)",
+        },
+        {
+          name: "--show-delete-progress",
+          description: "Show progress through merged branches",
+        },
+      ],
+    },
+    {
+      name: ["top", "t"],
+      description:
+        "Switch to the tip branch of the current stack. Prompts if ambiguous",
+    },
+    {
+      name: ["track", "tr"],
+      description:
+        "Start tracking the current (or provided) branch with Graphite by selecting its parent. This command can also be used to fix corrupted Graphite metadata",
+      args: {
+        name: "branch",
+        description: "Branch name",
+      },
+      options: [
+        {
+          name: ["--parent", "-p"],
+          description:
+            "The tracked branch's parent. If unset, prompts for a parent branch",
+          args: {
+            name: "parent",
+            description: "Name of parent branch",
+          },
+        },
+        {
+          name: ["--force", "-f"],
+          description:
+            "Sets the parent to the most recent tracked ancestor of the branch being tracked. Takes precedence over `--parent`",
+        },
+      ],
+    },
+    {
+      name: "trunk",
+      description: "Switch to the trunk branch",
+    },
+    {
+      name: ["untrack", "utr"],
+      description:
+        "Stop tracking a branch with Graphite. If the branch has children, they will also be untracked. Default to the current branch if none is passed in",
+      args: {
+        name: "branch",
+        description: "Branch name",
+      },
+      options: [
+        {
+          name: ["--force", "-f"],
+          description:
+            "Will not prompt for confirmation before untracking a branch with children",
+        },
+      ],
+    },
+    {
+      name: ["up", "u"],
+      description:
+        "Switch to the child of the current branch. Prompts if ambiguous",
+      args: {
+        name: "steps",
+        description: "The number of levels to traverse upstack",
+        isOptional: true,
+        default: "1",
+      },
+      options: [
+        {
+          name: ["--steps", "-n"],
+          description: "The number of levels to traverse upstack",
+          args: {
+            name: "steps",
+            default: "1",
+          },
         },
       ],
     },
@@ -937,7 +724,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["--quiet", "-q"],
-      description: "Minimize output to the terminal",
+      description: "Minimize output to the terminal. Implies --no-interactive",
       priority: 10,
       isPersistent: true,
     },
@@ -956,6 +743,12 @@ const completionSpec: Fig.Spec = {
     {
       name: "--debug",
       description: "Display debug output",
+      priority: 10,
+      isPersistent: true,
+    },
+    {
+      name: "--cwd",
+      description: "Working directory in which to perform operations",
       priority: 10,
       isPersistent: true,
     },


### PR DESCRIPTION
Thanks for the great CLI tool 🙌 

This PR will update the spec for the [graphite CLI](https://graphite.dev/docs/command-reference) - adding new commands or removed now unused commands.
Also cohered to the alphabetical ordering of the commands (not necessarily of all subcommands) and added a bit more type safety to the `submitOptions`.

The changes look more extreme than they actually are, most of the new commands were subcommands before.
To check against the original list, here's the link to the graphite docs: https://graphite.dev/docs/command-reference

Closes #2093 