### PR TITLE
spec(bundle): Add gem autocomplete and binaries autocomplete

### DIFF
--- a/src/_utils/spec.ts
+++ b/src/_utils/spec.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line @withfig/fig-linter/no-missing-default-export
+export const specToSuggestions = (spec: Fig.Spec): Fig.Suggestion => {
+  return {
+    name: spec.name,
+    ...("icon" in spec && { icon: spec.icon }),
+  };
+};

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,3 +1,19 @@
+import rails from "./rails";
+import rubocop from "./rubocop";
+import rspec from "./rspec";
+import rake from "./rake";
+import { gemsGenerator } from "./gem";
+import pry from "./pry";
+import { specToSuggestions } from "./_utils/spec";
+
+const EXEC_SUGGESTIONS: Fig.Suggestion[] = [
+  specToSuggestions(rails),
+  specToSuggestions(rubocop),
+  specToSuggestions(rspec),
+  specToSuggestions(rake),
+  specToSuggestions(pry),
+];
+
 const gemfileGemsGenerator: Fig.Generator = {
   script: "bundle list --name-only",
   postProcess: (out) => {
@@ -175,7 +191,30 @@ const completionSpec: Fig.Spec = {
           description: "Pass all file descriptors to the new process",
         },
       ],
-      args: { isCommand: true },
+      args: {
+        isCommand: true,
+        generators: {
+          script: "bundle list --name-only",
+          cache: {
+            cacheByDirectory: true,
+            strategy: "stale-while-revalidate",
+            ttl: 60 * 60,
+          },
+          postProcess: (out) => {
+            const gems = out.split("\n");
+
+            return EXEC_SUGGESTIONS.filter((spec) => {
+              if (spec.name === "rspec") {
+                return gems.includes("rspec-core");
+              }
+
+              return gems.includes(
+                typeof spec.name === "string" ? spec.name : spec.name[0]
+              );
+            });
+          },
+        },
+      },
     },
     { name: "config", args: {} },
     { name: "help" },
@@ -184,7 +223,10 @@ const completionSpec: Fig.Spec = {
     {
       name: "add",
       description: "Add gem to the Gemfile and run bundle install",
-      args: {},
+      args: {
+        name: "gem",
+        generators: gemsGenerator,
+      },
       options: [
         {
           name: ["--version", "-v"],

--- a/src/gem.ts
+++ b/src/gem.ts
@@ -1,4 +1,4 @@
-const gems: Fig.Generator = {
+export const gemsGenerator: Fig.Generator = {
   trigger: () => true,
   custom: async (tokens, executeShellCommand) => {
     const searchTerm = tokens[tokens.length - 1];
@@ -172,7 +172,7 @@ const completionSpec: Fig.Spec = {
       description: "Install a gem into the local repository",
       args: {
         name: "GEMNAME",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
       },
       options: [
@@ -282,7 +282,7 @@ const completionSpec: Fig.Spec = {
       description: "Check a gem repository for added or missing files",
       args: {
         name: "GEMNAME",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
         isOptional: true,
       },
@@ -345,7 +345,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "GEMNAME",
         description: "Name of gem to cleanup",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
         isOptional: true,
       },
@@ -384,7 +384,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "GEMNAME",
         description: "Name of gem to list contents for",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
       },
       options: [
@@ -533,7 +533,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "GEMNAME",
         description: "Name of gem to download",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
       },
       options: [
@@ -634,7 +634,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "GEMNAME",
         description: "Name of the gem to print information about",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
       },
       options: [
@@ -678,7 +678,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "GEMNAME",
         description: "Name of the gem to print information about",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
       },
       options: [
@@ -708,7 +708,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "GEMNAME",
         description: "Name of the gem to print information about",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
         isOptional: true,
       },
@@ -723,7 +723,7 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "GEMNAME",
             description: "Name of the gem to print information about",
-            generators: gems,
+            generators: gemsGenerator,
             debounce: true,
           },
           requiresSeparator: true,
@@ -828,7 +828,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "GEMNAME",
         description: "Gem to generate documentation for (unless –all)",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
         isOptional: true,
       },
@@ -991,7 +991,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "GEMFILE",
           description: "Name of gem to show the gemspec for",
-          generators: gems,
+          generators: gemsGenerator,
           debounce: true,
         },
         {
@@ -1054,7 +1054,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "GEMNAME",
         description: "Name of gem to unpack",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
       },
       options: [
@@ -1088,7 +1088,7 @@ const completionSpec: Fig.Spec = {
       args: {
         name: "GEM",
         description: "Name of gem",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
       },
       options: [
@@ -1116,7 +1116,7 @@ const completionSpec: Fig.Spec = {
       description: "Uninstall gems from the local repository",
       args: {
         name: "GEMNAME",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
       },
       options: [
@@ -1297,7 +1297,7 @@ const completionSpec: Fig.Spec = {
       description: "Manage gem owners of a gem on the push server",
       args: {
         name: "GEMNAME",
-        generators: gems,
+        generators: gemsGenerator,
         debounce: true,
       },
       options: [

--- a/src/rspec.ts
+++ b/src/rspec.ts
@@ -1,0 +1,16 @@
+const completionSpec: Fig.Spec = {
+  name: "rspec",
+  icon: "https://rspec.info/images/logo.png",
+  description:
+    "Behaviour Driven Development for Ruby. Making TDD Productive and Fun",
+  args: {
+    name: "file",
+    description: "The file to run",
+    default: "./spec",
+    generators: {
+      template: ["filepaths", "folders"],
+    },
+  },
+};
+
+export default completionSpec;

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -1,0 +1,23 @@
+const completionSpec: Fig.Spec = {
+  name: "rubocop",
+  description:
+    "A Ruby static code analyzer and formatter, based on the community Ruby style guide",
+  icon: "https://github.com/rubocop/rubocop/blob/master/logo/rubo-logo-symbol.png?raw=true",
+  args: {
+    name: "file",
+    template: "filepaths",
+    isVariadic: true,
+  },
+  options: [
+    {
+      name: ["-a", "--autocorrect"],
+      description: "Autocorrect offenses (only when it's safe)",
+    },
+    {
+      name: ["-A", "--autocorrect-all"],
+      description: "Autocorrect offenses (safe and unsafe)",
+    },
+  ],
+};
+
+export default completionSpec;


### PR DESCRIPTION
This PR also includes
1. stubs for rspec and rubocop (will be done in a separate PR later, but the 2 most common things are added)
2. utility to convert a spec into a suggestion (that's gonna be used in other PRs i.e. npx to load i.e. create-vite to DRY up icons/names of bins across specs)
