### PR TITLE
feat: add progressline completion spec

### DIFF
--- a/src/progressline.ts
+++ b/src/progressline.ts
@@ -1,0 +1,41 @@
+const completionSpec: Fig.Spec = {
+  name: "progressline",
+  description: "⏳Track commands progress in a compact one-line format",
+
+  options: [
+    {
+      name: ["--help", "-h"],
+      description: "Show help for progressline",
+    },
+    {
+      name: ["--log-all", "-a"],
+      description: "Log all lines above the progress line",
+    },
+    {
+      name: ["--activity-style", "-s"],
+      args: {
+        name: "style",
+        default: "dots",
+        suggestions: ["dots", "kitt", "snake"],
+      },
+      description: "Set style of the activity indicator",
+    },
+    {
+      name: ["--original-log-path", "-l"],
+      description: "Save the original log to a file",
+      args: {
+        name: "path",
+        template: "filepaths",
+      },
+    },
+    {
+      name: ["--log-matches", "-m"],
+      description:
+        "Log above progress line lines matching the given regular expressions",
+      args: {
+        name: "regex",
+      },
+    },
+  ],
+};
+export default completionSpec;


### PR DESCRIPTION
https://github.com/kattouf/ProgressLine

```sh
❯ progressline --help
OVERVIEW: A command-line tool for compactly tracking the progress of piped commands.

USAGE: some-command | progressline

OPTIONS:
  -s, --activity-style <activity-style>
                          The style of the activity indicator. (values: dots, kitt, snake; default: dots)
  -l, --original-log-path <original-log-path>
                          Save the original log to a file.
  -m, --log-matches <log-matches>
                          Log above progress line lines matching the given regular expressions.
  -a, --log-all           Log all lines above the progress line.
  -h, --help              Show help information.
```