### PR TITLE
Merge npx binary running across tools

### DIFF
--- a/src/_utils/spec.ts
+++ b/src/_utils/spec.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line @withfig/fig-linter/no-missing-default-export
+export const specToSuggestions = (spec: Fig.Spec): Fig.Suggestion => {
+  return {
+    name: spec.name,
+    ...("icon" in spec && { icon: spec.icon }),
+  };
+};

--- a/src/bunx.ts
+++ b/src/bunx.ts
@@ -1,27 +1,11 @@
-import { npxSuggestions } from "./npx";
+import { npxLocalBinsGenerator, npxSuggestions } from "./npx";
 
 const bunx: Fig.Spec = {
   name: "bunx",
   args: {
     name: "command",
     isCommand: true,
-    generators: {
-      script: `until [[ -d node_modules/ ]] || [[ $PWD = '/' ]]; do cd ..; done; ls -1 node_modules/.bin/`,
-      postProcess: function (out) {
-        const cli = [...npxSuggestions].reduce(
-          (acc, { name }) => [...acc, name],
-          []
-        );
-        return out
-          .split("\n")
-          .filter((name) => !cli.includes(name))
-          .map((name) => ({
-            name,
-            icon: "fig://icon?type=command",
-            loadSpec: name,
-          }));
-      },
-    },
+    generators: npxLocalBinsGenerator(true),
     description: "The command to run",
     suggestions: [...npxSuggestions],
   },

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -2,6 +2,7 @@
 
 import { npmScriptsGenerator, npmSearchGenerator } from "./npm";
 import { dependenciesGenerator, nodeClis } from "./yarn";
+import { npxLocalBinsGenerator } from "./npx";
 
 const filterMessages = (out: string): string => {
   return out.startsWith("warning:") || out.startsWith("error:")
@@ -504,8 +505,8 @@ node_modules/.bin is added to the PATH, so pnpm exec allows executing commands o
     args: {
       name: "Scripts",
       filterStrategy: "fuzzy",
-      generators: dependenciesGenerator,
-      isVariadic: true,
+      // TODO: fix loading + fix loading of rw
+      generators: npxLocalBinsGenerator(),
     },
     options: [
       {
@@ -882,6 +883,15 @@ Please note that this is prohibited when a store server is running`,
         description: `Returns the path to the active store directory`,
       },
     ],
+  },
+  {
+    name: "init",
+    description:
+      "Creates a basic package.json file in the current directory, if it doesn't exist already",
+  },
+  {
+    name: "doctor",
+    description: "Checks for known common issues with pnpm configuration",
   },
 ];
 

--- a/src/pnpx.ts
+++ b/src/pnpx.ts
@@ -1,38 +1,13 @@
+import { npxSuggestions } from "./npx";
+
 const completionSpec: Fig.Spec = {
   name: "pnpx",
   description: "Execute binaries from npm packages",
-  subcommands: [
-    {
-      name: "create-react-native-app",
-      icon: "https://reactnative.dev/img/pwa/manifest-icon-512.png",
-      loadSpec: "create-react-native-app",
-    },
-    {
-      name: "react-native",
-      icon: "https://reactnative.dev/img/pwa/manifest-icon-512.png",
-      loadSpec: "react-native",
-    },
-    {
-      name: "tailwindcss",
-      icon: "https://tailwindcss.com/favicon-32x32.png",
-      loadSpec: "tailwindcss",
-    },
-    {
-      name: "next",
-      icon: "https://nextjs.org/static/favicon/favicon-16x16.png",
-      loadSpec: "next",
-    },
-    {
-      name: "gltfjsx",
-      icon: "https://raw.githubusercontent.com/pmndrs/branding/master/logo.svg",
-      loadSpec: "gltfjsx",
-    },
-    {
-      name: "prisma",
-      icon: "https://raw.githubusercontent.com/prisma/docs/main/src/images/favicon-16x16.png",
-      loadSpec: "prisma",
-    },
-  ],
+  args: {
+    name: "name",
+    isCommand: true,
+    suggestions: [...npxSuggestions],
+  },
   options: [
     {
       name: ["--package", "-p"],

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -324,6 +324,7 @@ const commonOptions: Fig.Option[] = [
   },
 ];
 
+// TODO: Extract this to be used with bun|pnpm|npm create
 export const createCLIsGenerator: Fig.Generator = {
   script: function (context) {
     if (context[context.length - 1] === "") return "";


### PR DESCRIPTION
TODO:
- [ ] Extract create-PACKAGE loginc from yarn
- [ ] Make sure redwood and similar aliases work
- [ ] Maybe port to deno? (since it technically supports it?)
- [ ] Convert `npxSuggestions` array in npx.ts to load more specs (instead of hardcoding name and icon)
