### PR TITLE
feat(git): fix non-standard UTF chars in descriptions

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -3848,7 +3848,7 @@ const addOptions: Fig.Option[] = [
   {
     name: ["-n", "--dry-run"],
     description:
-      "Don’t actually add the file(s), just show if they exist and/or will be ignored",
+      "Don't actually add the file(s), just show if they exist and/or will be ignored",
   },
   { name: ["-v", "--verbose"], description: "Be verbose" },
   {
@@ -3893,7 +3893,7 @@ const addOptions: Fig.Option[] = [
   {
     name: "--refresh",
     description:
-      "Don’t add the file(s), but only refresh their stat() information in the index",
+      "Don't add the file(s), but only refresh their stat() information in the index",
   },
   {
     name: "--ignore-errors",
@@ -4102,7 +4102,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: "--html-path",
-      description: "Print Git’s HTML documentation path",
+      description: "Print Git's HTML documentation path",
     },
     {
       name: "--man-path",
@@ -4992,12 +4992,12 @@ const completionSpec: Fig.Spec = {
         {
           name: "--no-keep-empty",
           description:
-            "Do not keep commits that start empty before the rebase (i.e. that do not change anything from its parent) in the result. The default is to keep commits which start empty, since creating such commits requires passing the --allow-empty override flag to git commit, signifying that a user is very intentionally creating such a commit and thus wants to keep it. Usage of this flag will probably be rare, since you can get rid of commits that start empty by just firing up an interactive rebase and removing the lines corresponding to the commits you don’t want. This flag exists as a convenient shortcut, such as for cases where external tools generate many empty commits and you want them all removed. For commits which do not start empty but become empty after rebasing, see the --empty flag",
+            "Do not keep commits that start empty before the rebase (i.e. that do not change anything from its parent) in the result. The default is to keep commits which start empty, since creating such commits requires passing the --allow-empty override flag to git commit, signifying that a user is very intentionally creating such a commit and thus wants to keep it. Usage of this flag will probably be rare, since you can get rid of commits that start empty by just firing up an interactive rebase and removing the lines corresponding to the commits you don't want. This flag exists as a convenient shortcut, such as for cases where external tools generate many empty commits and you want them all removed. For commits which do not start empty but become empty after rebasing, see the --empty flag",
         },
         {
           name: "--keep-empty",
           description:
-            "Keep commits that start empty before the rebase (i.e. that do not change anything from its parent) in the result. The default is to keep commits which start empty, since creating such commits requires passing the --allow-empty override flag to git commit, signifying that a user is very intentionally creating such a commit and thus wants to keep it. Usage of this flag will probably be rare, since you can get rid of commits that start empty by just firing up an interactive rebase and removing the lines corresponding to the commits you don’t want. This flag exists as a convenient shortcut, such as for cases where external tools generate many empty commits and you want them all removed. For commits which do not start empty but become empty after rebasing, see the --empty flag",
+            "Keep commits that start empty before the rebase (i.e. that do not change anything from its parent) in the result. The default is to keep commits which start empty, since creating such commits requires passing the --allow-empty override flag to git commit, signifying that a user is very intentionally creating such a commit and thus wants to keep it. Usage of this flag will probably be rare, since you can get rid of commits that start empty by just firing up an interactive rebase and removing the lines corresponding to the commits you don't want. This flag exists as a convenient shortcut, such as for cases where external tools generate many empty commits and you want them all removed. For commits which do not start empty but become empty after rebasing, see the --empty flag",
         },
         {
           name: "--reapply-cherry-picks",
@@ -5205,12 +5205,12 @@ const completionSpec: Fig.Spec = {
         {
           name: "--autosquash",
           description:
-            "When the commit log message begins with 'squash! …​' (or 'fixup! …​'), and there is already a commit in the todo list that matches the same ..., automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from pick to squash (or fixup). A commit matches the ... if the commit subject matches, or if the ... refers to the commit’s hash. As a fall-back, partial matches of the commit subject work, too. The recommended way to create fixup/squash commits is by using the --fixup/--squash options of git-commit[1]",
+            "When the commit log message begins with 'squash! …​' (or 'fixup! …​'), and there is already a commit in the todo list that matches the same ..., automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from pick to squash (or fixup). A commit matches the ... if the commit subject matches, or if the ... refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too. The recommended way to create fixup/squash commits is by using the --fixup/--squash options of git-commit[1]",
         },
         {
           name: "--no-autosquash",
           description:
-            "When the commit log message begins with 'squash! …' (or 'fixup! …'), and there is already a commit in the todo list that matches the same ..., automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from pick to squash (or fixup). A commit matches the ... if the commit subject matches, or if the ... refers to the commit’s hash. As a fall-back, partial matches of the commit subject work, too. The recommended way to create fixup/squash commits is by using the --fixup/--squash options of git-commit[1]",
+            "When the commit log message begins with 'squash! …' (or 'fixup! …'), and there is already a commit in the todo list that matches the same ..., automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from pick to squash (or fixup). A commit matches the ... if the commit subject matches, or if the ... refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too. The recommended way to create fixup/squash commits is by using the --fixup/--squash options of git-commit[1]",
         },
         {
           name: "--autostash",
@@ -5479,7 +5479,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-n", "--dry-run"],
           description:
-            "Don’t actually remove anything, just show what would be done",
+            "Don't actually remove anything, just show what would be done",
         },
         {
           name: ["-q", "--quiet"],
@@ -5497,7 +5497,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "-x",
           description:
-            "Don’t use the standard ignore rules (see gitignore(5)), but still use the ignore rules given with -e options from the command line. This allows removing all untracked files, including build products. This can be used (possibly in conjunction with git restore or git reset) to create a pristine working directory to test a clean build",
+            "Don't use the standard ignore rules (see gitignore(5)), but still use the ignore rules given with -e options from the command line. This allows removing all untracked files, including build products. This can be used (possibly in conjunction with git restore or git reset) to create a pristine working directory to test a clean build",
         },
         {
           name: "-X",
@@ -5718,7 +5718,7 @@ const completionSpec: Fig.Spec = {
           name: ["--rebase", "-r"],
           isDangerous: true,
           description:
-            "Fetch the remote’s copy of current branch and rebases it into the local copy",
+            "Fetch the remote's copy of current branch and rebases it into the local copy",
           args: {
             isOptional: true,
             name: "remote",
@@ -5810,7 +5810,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--signoff",
           description:
-            "Add a Signed-off-by trailer by the committer at the end of the commit log message. The meaning of a signoff depends on the project to which you’re committing. For example, it may certify that the committer has the rights to submit the work under the project’s license or agrees to some contributor representation, such as a Developer Certificate of Origin. (See http://developercertificate.org for the one used by the Linux kernel and Git projects.) Consult the documentation or leadership of the project to which you’re contributing to understand how the signoffs are used in that project",
+            "Add a Signed-off-by trailer by the committer at the end of the commit log message. The meaning of a signoff depends on the project to which you're committing. For example, it may certify that the committer has the rights to submit the work under the project's license or agrees to some contributor representation, such as a Developer Certificate of Origin. (See http://developercertificate.org for the one used by the Linux kernel and Git projects.) Consult the documentation or leadership of the project to which you're contributing to understand how the signoffs are used in that project",
         },
         {
           name: "--no-signoff",
@@ -6346,7 +6346,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "-m",
               description:
-                "A symbolic-ref refs/remotes/<name>/HEAD is set up to point at remote’s <master> branch",
+                "A symbolic-ref refs/remotes/<name>/HEAD is set up to point at remote's <master> branch",
               args: {
                 name: "master",
               },
@@ -7157,7 +7157,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--server-option",
           description:
-            "Transmit the given string to the server when communicating using protocol version 2. The given string must not contain a NUL or LF character. The server’s handling of server options, including unknown ones, is server-specific. When multiple --server-option=<option> are given, they are all sent to the other side in the order listed on the command line",
+            "Transmit the given string to the server when communicating using protocol version 2. The given string must not contain a NUL or LF character. The server's handling of server options, including unknown ones, is server-specific. When multiple --server-option=<option> are given, they are all sent to the other side in the order listed on the command line",
           requiresSeparator: true,
           args: {
             name: "option",
@@ -7199,7 +7199,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-b", "--branch"],
           description:
-            "Instead of pointing the newly created HEAD to the branch pointed to by the cloned repository’s HEAD, point to <name> branch instead. In a non-bare repository, this is the branch that will be checked out. --branch can also take tags and detaches the HEAD at that commit in the resulting repository",
+            "Instead of pointing the newly created HEAD to the branch pointed to by the cloned repository's HEAD, point to <name> branch instead. In a non-bare repository, this is the branch that will be checked out. --branch can also take tags and detaches the HEAD at that commit in the resulting repository",
           args: { name: "branch name" },
         },
         {
@@ -7254,17 +7254,17 @@ const completionSpec: Fig.Spec = {
         {
           name: "--single-branch",
           description:
-            "Clone only the history leading to the tip of a single branch, either specified by the --branch option or the primary branch remote’s HEAD points at. Further fetches into the resulting repository will only update the remote-tracking branch for the branch this option was used for the initial cloning. If the HEAD at the remote did not point at any branch when --single-branch clone was made, no remote-tracking branch is created",
+            "Clone only the history leading to the tip of a single branch, either specified by the --branch option or the primary branch remote's HEAD points at. Further fetches into the resulting repository will only update the remote-tracking branch for the branch this option was used for the initial cloning. If the HEAD at the remote did not point at any branch when --single-branch clone was made, no remote-tracking branch is created",
         },
         {
           name: "--no-single-branch",
           description:
-            "Do not clone only the history leading to the tip of a single branch, either specified by the --branch option or the primary branch remote’s HEAD points at. Further fetches into the resulting repository will only update the remote-tracking branch for the branch this option was used for the initial cloning. If the HEAD at the remote did not point at any branch when --single-branch clone was made, no remote-tracking branch is created",
+            "Do not clone only the history leading to the tip of a single branch, either specified by the --branch option or the primary branch remote's HEAD points at. Further fetches into the resulting repository will only update the remote-tracking branch for the branch this option was used for the initial cloning. If the HEAD at the remote did not point at any branch when --single-branch clone was made, no remote-tracking branch is created",
         },
         {
           name: "--no-tags",
           description:
-            "Don’t clone any tags, and set remote.<remote>.tagOpt=--no-tags in the config, ensuring that future git pull and git fetch operations won’t follow any tags. Subsequent explicit tag fetches will still work, (see git-fetch[1])",
+            "Don't clone any tags, and set remote.<remote>.tagOpt=--no-tags in the config, ensuring that future git pull and git fetch operations won't follow any tags. Subsequent explicit tag fetches will still work, (see git-fetch[1])",
         },
         {
           name: "--recurse-submodules",
@@ -7287,7 +7287,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--remote-submodules",
           description:
-            "All submodules which are cloned will use the status of the submodule’s remote-tracking branch to update the submodule, rather than the superproject’s recorded SHA-1. Equivalent to passing --remote to git submodule update",
+            "All submodules which are cloned will use the status of the submodule's remote-tracking branch to update the submodule, rather than the superproject's recorded SHA-1. Equivalent to passing --remote to git submodule update",
         },
         {
           name: "--no-remote-submodules",
@@ -7475,7 +7475,7 @@ const completionSpec: Fig.Spec = {
         {
           name: ["-n", "--dry-run"],
           description:
-            "Don’t actually remove any file(s). Instead, just show if they exist in the index and would otherwise be removed by the command",
+            "Don't actually remove any file(s). Instead, just show if they exist in the index and would otherwise be removed by the command",
         },
         { name: "-r", description: "Allow recursive removal" },
       ],
@@ -7997,7 +7997,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "-l",
           description:
-            "Create the new branch’s reflog; see git-branch[1] for details",
+            "Create the new branch's reflog; see git-branch[1] for details",
         },
         {
           name: ["-d", "--detach"],
@@ -8316,7 +8316,7 @@ const completionSpec: Fig.Spec = {
             {
               name: "--name",
               description:
-                "It sets the submodule’s name to the given string instead of defaulting to its path",
+                "It sets the submodule's name to the given string instead of defaulting to its path",
               insertValue: "--name '{cursor}'",
               args: {
                 name: "name",
@@ -8405,7 +8405,7 @@ const completionSpec: Fig.Spec = {
             {
               name: ["-f", "--force"],
               description:
-                "The submodule’s working tree will be removed even if it contains local modifications",
+                "The submodule's working tree will be removed even if it contains local modifications",
             },
             {
               name: "--all",
@@ -8436,11 +8436,11 @@ const completionSpec: Fig.Spec = {
             {
               name: "--remote",
               description:
-                "Instead of using the superproject’s recorded SHA-1 to update the submodule, use the status of the submodule’s remote-tracking branch",
+                "Instead of using the superproject's recorded SHA-1 to update the submodule, use the status of the submodule's remote-tracking branch",
             },
             {
               name: ["-N", "--no-fetch"],
-              description: "Don’t fetch new objects from the remote site",
+              description: "Don't fetch new objects from the remote site",
             },
             {
               name: "--no-recommend-shallow",
@@ -8655,7 +8655,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "absorbgitdirs",
           description:
-            "If a git directory of a submodule is inside the submodule, move the git directory of the submodule into its superproject’s $GIT_DIR/modules path and then connect the git directory and its working directory by setting the core.worktree and adding a .git file pointing to the git directory embedded in the superprojects git directory",
+            "If a git directory of a submodule is inside the submodule, move the git directory of the submodule into its superproject's $GIT_DIR/modules path and then connect the git directory and its working directory by setting the core.worktree and adding a .git file pointing to the git directory embedded in the superprojects git directory",
         },
       ],
       options: [
@@ -8767,7 +8767,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--signoff",
           description:
-            "Add a Signed-off-by trailer by the committer at the end of the commit log message. The meaning of a signoff depends on the project to which you’re committing. For example, it may certify that the committer has the rights to submit the work under the project’s license or agrees to some contributor representation, such as a Developer Certificate of Origin. (See http://developercertificate.org for the one used by the Linux kernel and Git projects.) Consult the documentation or leadership of the project to which you’re contributing to understand how the signoffs are used in that project",
+            "Add a Signed-off-by trailer by the committer at the end of the commit log message. The meaning of a signoff depends on the project to which you're committing. For example, it may certify that the committer has the rights to submit the work under the project's license or agrees to some contributor representation, such as a Developer Certificate of Origin. (See http://developercertificate.org for the one used by the Linux kernel and Git projects.) Consult the documentation or leadership of the project to which you're contributing to understand how the signoffs are used in that project",
         },
         {
           name: "--no-signoff",
@@ -9627,7 +9627,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--strict-paths",
           description:
-            'Match paths exactly (i.e. don’t allow "/foo/repo" when the real path is "/foo/repo.git" or "/foo/repo/.git") and don’t do user-relative paths.  git daemon will refuse to start when this option is enabled and no whitelist is specified',
+            'Match paths exactly (i.e. don't allow "/foo/repo" when the real path is "/foo/repo.git" or "/foo/repo/.git") and don't do user-relative paths.  git daemon will refuse to start when this option is enabled and no whitelist is specified',
         },
         {
           name: "--base-path",
@@ -9645,7 +9645,7 @@ const completionSpec: Fig.Spec = {
           name: "--interpolated-path",
           requiresSeparator: true,
           description:
-            "To support virtual hosting, an interpolated path template can be used to dynamically construct alternate paths. The template supports %H for the target hostname as supplied by the client but converted to all lowercase, %CH for the canonical hostname, %IP for the server’s IP address, %P for the port number, and %D for the absolute path of the named repository. After interpolation, the path is validated against the directory whitelist",
+            "To support virtual hosting, an interpolated path template can be used to dynamically construct alternate paths. The template supports %H for the target hostname as supplied by the client but converted to all lowercase, %CH for the canonical hostname, %IP for the server's IP address, %P for the port number, and %D for the absolute path of the named repository. After interpolation, the path is validated against the directory whitelist",
           args: { name: "path-template" },
         },
         {
@@ -9740,7 +9740,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--user",
           description:
-            "Change daemon’s uid and gid before entering the service loop. When only --user is given without --group, the primary group ID for the user is used. The values of the option are given to getpwnam(3) and getgrnam(3) and numeric IDs are not supported",
+            "Change daemon's uid and gid before entering the service loop. When only --user is given without --group, the primary group ID for the user is used. The values of the option are given to getpwnam(3) and getgrnam(3) and numeric IDs are not supported",
           requiresSeparator: true,
           exclusiveOn: ["--inetd"],
           args: { name: "user" },
@@ -9748,7 +9748,7 @@ const completionSpec: Fig.Spec = {
         {
           name: "--group",
           description:
-            "Change daemon’s gid before entering the service loop. The value of this option is given to getgrnam(3) and numeric IDs are not supported",
+            "Change daemon's gid before entering the service loop. The value of this option is given to getgrnam(3) and numeric IDs are not supported",
           exclusiveOn: ["--inetd"],
         },
         {


### PR DESCRIPTION
VSCode pointed out to me that there were a bunch of cases in the Git spec (and 50 other specs) where the `U+2019` char (`’`) is being used instead of the more standard `U+0060` char (`'`). This can lead to mistaken formatting, especially when copying code.