### PR TITLE
[IDEA]spec(rails): Interactive rails g arguments

### DIFF
--- a/src/rails.ts
+++ b/src/rails.ts
@@ -477,7 +477,7 @@ const defaultCommands: Fig.Subcommand[] = [
     ],
   },
   {
-    name: ["g", "generator"],
+    name: ["g", "generate"],
     description: "Use templates to generate Rails resources",
     args: [
       {


### PR DESCRIPTION
This is a heavy MVP that's more of an idea but wanted to push it up to discuss

rails has really nice migration/model/scaffold generators that can take in arguments for columns

i.e. `rails g model Post title:string likes:integer slug:string:uniq`

My idea with this PR was to try and build the autocomplete generator that would for `rails g model Post title` suggest [title, title:string, title:string:uniq, title:integer ...] 

If anyone has any ideas for a better approach / want's to use this in other specs so we should extract this or anything feel free to comment on this
