### PR TITLE
feat(bun): add subcommands, options, logo

### DIFF
--- a/src/bun.ts
+++ b/src/bun.ts
@@ -7,6 +7,9 @@ import {
 import { npxSuggestions } from "./npx";
 import { createCLIsGenerator } from "./yarn";
 
+const icon =
+  "data:image/svg+xml;base64,PHN2ZyBpZD0iQnVuIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4MCA3MCI+PHRpdGxlPkJ1biBMb2dvPC90aXRsZT48cGF0aCBpZD0iU2hhZG93IiBkPSJNNzEuMDksMjAuNzRjLS4xNi0uMTctLjMzLS4zNC0uNS0uNXMtLjMzLS4zNC0uNS0uNS0uMzMtLjM0LS41LS41LS4zMy0uMzQtLjUtLjUtLjMzLS4zNC0uNS0uNS0uMzMtLjM0LS41LS41LS4zMy0uMzQtLjUtLjVBMjYuNDYsMjYuNDYsMCwwLDEsNzUuNSwzNS43YzAsMTYuNTctMTYuODIsMzAuMDUtMzcuNSwzMC4wNS0xMS41OCwwLTIxLjk0LTQuMjMtMjguODMtMTAuODZsLjUuNS41LjUuNS41LjUuNS41LjUuNS41LjUuNUMxOS41NSw2NS4zLDMwLjE0LDY5Ljc1LDQyLDY5Ljc1YzIwLjY4LDAsMzcuNS0xMy40OCwzNy41LTMwQzc5LjUsMzIuNjksNzYuNDYsMjYsNzEuMDksMjAuNzRaIi8+PGcgaWQ9IkJvZHkiPjxwYXRoIGlkPSJCYWNrZ3JvdW5kIiBkPSJNNzMsMzUuN2MwLDE1LjIxLTE1LjY3LDI3LjU0LTM1LDI3LjU0UzMsNTAuOTEsMywzNS43QzMsMjYuMjcsOSwxNy45NCwxOC4yMiwxM1MzMy4xOCwzLDM4LDNzOC45NCw0LjEzLDE5Ljc4LDEwQzY3LDE3Ljk0LDczLDI2LjI3LDczLDM1LjdaIiBzdHlsZT0iZmlsbDojZmJmMGRmIi8+PHBhdGggaWQ9IkJvdHRvbV9TaGFkb3ciIGRhdGEtbmFtZT0iQm90dG9tIFNoYWRvdyIgZD0iTTczLDM1LjdhMjEuNjcsMjEuNjcsMCwwLDAtLjgtNS43OGMtMi43MywzMy4zLTQzLjM1LDM0LjktNTkuMzIsMjQuOTRBNDAsNDAsMCwwLDAsMzgsNjMuMjRDNTcuMyw2My4yNCw3Myw1MC44OSw3MywzNS43WiIgc3R5bGU9ImZpbGw6I2Y2ZGVjZSIvPjxwYXRoIGlkPSJMaWdodF9TaGluZSIgZGF0YS1uYW1lPSJMaWdodCBTaGluZSIgZD0iTTI0LjUzLDExLjE3QzI5LDguNDksMzQuOTQsMy40Niw0MC43OCwzLjQ1QTkuMjksOS4yOSwwLDAsMCwzOCwzYy0yLjQyLDAtNSwxLjI1LTguMjUsMy4xMy0xLjEzLjY2LTIuMywxLjM5LTMuNTQsMi4xNS0yLjMzLDEuNDQtNSwzLjA3LTgsNC43QzguNjksMTguMTMsMywyNi42MiwzLDM1LjdjMCwuNCwwLC44LDAsMS4xOUM5LjA2LDE1LjQ4LDIwLjA3LDEzLjg1LDI0LjUzLDExLjE3WiIgc3R5bGU9ImZpbGw6I2ZmZmVmYyIvPjxwYXRoIGlkPSJUb3AiIGQ9Ik0zNS4xMiw1LjUzQTE2LjQxLDE2LjQxLDAsMCwxLDI5LjQ5LDE4Yy0uMjguMjUtLjA2LjczLjMuNTksMy4zNy0xLjMxLDcuOTItNS4yMyw2LTEzLjE0QzM1LjcxLDUsMzUuMTIsNS4xMiwzNS4xMiw1LjUzWm0yLjI3LDBBMTYuMjQsMTYuMjQsMCwwLDEsMzksMTljLS4xMi4zNS4zMS42NS41NS4zNkM0MS43NCwxNi41Niw0My42NSwxMSwzNy45Myw1LDM3LjY0LDQuNzQsMzcuMTksNS4xNCwzNy4zOSw1LjQ5Wm0yLjc2LS4xN0ExNi40MiwxNi40MiwwLDAsMSw0NywxNy4xMmEuMzMuMzMsMCwwLDAsLjY1LjExYy45Mi0zLjQ5LjQtOS40NC03LjE3LTEyLjUzQzQwLjA4LDQuNTQsMzkuODIsNS4wOCw0MC4xNSw1LjMyWk0yMS42OSwxNS43NmExNi45NCwxNi45NCwwLDAsMCwxMC40Ny05Yy4xOC0uMzYuNzUtLjIyLjY2LjE4LTEuNzMsOC03LjUyLDkuNjctMTEuMTIsOS40NUMyMS4zMiwxNi40LDIxLjMzLDE1Ljg3LDIxLjY5LDE1Ljc2WiIgc3R5bGU9ImZpbGw6I2NjYmVhNztmaWxsLXJ1bGU6ZXZlbm9kZCIvPjxwYXRoIGlkPSJPdXRsaW5lIiBkPSJNMzgsNjUuNzVDMTcuMzIsNjUuNzUuNSw1Mi4yNy41LDM1LjdjMC0xMCw2LjE4LTE5LjMzLDE2LjUzLTI0LjkyLDMtMS42LDUuNTctMy4yMSw3Ljg2LTQuNjIsMS4yNi0uNzgsMi40NS0xLjUxLDMuNi0yLjE5QzMyLDEuODksMzUsLjUsMzgsLjVzNS42MiwxLjIsOC45LDMuMTRjMSwuNTcsMiwxLjE5LDMuMDcsMS44NywyLjQ5LDEuNTQsNS4zLDMuMjgsOSw1LjI3QzY5LjMyLDE2LjM3LDc1LjUsMjUuNjksNzUuNSwzNS43LDc1LjUsNTIuMjcsNTguNjgsNjUuNzUsMzgsNjUuNzVaTTM4LDNjLTIuNDIsMC01LDEuMjUtOC4yNSwzLjEzLTEuMTMuNjYtMi4zLDEuMzktMy41NCwyLjE1LTIuMzMsMS40NC01LDMuMDctOCw0LjdDOC42OSwxOC4xMywzLDI2LjYyLDMsMzUuNywzLDUwLjg5LDE4LjcsNjMuMjUsMzgsNjMuMjVTNzMsNTAuODksNzMsMzUuN0M3MywyNi42Miw2Ny4zMSwxOC4xMyw1Ny43OCwxMyw1NCwxMSw1MS4wNSw5LjEyLDQ4LjY2LDcuNjRjLTEuMDktLjY3LTIuMDktMS4yOS0zLTEuODRDNDIuNjMsNCw0MC40MiwzLDM4LDNaIi8+PC9nPjxnIGlkPSJNb3V0aCI+PGcgaWQ9IkJhY2tncm91bmQtMiIgZGF0YS1uYW1lPSJCYWNrZ3JvdW5kIj48cGF0aCBkPSJNNDUuMDUsNDNhOC45Myw4LjkzLDAsMCwxLTIuOTIsNC43MSw2LjgxLDYuODEsMCwwLDEtNCwxLjg4QTYuODQsNi44NCwwLDAsMSwzNCw0Ny43MSw4LjkzLDguOTMsMCwwLDEsMzEuMTIsNDNhLjcyLjcyLDAsMCwxLC44LS44MUg0NC4yNkEuNzIuNzIsMCwwLDEsNDUuMDUsNDNaIiBzdHlsZT0iZmlsbDojYjcxNDIyIi8+PC9nPjxnIGlkPSJUb25ndWUiPjxwYXRoIGlkPSJCYWNrZ3JvdW5kLTMiIGRhdGEtbmFtZT0iQmFja2dyb3VuZCIgZD0iTTM0LDQ3Ljc5YTYuOTEsNi45MSwwLDAsMCw0LjEyLDEuOSw2LjkxLDYuOTEsMCwwLDAsNC4xMS0xLjksMTAuNjMsMTAuNjMsMCwwLDAsMS0xLjA3LDYuODMsNi44MywwLDAsMC00LjktMi4zMSw2LjE1LDYuMTUsMCwwLDAtNSwyLjc4QzMzLjU2LDQ3LjQsMzMuNzYsNDcuNiwzNCw0Ny43OVoiIHN0eWxlPSJmaWxsOiNmZjYxNjQiLz48cGF0aCBpZD0iT3V0bGluZS0yIiBkYXRhLW5hbWU9Ik91dGxpbmUiIGQ9Ik0zNC4xNiw0N2E1LjM2LDUuMzYsMCwwLDEsNC4xOS0yLjA4LDYsNiwwLDAsMSw0LDEuNjljLjIzLS4yNS40NS0uNTEuNjYtLjc3YTcsNywwLDAsMC00LjcxLTEuOTMsNi4zNiw2LjM2LDAsMCwwLTQuODksMi4zNkE5LjUzLDkuNTMsMCwwLDAsMzQuMTYsNDdaIi8+PC9nPjxwYXRoIGlkPSJPdXRsaW5lLTMiIGRhdGEtbmFtZT0iT3V0bGluZSIgZD0iTTM4LjA5LDUwLjE5YTcuNDIsNy40MiwwLDAsMS00LjQ1LTIsOS41Miw5LjUyLDAsMCwxLTMuMTEtNS4wNSwxLjIsMS4yLDAsMCwxLC4yNi0xLDEuNDEsMS40MSwwLDAsMSwxLjEzLS41MUg0NC4yNmExLjQ0LDEuNDQsMCwwLDEsMS4xMy41MSwxLjE5LDEuMTksMCwwLDEsLjI1LDFoMGE5LjUyLDkuNTIsMCwwLDEtMy4xMSw1LjA1QTcuNDIsNy40MiwwLDAsMSwzOC4wOSw1MC4xOVptLTYuMTctNy40Yy0uMTYsMC0uMi4wNy0uMjEuMDlhOC4yOSw4LjI5LDAsMCwwLDIuNzMsNC4zN0E2LjIzLDYuMjMsMCwwLDAsMzguMDksNDlhNi4yOCw2LjI4LDAsMCwwLDMuNjUtMS43Myw4LjMsOC4zLDAsMCwwLDIuNzItNC4zNy4yMS4yMSwwLDAsMC0uMi0uMDlaIi8+PC9nPjxnIGlkPSJGYWNlIj48ZWxsaXBzZSBpZD0iUmlnaHRfQmx1c2giIGRhdGEtbmFtZT0iUmlnaHQgQmx1c2giIGN4PSI1My4yMiIgY3k9IjQwLjE4IiByeD0iNS44NSIgcnk9IjMuNDQiIHN0eWxlPSJmaWxsOiNmZWJiZDAiLz48ZWxsaXBzZSBpZD0iTGVmdF9CbHVjaCIgZGF0YS1uYW1lPSJMZWZ0IEJsdWNoIiBjeD0iMjIuOTUiIGN5PSI0MC4xOCIgcng9IjUuODUiIHJ5PSIzLjQ0IiBzdHlsZT0iZmlsbDojZmViYmQwIi8+PHBhdGggaWQ9IkV5ZXMiIGQ9Ik0yNS43LDM4LjhhNS41MSw1LjUxLDAsMSwwLTUuNS01LjUxQTUuNTEsNS41MSwwLDAsMCwyNS43LDM4LjhabTI0Ljc3LDBBNS41MSw1LjUxLDAsMSwwLDQ1LDMzLjI5LDUuNSw1LjUsMCwwLDAsNTAuNDcsMzguOFoiIHN0eWxlPSJmaWxsLXJ1bGU6ZXZlbm9kZCIvPjxwYXRoIGlkPSJJcmlzIiBkPSJNMjQsMzMuNjRhMi4wNywyLjA3LDAsMSwwLTIuMDYtMi4wN0EyLjA3LDIuMDcsMCwwLDAsMjQsMzMuNjRabTI0Ljc3LDBhMi4wNywyLjA3LDAsMSwwLTIuMDYtMi4wN0EyLjA3LDIuMDcsMCwwLDAsNDguNzUsMzMuNjRaIiBzdHlsZT0iZmlsbDojZmZmO2ZpbGwtcnVsZTpldmVub2RkIi8+PC9nPjwvc3ZnPg==";
+
 const dependencyOptions: Fig.Option[] = [
   {
     name: ["-c", "--config"],
@@ -274,7 +277,7 @@ const spec: Fig.Spec = {
     },
     {
       name: ["c", "create"],
-      icon: "🛠️",
+      icon,
       description: "Start a new project from a template",
       args: [
         {
@@ -349,7 +352,7 @@ const spec: Fig.Spec = {
     },
     {
       name: "run",
-      icon: "🛠️",
+      icon,
       description: "Run a package.json script or executable",
       args: [
         {
@@ -387,7 +390,8 @@ const spec: Fig.Spec = {
       name: ["rm", "remove"],
       icon: "📦",
       description: "Remove a dependency from package.json",
-      options: dependencyOptions,
+      icon,
+      icon,
       args: {
         name: "package",
         filterStrategy: "fuzzy",
@@ -397,12 +401,14 @@ const spec: Fig.Spec = {
     },
     {
       name: "upgrade",
-      icon: "🛠️",
+      icon,
       description: "Get the latest version of bun",
+      icon,
+      icon,
     },
     {
       name: "completions",
-      icon: "🛠️",
+      icon,
       description: "Install shell completions",
     },
     {
@@ -413,10 +419,11 @@ const spec: Fig.Spec = {
     {
       name: "help",
       description: "Print the help menu",
+      icon,
     },
     {
       name: "x",
-      icon: "🛠️",
+      icon,
       description: "Run an npx command",
       loadSpec: "bunx",
     },

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -266,6 +266,26 @@ const spec: Fig.Spec = {
       },
     },
     {
+
+/** Generate the globally linked packages stored in $BUN_INSTALL directory */
+const bunLinksGenerator: Fig.Generator = {
+  script:
+    "command find $BUN_INSTALL/install/global/node_modules -type l | awk -F 'node_modules/' '{print $2}'",
+  postProcess(out) {
+    return out.split("\n").map((dep) => {
+      return {
+        name: dep,
+        description: "link to this package",
+        icon: "📦",
+      };
+    });
+  },
+  cache: {
+    strategy: "stale-while-revalidate",
+    ttl: 60 * 60 * 24 * 7, // 1 week
+  },
+};
+
       name: "bun",
       icon: "📦",
       description: "Bundle dependencies of input files into a '.bun' file",
@@ -400,6 +420,31 @@ const spec: Fig.Spec = {
       },
     },
     {
+      name: "link",
+      icon: "📦",
+      description:
+        "Run without an argument to register this package to the global package registry. Uses the name field from package.json.",
+      args: {
+        name: "package",
+        filterStrategy: "fuzzy",
+        isOptional: true,
+        generators: bunLinksGenerator,
+        description: "install a package from the global package registry",
+      },
+      options: [
+        {
+          name: "--save",
+          description: "Save to package.json",
+          dependsOn: ["package"],
+        },
+      ],
+    },
+    {
+      name: "unlink",
+      icon: "📦",
+      description: "Unlink this package from the global package registry",
+      // Unliking a package by name is not yet implemented. Use bunLinksGenerator once it is implemented.
+    },
     {
       name: "upgrade",
       icon,

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -410,11 +410,42 @@ const bunLinksGenerator: Fig.Generator = {
       name: ["rm", "remove"],
       icon: "📦",
       description: "Remove a dependency from package.json",
-      icon,
-      icon,
+      options: dependencyOptions,
       args: {
         name: "package",
         filterStrategy: "fuzzy",
+        generators: dependenciesGenerator,
+        isVariadic: true,
+      },
+    },
+    {
+      name: ["build", "bun"],
+      icon,
+      description: "Bundle files using Bun's native bundler",
+      args: [
+        {
+          name: "entrypoints",
+          isVariadic: true,
+          generators: [
+            filepaths({
+              extensions: ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
+            }),
+          ],
+          description:
+            "entrypoint to bundle. If multiple entrypoints provided, must specify --outdir.",
+        },
+      ],
+      options: buildParams,
+    },
+    {
+      name: "update",
+      icon,
+      description: "Update outdated dependencies",
+      options: dependencyOptions,
+      args: {
+        name: "package",
+        filterStrategy: "fuzzy",
+        isOptional: true,
         generators: dependenciesGenerator,
         isVariadic: true,
       },

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -577,8 +577,12 @@ const dependencyOptions: Fig.Option[] = [
 
 /** Generate the globally linked packages stored in $BUN_INSTALL directory */
 const bunLinksGenerator: Fig.Generator = {
-  script:
-    "command find $BUN_INSTALL/install/global/node_modules -type l | awk -F 'node_modules/' '{print $2}'",
+  script: [
+    "command",
+    "sh",
+    "-c",
+    "find $BUN_INSTALL/install/global/node_modules -type l -o -type d -maxdepth 2 | awk -F 'node_modules/' '{print $2}'",
+  ],
   postProcess(out) {
     return out.split("\n").map((dep) => {
       return {
@@ -590,7 +594,7 @@ const bunLinksGenerator: Fig.Generator = {
   },
   cache: {
     strategy: "stale-while-revalidate",
-    ttl: 60 * 60 * 24 * 7, // 1 week
+    ttl: 60 * 60 * 24, // 24 hours
   },
 };
 
@@ -814,8 +818,12 @@ const spec: Fig.Spec = {
         name: "files",
         generators: {
           // Suggest test files -> https://bun.sh/docs/cli/test. (not in node_modules or .git)
-          script:
-            'command find $(npm prefix) | grep -E ".*.(test|_test|spec|_spec).(ts|tsx|js|jsx)$" | grep -vE ".*/node_modules/.*" | sed "s|$(npm prefix)/||"',
+          script: [
+            "command",
+            "sh",
+            "-c",
+            'find $(npm prefix) | grep -E ".*.(test|_test|spec|_spec).(ts|tsx|js|jsx)$" | grep -vE ".*/node_modules/.*" | sed "s|$(npm prefix)/||"',
+          ],
           postProcess(out) {
             return out.split("\n").map((file) => {
               return {

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -1,4 +1,8 @@
-import { keyValueList, filepaths } from "@fig/autocomplete-generators";
+import {
+  keyValueList,
+  filepaths,
+  valueList,
+} from "@fig/autocomplete-generators";
 import {
   npmScriptsGenerator,
   npmSearchGenerator,
@@ -18,15 +22,15 @@ const inspectArgs: Fig.SingleOrArray<Fig.Arg> = {
     {
       name: "3000",
       icon: "fig://icon?type=box",
-      description: "serve on port 3000",
+      description: "Serve on port 3000",
     },
     {
       name: "8080",
       icon: "fig://icon?type=box",
-      description: "serve on port 8080",
+      description: "Serve on port 8080",
     },
   ],
-  description: "Activate inspector on particular port and/or hostname. ",
+  description: "Activate inspector on particular port and/or hostname",
 };
 
 const loaders = [
@@ -45,7 +49,7 @@ const loaders = [
 const sharedPublicParams: Fig.Option[] = [
   {
     name: ["-h", "--help"],
-    description: "Display this help and exit.",
+    description: "Display this help and exit",
   },
   {
     name: ["-b", "--bun"],
@@ -57,9 +61,404 @@ const sharedPublicParams: Fig.Option[] = [
     args: {
       name: "path",
       description:
-        "Absolute path to resolve files & entry points from. This just changes the process' cwd.",
+        "Absolute path to resolve files & entry points from. This just changes the process' cwd",
     },
   },
+  {
+    name: ["-c", "--config"],
+    args: {
+      name: "path",
+      template: "filepaths",
+      description: "Config file to load Bun from (e.g. -c bunfig.toml)",
+      isOptional: true,
+    },
+    description: "Load config (bunfig.toml)",
+  },
+  {
+    name: "--extension-order",
+    args: {
+      name: "order",
+      isVariadic: true,
+      description: "Defaults to: .tsx,.ts,.jsx,.js,.json",
+    },
+  },
+  {
+    name: "--jsx-factory",
+    args: {
+      name: "name",
+      suggestions: ["React.createElement", "h", "preact.h"],
+    },
+    description: `Changes the function called when compiling JSX elements using the classic JSX runtime`,
+  },
+  {
+    name: "--jsx-fragment",
+    priority: 49,
+    args: { name: "string", isOptional: true },
+    insertValue: "--jsx-fragment='{cursor}'",
+    description: "Changes the function called when compiling JSX fragments",
+  },
+  {
+    name: "--jsx-import-source",
+    args: { name: "module", suggestions: ["react"] },
+    description: `Declares the module specifier to be used for importing the jsx and jsxs factory functions. Default: "react"`,
+  },
+  {
+    name: "--jsx-runtime",
+    args: { name: "name", suggestions: ["automatic", "classic"] },
+    description: `"automatic" (default) or "classic"`,
+  },
+  {
+    name: ["-r", "--preload"],
+    args: {
+      name: "args",
+      isVariadic: true,
+      description: "Import a module before other modules are loaded",
+    },
+  },
+  {
+    name: "--main-fields",
+    args: {
+      name: "args",
+      isVariadic: true,
+      description:
+        "Main fields to lookup in package.json. Defaults to --target dependent",
+    },
+  },
+  {
+    name: "--no-summary",
+    description: "Don't print a summary (when generating .bun)",
+  },
+  {
+    name: ["-v", "--version"],
+    description: "Print version and exit",
+  },
+  {
+    name: "--revision",
+    description: "Print version with revision and exit",
+  },
+  {
+    name: "--tsconfig-override",
+    args: {
+      name: "overrides",
+      description: "Load tsconfig from path instead of cwd/tsconfig.json",
+    },
+  },
+  {
+    name: ["-d", "--define"],
+    args: {
+      name: "k=v",
+      isVariadic: true,
+      description:
+        "Substitute key=value while parsing, e.g. --define process.env.NODE_ENV=development",
+    },
+  },
+  {
+    name: ["-e", "--external"],
+    args: {
+      name: "args",
+      isVariadic: true,
+      description:
+        "Exclude module from transpilation (can use * wildcards). ex: -e react",
+    },
+  },
+  {
+    name: ["-l", "--loader"],
+    args: {
+      name: "args",
+      isVariadic: true,
+      description:
+        "Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi",
+      generators: keyValueList({
+        keys: loaders.map((loader) => "." + loader),
+        values: loaders,
+      }),
+    },
+  },
+  {
+    name: ["-u", "--origin"],
+    args: {
+      name: "args",
+      description: 'Rewrite import URLs to start with --origin. Default: ""',
+    },
+  },
+  {
+    name: ["-p", "--port"],
+    args: {
+      name: "args",
+      description: 'Port to serve Bun\'s dev server on. Default: "3000"',
+    },
+  },
+  {
+    name: "--smol",
+    description: "Use less memory, but run garbage collection more often",
+  },
+  {
+    name: "--minify",
+    description: "Minify (experimental)",
+    priority: 50,
+  },
+  {
+    name: "--minify-syntax",
+    description: "Minify syntax and inline data (experimental)",
+  },
+  {
+    name: "--minify-whitespace",
+    description: "Minify whitespace (experimental)",
+  },
+  {
+    name: "--minify-identifiers",
+    description: "Minify identifiers",
+  },
+  {
+    name: "--no-macros",
+    description:
+      "Disable macros from being executed in the bundler, transpiler and runtime",
+  },
+  {
+    name: "--target",
+    description: "Target environment",
+    priority: 50,
+    args: {
+      generators: valueList({
+        values: ["node", "browser", "bun"],
+      }),
+    },
+  },
+  {
+    name: "--inspect",
+    description: "Activate Bun's debugger for a file",
+    requiresSeparator: true,
+    args: inspectArgs,
+  },
+  {
+    name: "--inspect-wait",
+    description:
+      "Activate Bun's Debugger, wait for a connection before executing",
+    requiresSeparator: true,
+    args: inspectArgs,
+  },
+  {
+    name: "--inspect-brk",
+    description:
+      "Activate Bun's Debugger, set breakpoint on first line of code and wait",
+    requiresSeparator: true,
+    args: inspectArgs,
+  },
+  {
+    name: "--if-present",
+    description: "Exit if the entrypoint does not exist",
+  },
+];
+
+// note: we are keeping --port and --origin as it can be reused for bun build and elsewhere
+const notBunDevFlags: Fig.Option[] = [
+  {
+    name: "--hot",
+    description:
+      "Enable auto reload in the Bun runtime, test runner, or bundler",
+    priority: 50,
+  },
+  {
+    name: "--watch",
+    description: "Automatically restart the process on file change",
+    priority: 50,
+  },
+  {
+    name: "--no-install",
+    description: "Disable auto install in the Bun runtime",
+  },
+  {
+    name: "-i",
+    description:
+      "Automatically install dependencies and use global cache in Bun's runtime, equivalent to --install=fallback",
+  },
+  {
+    name: "--install",
+    args: {
+      name: "arg",
+      description: `Install dependencies automatically when no node_modules are present, default: "auto". "force" to ignore node_modules, fallback to install any missing`,
+      suggestions: ["auto", "force", "fallback", "disable"],
+    },
+  },
+  {
+    name: "--prefer-offline",
+    description:
+      "Skip staleness checks for packages in the Bun runtime and resolve from disk",
+  },
+  {
+    name: "--prefer-latest",
+    description:
+      "Use the latest matching versions of packages in the Bun runtime, always checking npm",
+  },
+  {
+    name: "--silent",
+    description: "Don't repeat the command for bun run",
+  },
+];
+
+const buildOnlyParams: Fig.Option[] = [
+  {
+    name: "compile",
+    description:
+      "Generate a standalone Bun executable containing your bundled code",
+    priority: 50,
+  },
+  {
+    name: "--format",
+    description:
+      "Specifies the module format to build to. Only esm is supported currently",
+    args: {
+      name: "args",
+      suggestions: ["esm"],
+    },
+  },
+  {
+    name: "--outdir",
+    description: 'Default to "dist" if multiple files',
+    priority: 50,
+    args: {
+      name: "path",
+    },
+  },
+  {
+    name: "--outfile",
+    description: "Write to a file",
+    priority: 50,
+    args: {
+      name: "path",
+    },
+  },
+  {
+    name: "--root",
+    description: "Root directory used for multiple entry points",
+    args: {
+      name: "path",
+    },
+  },
+  {
+    name: "--splitting",
+    description: "Enable code splitting",
+    priority: 50,
+  },
+  {
+    name: "--public-path",
+    description: "A prefix to be appended to any import paths in bundled code",
+    args: {
+      name: "args",
+    },
+  },
+  {
+    name: "--sourcemap",
+    description: "Build with sourcemaps - 'inline', 'external', or 'none'",
+    requiresSeparator: "-",
+    priority: 50,
+    args: {
+      name: "args",
+      isOptional: true,
+      suggestions: ["inline", "external", "none"],
+    },
+  },
+  {
+    name: "--entry-naming",
+    description:
+      'Customize entry point filenames. Defaults to "[dir]/[name].[ext]"',
+    args: {
+      name: "args",
+    },
+  },
+  {
+    name: "--chunk-naming",
+    description: 'Customize chunk filenames. Defaults to "[name]-[hash].[ext]"',
+    args: {
+      name: "args",
+    },
+  },
+  {
+    name: "--asset-naming",
+    description: 'Customize asset filenames. Defaults to "[name]-[hash].[ext]"',
+    args: {
+      name: "args",
+    },
+  },
+  {
+    name: "--server-components",
+    description: "Enable React Server Components (experimental)",
+  },
+  {
+    name: "--no-bundle",
+    description: "Transpile file only, do not bundle",
+  },
+];
+
+const testOnlyParams: Fig.Option[] = [
+  {
+    name: "--timeout",
+    description: "Set the per-test timeout in milliseconds, default is 5000",
+    args: {
+      name: "number",
+    },
+  },
+  {
+    name: "--update-snapshots",
+    description: "Update snapshot files",
+  },
+  {
+    name: "--rerun-each",
+    description:
+      "Re-run each test file <NUMBER> times, helps catch certain bugs",
+    args: {
+      name: "number",
+    },
+  },
+  {
+    name: "--only",
+    description: 'Only run tests that are marked with "test.only()"',
+  },
+  {
+    name: "--todo",
+    description: 'Include tests that are marked with "test.todo()"',
+  },
+  {
+    name: "--coverage",
+    description: "Generate a coverage profile",
+  },
+  {
+    name: "--bail",
+    description:
+      "Exit the test suite after <NUMBER> failures. If you do not specify a number, it defaults to 1",
+    args: {
+      name: "number",
+      isOptional: true,
+    },
+  },
+  {
+    name: ["-t", "--test-name-pattern"],
+    description: "Run only tests with a name that matches the given regex",
+    args: {
+      name: "pattern",
+    },
+  },
+];
+
+const debugParams: Fig.Option[] = [
+  {
+    name: "--dump-environment-variables",
+    description:
+      "Dump environment variables from .env and process as JSON and quit. Useful for debugging",
+    priority: 49,
+  },
+  {
+    name: "--dump-limits",
+    description: "Dump system limits. Useful for debugging",
+    priority: 49,
+  },
+];
+
+const publicParams = [...sharedPublicParams, ...notBunDevFlags];
+const buildParams = [...publicParams, ...buildOnlyParams, ...debugParams];
+const testParams = [...publicParams, ...testOnlyParams, ...debugParams];
+
+const dependencyOptions: Fig.Option[] = [
   {
     name: ["-c", "--config"],
     args: {
@@ -82,18 +481,21 @@ const sharedPublicParams: Fig.Option[] = [
     description: "Don't save a lockfile",
   },
   {
+    name: "--save",
+    description: "Save to package.json",
+  },
+  {
     name: "--dry-run",
     description: "Don't install anything",
   },
   {
-    name: "--lockfile",
-    args: { name: "path", template: "filepaths" },
-    description: "Store & load a lockfile at a specific filepath",
+    name: "--frozen-lockfile",
+    description: "Disallow changes to lockfile",
   },
   {
     name: ["-f", "--force"],
     description:
-      "Always request the latest versions from the registry & reinstall all dependenices",
+      "Always request the latest versions from the registry & reinstall all dependencies",
   },
   {
     name: "--cache-dir",
@@ -140,182 +542,38 @@ const sharedPublicParams: Fig.Option[] = [
     name: "--help",
     description: "Print the help menu",
   },
+  {
+    name: "--no-progress",
+    description: "Disable the progress bar",
+  },
+  {
+    name: "--no-summary",
+    description: "Don't print a summary",
+  },
+  {
+    name: "--no-verify",
+    description: "Skip verifying integrity of newly downloaded packages",
+  },
+  {
+    name: "--ignore-scripts",
+    description:
+      "Skip lifecycle scripts in the project's package.json (dependency scripts are never run)",
+  },
+  {
+    name: ["-d", "--dev", "-D", "--development"],
+    description: "Install as devDependency",
+    priority: 75,
+    isRepeatable: false,
+  },
+  {
+    name: "--exact",
+    description: "Install exact version",
+  },
+  {
+    name: "--optional",
+    description: "Install as optionalDependency",
+  },
 ];
-
-const spec: Fig.Spec = {
-  name: "bun",
-  description:
-    "A fast bundler, transpiler, JavaScript Runtime and package manager for web software",
-  args: [
-    {
-      name: "file",
-      generators: [
-        // js jsx mjs cjs ts tsx mts cts
-        filepaths({ matches: /\.[mc]?[jt]sx?$/ }),
-        npmScriptsGenerator,
-      ],
-    },
-    {
-      name: "args",
-    },
-  ],
-  options: [
-    {
-      name: "--use",
-      args: { name: "framework", suggestions: ["next"], template: "folders" },
-      description: `Choose a framework, e.g. "--use next". It checks first for a package named "bun-framework-packagename" and then "packagename"`,
-    },
-    {
-      name: "--bunfile",
-      args: { name: "path", template: "filepaths" },
-      description: `Use a .bun file (default: node_modules.bun)`,
-    },
-    {
-      name: "--inspect",
-      description: "Activate Bun's Debugger",
-    },
-    {
-      name: "--inspect-wait",
-      description:
-        "Activate Bun's Debugger, wait for a connection before executing",
-    },
-    {
-      name: "--inspect-brk",
-      description:
-        "Activate Bun's Debugger, set breakpoint on first line of code and wait",
-    requiresSeparator: true,
-    },
-    {
-      name: "--server-bunfile",
-      args: { name: "path", template: "filepaths" },
-      description: `Use a .server.bun file (default: node_modules.server.bun)`,
-    },
-    {
-      name: "--cwd",
-      args: { name: "path", template: "folders" },
-      description: `Absolute path to resolve files & entry points from. This just changes the process' cwd`,
-    },
-    {
-      name: ["-c", "--config"],
-      args: { name: "path", isOptional: true, template: "filepaths" },
-      description: `Config file to load bun from (e.g. -c bunfig.toml`,
-    },
-    {
-      name: "--disable-react-fast-refresh",
-      description: `Disable React Fast Refresh`,
-    },
-    {
-      name: "--disable-hmr",
-      description: `Disable Hot Module Reloading (disables fast refresh too)`,
-    },
-    {
-      name: "--extension-order",
-      args: {
-        name: "order",
-        isVariadic: true,
-        generators: keyValueList({
-          keys: [".tsx", ".ts", ".jsx", ".js", ".json"],
-        }),
-      },
-      description: `Defaults to: .tsx,.ts,.jsx,.js,.json`,
-    },
-    {
-      name: "--jsx-factory",
-      args: {
-        name: "name",
-        suggestions: ["React.createElement", "h", "preact.h"],
-      },
-      description: `Changes the function called when compiling JSX elements using the classic JSX runtime`,
-    },
-    {
-      name: "--jsx-fragment",
-      args: { name: "name", suggestions: ["React.Fragment", "Fragment"] },
-      description: `Changes the function called when compiling JSX fragments`,
-    },
-    {
-      name: "--jsx-import-source",
-      args: { name: "module", suggestions: ["react"] },
-      description: `Declares the module specifier to be used for importing the jsx and jsxs factory functions. Default: "react"`,
-    },
-    {
-      name: "--jsx-production",
-      description: `Use jsx instead of jsxDEV (default) for the automatic runtime`,
-    },
-    {
-      name: "--jsx-runtime",
-      args: { name: "name", suggestions: ["automatic", "classic"] },
-      description: `"automatic" (default) or "classic"`,
-    },
-    {
-      name: "--main-fields",
-      args: { name: "fields", isVariadic: true },
-      description: `Main fields to lookup in package.json. Defaults to --platform dependent`,
-    },
-    {
-      name: "--no-summary",
-      description: `Don't print a summary (when generating .bun)`,
-    },
-    { name: ["-v", "--version"], description: `Print version and exit` },
-    {
-      name: "--platform",
-      args: { name: "name", suggestions: ["browser", "node"] },
-      description: `"browser" or "node". Defaults to "browser"`,
-    },
-    {
-      name: "--public-dir",
-      args: { name: "path", template: "folders" },
-      description: `Top-level directory for .html files, fonts or anything external. Defaults to "<cwd>/public", to match create-react-app and Next.js`,
-    },
-    {
-      name: "--tsconfig-override",
-      args: { name: "path", template: "filepaths" },
-      description: `Load tsconfig from path instead of cwd/tsconfig.json`,
-    },
-    {
-      name: ["-d", "--define"],
-      args: { name: "k:v", isVariadic: true },
-      description: `Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:"development". Values are parsed as JSON`,
-    },
-    {
-      name: ["-e", "--external"],
-      args: { name: "module", isVariadic: true },
-      description: `Exclude module from transpilation (can use * wildcards). ex: -e react`,
-    },
-    { name: ["-h", "--help"], description: `Display this help and exit` },
-    {
-      name: ["-i", "--inject"],
-      args: { name: "module", isVariadic: true },
-      description: `Inject module at the top of every file`,
-    },
-    {
-      name: ["-l", "--loader"],
-      args: { name: "loader", isVariadic: true },
-      description: `Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: jsx, js, json, tsx, ts, css`,
-    },
-    {
-      name: ["-u", "--origin"],
-      args: { name: "url" },
-      description: `Rewrite import URLs to start with --origin. Default: ""`,
-    },
-    {
-      name: ["-p", "--port"],
-      args: { name: "port" },
-      description: `Port to serve bun's dev server on. Default: "3000"`,
-    },
-    { name: "--silent", description: `Don't repeat the command for bun run` },
-  ],
-  subcommands: [
-    {
-      name: "dev",
-      icon: "🛠️",
-      description: "Start a bun Dev server",
-      args: {
-        name: "files",
-        template: "filepaths",
-        isVariadic: true,
-      },
-    },
-    {
 
 /** Generate the globally linked packages stored in $BUN_INSTALL directory */
 const bunLinksGenerator: Fig.Generator = {
@@ -325,7 +583,7 @@ const bunLinksGenerator: Fig.Generator = {
     return out.split("\n").map((dep) => {
       return {
         name: dep,
-        description: "link to this package",
+        description: "Link to this package",
         icon: "📦",
       };
     });
@@ -336,14 +594,20 @@ const bunLinksGenerator: Fig.Generator = {
   },
 };
 
-      name: "bun",
-      icon: "📦",
-      description: "Bundle dependencies of input files into a '.bun' file",
-      args: {
-        name: "files",
-        template: "filepaths",
-        isVariadic: true,
-      },
+const spec: Fig.Spec = {
+  name: "bun",
+  description:
+    "A fast bundler, transpiler, JavaScript Runtime and package manager for web software",
+  icon,
+  args: [
+    {
+      name: "file",
+      generators: [
+        // js jsx mjs cjs ts tsx mts cts
+        filepaths({ matches: /\.[mc]?[jt]sx?$/ }),
+        npmScriptsGenerator,
+      ],
+    },
     {
       name: "args",
     },
@@ -435,18 +699,16 @@ const bunLinksGenerator: Fig.Generator = {
       name: "run",
       icon,
       description: "Run a package.json script or executable",
-      args: [
-        {
-          name: "script",
-          filterStrategy: "fuzzy",
-          generators: [
-            filepaths({
-              extensions: ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
-            }),
-            npmScriptsGenerator,
-          ],
-        },
-      ],
+      args: {
+        name: "script",
+        filterStrategy: "fuzzy",
+        generators: [
+          filepaths({
+            extensions: ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
+          }),
+          npmScriptsGenerator,
+        ],
+      },
     },
     {
       name: ["i", "install"],
@@ -483,19 +745,15 @@ const bunLinksGenerator: Fig.Generator = {
       name: ["build", "bun"],
       icon,
       description: "Bundle files using Bun's native bundler",
-      args: [
-        {
-          name: "entrypoints",
-          isVariadic: true,
-          generators: [
-            filepaths({
-              extensions: ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
-            }),
-          ],
-          description:
-            "entrypoint to bundle. If multiple entrypoints provided, must specify --outdir.",
-        },
-      ],
+      args: {
+        name: "entrypoints",
+        isVariadic: true,
+        generators: filepaths({
+          extensions: ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
+        }),
+        description:
+          "Entrypoint to bundle. If multiple entrypoints provided, must specify --outdir",
+      },
       options: buildParams,
     },
     {
@@ -515,13 +773,13 @@ const bunLinksGenerator: Fig.Generator = {
       name: "link",
       icon: "📦",
       description:
-        "Run without an argument to register this package to the global package registry. Uses the name field from package.json.",
+        "Run without an argument to register this package to the global package registry. Uses the name field from package.json",
       args: {
         name: "package",
         filterStrategy: "fuzzy",
         isOptional: true,
         generators: bunLinksGenerator,
-        description: "install a package from the global package registry",
+        description: "Install a package from the global package registry",
       },
       options: [
         {
@@ -554,38 +812,36 @@ const bunLinksGenerator: Fig.Generator = {
       description: "Run unit tests with Bun",
       args: {
         name: "files",
-        generators: [
-          {
-            // Suggest test files -> https://bun.sh/docs/cli/test. (not in node_modules or .git)
-            script:
-              'command find $(npm prefix) | grep -E ".*.(test|_test|spec|_spec).(ts|tsx|js|jsx)$" | grep -vE ".*/node_modules/.*" | sed "s|$(npm prefix)/||"',
-            postProcess(out) {
-              return out.split("\n").map((file) => {
-                return {
-                  name: file.split("/").pop(),
-                  priority: 76,
-                  description: `run ${file}`,
-                  insertValue: file,
-                };
-              });
-            },
-            cache: {
-              strategy: "stale-while-revalidate",
-              ttl: 60 * 60 * 24, // 24 hours
-            },
+        generators: {
+          // Suggest test files -> https://bun.sh/docs/cli/test. (not in node_modules or .git)
+          script:
+            'command find $(npm prefix) | grep -E ".*.(test|_test|spec|_spec).(ts|tsx|js|jsx)$" | grep -vE ".*/node_modules/.*" | sed "s|$(npm prefix)/||"',
+          postProcess(out) {
+            return out.split("\n").map((file) => {
+              return {
+                name: file.split("/").pop(),
+                priority: 76,
+                description: `run ${file}`,
+                insertValue: file,
+              };
+            });
           },
-        ],
+          cache: {
+            strategy: "stale-while-revalidate",
+            ttl: 60 * 60 * 24, // 24 hours
+          },
+        },
         isVariadic: true,
         filterStrategy: "fuzzy",
         isOptional: true,
-        description: "test files to run",
+        description: "Test files to run",
       },
       options: testParams,
     },
     {
       name: "pm",
       icon,
-      description: "Set of utilities for working with Bun's package manager.",
+      description: "Set of utilities for working with Bun's package manager",
       options: [
         {
           name: "bin",

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -10,7 +10,56 @@ import { createCLIsGenerator } from "./yarn";
 const icon =
   "data:image/svg+xml;base64,PHN2ZyBpZD0iQnVuIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4MCA3MCI+PHRpdGxlPkJ1biBMb2dvPC90aXRsZT48cGF0aCBpZD0iU2hhZG93IiBkPSJNNzEuMDksMjAuNzRjLS4xNi0uMTctLjMzLS4zNC0uNS0uNXMtLjMzLS4zNC0uNS0uNS0uMzMtLjM0LS41LS41LS4zMy0uMzQtLjUtLjUtLjMzLS4zNC0uNS0uNS0uMzMtLjM0LS41LS41LS4zMy0uMzQtLjUtLjVBMjYuNDYsMjYuNDYsMCwwLDEsNzUuNSwzNS43YzAsMTYuNTctMTYuODIsMzAuMDUtMzcuNSwzMC4wNS0xMS41OCwwLTIxLjk0LTQuMjMtMjguODMtMTAuODZsLjUuNS41LjUuNS41LjUuNS41LjUuNS41LjUuNUMxOS41NSw2NS4zLDMwLjE0LDY5Ljc1LDQyLDY5Ljc1YzIwLjY4LDAsMzcuNS0xMy40OCwzNy41LTMwQzc5LjUsMzIuNjksNzYuNDYsMjYsNzEuMDksMjAuNzRaIi8+PGcgaWQ9IkJvZHkiPjxwYXRoIGlkPSJCYWNrZ3JvdW5kIiBkPSJNNzMsMzUuN2MwLDE1LjIxLTE1LjY3LDI3LjU0LTM1LDI3LjU0UzMsNTAuOTEsMywzNS43QzMsMjYuMjcsOSwxNy45NCwxOC4yMiwxM1MzMy4xOCwzLDM4LDNzOC45NCw0LjEzLDE5Ljc4LDEwQzY3LDE3Ljk0LDczLDI2LjI3LDczLDM1LjdaIiBzdHlsZT0iZmlsbDojZmJmMGRmIi8+PHBhdGggaWQ9IkJvdHRvbV9TaGFkb3ciIGRhdGEtbmFtZT0iQm90dG9tIFNoYWRvdyIgZD0iTTczLDM1LjdhMjEuNjcsMjEuNjcsMCwwLDAtLjgtNS43OGMtMi43MywzMy4zLTQzLjM1LDM0LjktNTkuMzIsMjQuOTRBNDAsNDAsMCwwLDAsMzgsNjMuMjRDNTcuMyw2My4yNCw3Myw1MC44OSw3MywzNS43WiIgc3R5bGU9ImZpbGw6I2Y2ZGVjZSIvPjxwYXRoIGlkPSJMaWdodF9TaGluZSIgZGF0YS1uYW1lPSJMaWdodCBTaGluZSIgZD0iTTI0LjUzLDExLjE3QzI5LDguNDksMzQuOTQsMy40Niw0MC43OCwzLjQ1QTkuMjksOS4yOSwwLDAsMCwzOCwzYy0yLjQyLDAtNSwxLjI1LTguMjUsMy4xMy0xLjEzLjY2LTIuMywxLjM5LTMuNTQsMi4xNS0yLjMzLDEuNDQtNSwzLjA3LTgsNC43QzguNjksMTguMTMsMywyNi42MiwzLDM1LjdjMCwuNCwwLC44LDAsMS4xOUM5LjA2LDE1LjQ4LDIwLjA3LDEzLjg1LDI0LjUzLDExLjE3WiIgc3R5bGU9ImZpbGw6I2ZmZmVmYyIvPjxwYXRoIGlkPSJUb3AiIGQ9Ik0zNS4xMiw1LjUzQTE2LjQxLDE2LjQxLDAsMCwxLDI5LjQ5LDE4Yy0uMjguMjUtLjA2LjczLjMuNTksMy4zNy0xLjMxLDcuOTItNS4yMyw2LTEzLjE0QzM1LjcxLDUsMzUuMTIsNS4xMiwzNS4xMiw1LjUzWm0yLjI3LDBBMTYuMjQsMTYuMjQsMCwwLDEsMzksMTljLS4xMi4zNS4zMS42NS41NS4zNkM0MS43NCwxNi41Niw0My42NSwxMSwzNy45Myw1LDM3LjY0LDQuNzQsMzcuMTksNS4xNCwzNy4zOSw1LjQ5Wm0yLjc2LS4xN0ExNi40MiwxNi40MiwwLDAsMSw0NywxNy4xMmEuMzMuMzMsMCwwLDAsLjY1LjExYy45Mi0zLjQ5LjQtOS40NC03LjE3LTEyLjUzQzQwLjA4LDQuNTQsMzkuODIsNS4wOCw0MC4xNSw1LjMyWk0yMS42OSwxNS43NmExNi45NCwxNi45NCwwLDAsMCwxMC40Ny05Yy4xOC0uMzYuNzUtLjIyLjY2LjE4LTEuNzMsOC03LjUyLDkuNjctMTEuMTIsOS40NUMyMS4zMiwxNi40LDIxLjMzLDE1Ljg3LDIxLjY5LDE1Ljc2WiIgc3R5bGU9ImZpbGw6I2NjYmVhNztmaWxsLXJ1bGU6ZXZlbm9kZCIvPjxwYXRoIGlkPSJPdXRsaW5lIiBkPSJNMzgsNjUuNzVDMTcuMzIsNjUuNzUuNSw1Mi4yNy41LDM1LjdjMC0xMCw2LjE4LTE5LjMzLDE2LjUzLTI0LjkyLDMtMS42LDUuNTctMy4yMSw3Ljg2LTQuNjIsMS4yNi0uNzgsMi40NS0xLjUxLDMuNi0yLjE5QzMyLDEuODksMzUsLjUsMzgsLjVzNS42MiwxLjIsOC45LDMuMTRjMSwuNTcsMiwxLjE5LDMuMDcsMS44NywyLjQ5LDEuNTQsNS4zLDMuMjgsOSw1LjI3QzY5LjMyLDE2LjM3LDc1LjUsMjUuNjksNzUuNSwzNS43LDc1LjUsNTIuMjcsNTguNjgsNjUuNzUsMzgsNjUuNzVaTTM4LDNjLTIuNDIsMC01LDEuMjUtOC4yNSwzLjEzLTEuMTMuNjYtMi4zLDEuMzktMy41NCwyLjE1LTIuMzMsMS40NC01LDMuMDctOCw0LjdDOC42OSwxOC4xMywzLDI2LjYyLDMsMzUuNywzLDUwLjg5LDE4LjcsNjMuMjUsMzgsNjMuMjVTNzMsNTAuODksNzMsMzUuN0M3MywyNi42Miw2Ny4zMSwxOC4xMyw1Ny43OCwxMyw1NCwxMSw1MS4wNSw5LjEyLDQ4LjY2LDcuNjRjLTEuMDktLjY3LTIuMDktMS4yOS0zLTEuODRDNDIuNjMsNCw0MC40MiwzLDM4LDNaIi8+PC9nPjxnIGlkPSJNb3V0aCI+PGcgaWQ9IkJhY2tncm91bmQtMiIgZGF0YS1uYW1lPSJCYWNrZ3JvdW5kIj48cGF0aCBkPSJNNDUuMDUsNDNhOC45Myw4LjkzLDAsMCwxLTIuOTIsNC43MSw2LjgxLDYuODEsMCwwLDEtNCwxLjg4QTYuODQsNi44NCwwLDAsMSwzNCw0Ny43MSw4LjkzLDguOTMsMCwwLDEsMzEuMTIsNDNhLjcyLjcyLDAsMCwxLC44LS44MUg0NC4yNkEuNzIuNzIsMCwwLDEsNDUuMDUsNDNaIiBzdHlsZT0iZmlsbDojYjcxNDIyIi8+PC9nPjxnIGlkPSJUb25ndWUiPjxwYXRoIGlkPSJCYWNrZ3JvdW5kLTMiIGRhdGEtbmFtZT0iQmFja2dyb3VuZCIgZD0iTTM0LDQ3Ljc5YTYuOTEsNi45MSwwLDAsMCw0LjEyLDEuOSw2LjkxLDYuOTEsMCwwLDAsNC4xMS0xLjksMTAuNjMsMTAuNjMsMCwwLDAsMS0xLjA3LDYuODMsNi44MywwLDAsMC00LjktMi4zMSw2LjE1LDYuMTUsMCwwLDAtNSwyLjc4QzMzLjU2LDQ3LjQsMzMuNzYsNDcuNiwzNCw0Ny43OVoiIHN0eWxlPSJmaWxsOiNmZjYxNjQiLz48cGF0aCBpZD0iT3V0bGluZS0yIiBkYXRhLW5hbWU9Ik91dGxpbmUiIGQ9Ik0zNC4xNiw0N2E1LjM2LDUuMzYsMCwwLDEsNC4xOS0yLjA4LDYsNiwwLDAsMSw0LDEuNjljLjIzLS4yNS40NS0uNTEuNjYtLjc3YTcsNywwLDAsMC00LjcxLTEuOTMsNi4zNiw2LjM2LDAsMCwwLTQuODksMi4zNkE5LjUzLDkuNTMsMCwwLDAsMzQuMTYsNDdaIi8+PC9nPjxwYXRoIGlkPSJPdXRsaW5lLTMiIGRhdGEtbmFtZT0iT3V0bGluZSIgZD0iTTM4LjA5LDUwLjE5YTcuNDIsNy40MiwwLDAsMS00LjQ1LTIsOS41Miw5LjUyLDAsMCwxLTMuMTEtNS4wNSwxLjIsMS4yLDAsMCwxLC4yNi0xLDEuNDEsMS40MSwwLDAsMSwxLjEzLS41MUg0NC4yNmExLjQ0LDEuNDQsMCwwLDEsMS4xMy41MSwxLjE5LDEuMTksMCwwLDEsLjI1LDFoMGE5LjUyLDkuNTIsMCwwLDEtMy4xMSw1LjA1QTcuNDIsNy40MiwwLDAsMSwzOC4wOSw1MC4xOVptLTYuMTctNy40Yy0uMTYsMC0uMi4wNy0uMjEuMDlhOC4yOSw4LjI5LDAsMCwwLDIuNzMsNC4zN0E2LjIzLDYuMjMsMCwwLDAsMzguMDksNDlhNi4yOCw2LjI4LDAsMCwwLDMuNjUtMS43Myw4LjMsOC4zLDAsMCwwLDIuNzItNC4zNy4yMS4yMSwwLDAsMC0uMi0uMDlaIi8+PC9nPjxnIGlkPSJGYWNlIj48ZWxsaXBzZSBpZD0iUmlnaHRfQmx1c2giIGRhdGEtbmFtZT0iUmlnaHQgQmx1c2giIGN4PSI1My4yMiIgY3k9IjQwLjE4IiByeD0iNS44NSIgcnk9IjMuNDQiIHN0eWxlPSJmaWxsOiNmZWJiZDAiLz48ZWxsaXBzZSBpZD0iTGVmdF9CbHVjaCIgZGF0YS1uYW1lPSJMZWZ0IEJsdWNoIiBjeD0iMjIuOTUiIGN5PSI0MC4xOCIgcng9IjUuODUiIHJ5PSIzLjQ0IiBzdHlsZT0iZmlsbDojZmViYmQwIi8+PHBhdGggaWQ9IkV5ZXMiIGQ9Ik0yNS43LDM4LjhhNS41MSw1LjUxLDAsMSwwLTUuNS01LjUxQTUuNTEsNS41MSwwLDAsMCwyNS43LDM4LjhabTI0Ljc3LDBBNS41MSw1LjUxLDAsMSwwLDQ1LDMzLjI5LDUuNSw1LjUsMCwwLDAsNTAuNDcsMzguOFoiIHN0eWxlPSJmaWxsLXJ1bGU6ZXZlbm9kZCIvPjxwYXRoIGlkPSJJcmlzIiBkPSJNMjQsMzMuNjRhMi4wNywyLjA3LDAsMSwwLTIuMDYtMi4wN0EyLjA3LDIuMDcsMCwwLDAsMjQsMzMuNjRabTI0Ljc3LDBhMi4wNywyLjA3LDAsMSwwLTIuMDYtMi4wN0EyLjA3LDIuMDcsMCwwLDAsNDguNzUsMzMuNjRaIiBzdHlsZT0iZmlsbDojZmZmO2ZpbGwtcnVsZTpldmVub2RkIi8+PC9nPjwvc3ZnPg==";
 
-const dependencyOptions: Fig.Option[] = [
+/** Suggest common ports for the various --inspect options */
+const inspectArgs: Fig.SingleOrArray<Fig.Arg> = {
+  name: "[host:]port",
+  isOptional: true,
+  suggestions: [
+    {
+      name: "3000",
+      icon: "fig://icon?type=box",
+      description: "serve on port 3000",
+    },
+    {
+      name: "8080",
+      icon: "fig://icon?type=box",
+      description: "serve on port 8080",
+    },
+  ],
+  description: "Activate inspector on particular port and/or hostname. ",
+};
+
+const loaders = [
+  "js",
+  "jsx",
+  "ts",
+  "tsx",
+  "json",
+  "toml",
+  "text",
+  "file",
+  "wasm",
+  "napi",
+];
+/** Format from https://github.com/oven-sh/bun/blob/dcbcf9803a19be989c0f48d22a50a43731fcfacd/src/cli.zig */
+const sharedPublicParams: Fig.Option[] = [
+  {
+    name: ["-h", "--help"],
+    description: "Display this help and exit.",
+  },
+  {
+    name: ["-b", "--bun"],
+    description:
+      "Force a script or package to use Bun's runtime instead of Node.js (via symlinking node)",
+  },
+  {
+    name: "--cwd",
+    args: {
+      name: "path",
+      description:
+        "Absolute path to resolve files & entry points from. This just changes the process' cwd.",
+    },
+  },
   {
     name: ["-c", "--config"],
     args: {
@@ -134,6 +183,7 @@ const spec: Fig.Spec = {
       name: "--inspect-brk",
       description:
         "Activate Bun's Debugger, set breakpoint on first line of code and wait",
+    requiresSeparator: true,
     },
     {
       name: "--server-bunfile",
@@ -294,7 +344,18 @@ const bunLinksGenerator: Fig.Generator = {
         template: "filepaths",
         isVariadic: true,
       },
+    {
+      name: "args",
     },
+  ],
+  // These flags are used before the subcommand or file
+  options: publicParams.filter(
+    (param) =>
+      param.name.includes("--inspect") ||
+      param.name.includes("--hot") ||
+      param.name.includes("--watch")
+  ),
+  subcommands: [
     {
       name: ["c", "create"],
       icon,
@@ -378,12 +439,12 @@ const bunLinksGenerator: Fig.Generator = {
         {
           name: "script",
           filterStrategy: "fuzzy",
-          generators: npmScriptsGenerator,
-        },
-        {
-          name: "args",
-          isVariadic: true,
-          isOptional: true,
+          generators: [
+            filepaths({
+              extensions: ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
+            }),
+            npmScriptsGenerator,
+          ],
         },
       ],
     },

--- a/src/bun.ts
+++ b/src/bun.ts
@@ -400,11 +400,82 @@ const spec: Fig.Spec = {
       },
     },
     {
+    {
       name: "upgrade",
       icon,
       description: "Get the latest version of bun",
+      options: [
+        {
+          name: "--canary",
+          description: "Install the latest canary release",
+        },
+      ],
+    },
+    {
+      name: "test",
       icon,
+      description: "Run unit tests with Bun",
+      args: {
+        name: "files",
+        generators: [
+          {
+            // Suggest test files -> https://bun.sh/docs/cli/test. (not in node_modules or .git)
+            script:
+              'command find $(npm prefix) | grep -E ".*.(test|_test|spec|_spec).(ts|tsx|js|jsx)$" | grep -vE ".*/node_modules/.*" | sed "s|$(npm prefix)/||"',
+            postProcess(out) {
+              return out.split("\n").map((file) => {
+                return {
+                  name: file.split("/").pop(),
+                  priority: 76,
+                  description: `run ${file}`,
+                  insertValue: file,
+                };
+              });
+            },
+            cache: {
+              strategy: "stale-while-revalidate",
+              ttl: 60 * 60 * 24, // 24 hours
+            },
+          },
+        ],
+        isVariadic: true,
+        filterStrategy: "fuzzy",
+        isOptional: true,
+        description: "test files to run",
+      },
+      options: testParams,
+    },
+    {
+      name: "pm",
       icon,
+      description: "Set of utilities for working with Bun's package manager.",
+      options: [
+        {
+          name: "bin",
+          description: "Print the path to bin folder",
+        },
+        {
+          name: "cache",
+          description: "Print the path to the cache folder",
+        },
+        {
+          name: "hash",
+          description: "Generate & print the hash of the current lockfile",
+        },
+        {
+          name: "hash-print",
+          description: "Print the hash stored in the current lockfile",
+        },
+        {
+          name: "hash-string",
+          description: "Print the string used to hash the lockfile",
+        },
+        {
+          name: "ls",
+          description:
+            "List the dependency tree according to the current lockfile",
+        },
+      ],
     },
     {
       name: "completions",
@@ -426,6 +497,23 @@ const spec: Fig.Spec = {
       icon,
       description: "Run an npx command",
       loadSpec: "bunx",
+    },
+    {
+      name: "repl",
+      icon,
+      description:
+        "Run a REPL (read eval print loop) with the Bun runtime.(experimental)",
+    },
+    {
+      name: "init",
+      icon,
+      description: "Initialize a new bun project",
+      options: [
+        {
+          name: ["-y", "--yes"],
+          description: "Answer yes to all prompts",
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
- add `link` subcommand with custom generator to get globally installed packages
- add `--save` option for "link" to save to package.json
- add `unlink` subcommand
- add `--canary` option to "upgrade" subcommand.
- remove `dev` subcommand (Bun no longer uses)
- add keyValueList generator for `--loader` option on `build` subcommand
- add `test` subcommand, with generator to pull in test files recognized by bun
- add `repl` subcommand
- add `build` subcommand with options
- add file suggestions to `run` subcommand
- add generator to get installed packages for `rm` subcommand
- add `--sourcemap` option with appropriate valueList
- add `--outdir` and `--outfile` options
- add `--watch` and `--hot` as global options
- add host/port suggestions for `--inspect` options
- refactor subcommand options to follow the [Bun source repo](https://github.com/oven-sh/bun/tree/main/src/cli)
- add Bun logo as icon