### PR TITLE
fix(git): Separate local and remote branches in branch display#2101

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -63,6 +63,8 @@ const postProcessBranches =
     }
 
     const seen = new Set<string>();
+    const local = new Set<string>();
+    const remote = new Set<string>();
     return output
       .split("\n")
       .filter((line) => !line.trim().startsWith("HEAD"))
@@ -71,6 +73,7 @@ const postProcessBranches =
         const parts = branch.match(/\S+/g);
         if (parts.length > 1) {
           if (parts[0] === "*") {
+            local.add(branch.replace("*", "").trim());
             // We are in a detached HEAD state
             if (branch.includes("HEAD detached")) {
               return null;
@@ -93,6 +96,9 @@ const postProcessBranches =
         if (insertWithoutRemotes && name.startsWith("remotes/")) {
           name = name.slice(name.indexOf("/", 8) + 1);
           description = "Remote branch";
+          remote.add(name);
+        } else {
+          local.add(name);
         }
 
         const space = name.indexOf(" ");
@@ -106,6 +112,25 @@ const postProcessBranches =
           icon: "fig://icon?type=git",
           priority: 75,
         };
+      })
+      .map((suggestion) => {
+        if (local.has(suggestion.name) && remote.has(suggestion.name)) {
+          return suggestion;
+        } else if (local.has(suggestion.name) && !remote.has(suggestion.name)) {
+          return {
+            ...suggestion,
+            description: "Local branch",
+          };
+        } else if (!local.has(suggestion.name) && remote.has(suggestion.name)) {
+          return {
+            ...suggestion,
+            name: "remotes/origin/" + suggestion.name,
+            icon: "fig://icon?type=alert",
+            priority: 74,
+          };
+        }
+
+        return suggestion;
       })
       .filter((suggestion) => {
         if (seen.has(suggestion.name)) return false;


### PR DESCRIPTION
## Bug Cause
When retrieving the branch list, both local and remote branches are fetched and exposed with the same names.
As a result, when users use the autocomplete feature, they see suggestions for branches that have been deleted locally (or remotely).
#2101 #2268


## Additional Features
- If both local and remote branches exist, display as before (description: Branch).
- If only a local branch exists, add "Local branch" to the description.
- If only a remote branch exists, set name to remotes/origin/{branch}, use an alert icon, set description to "Remote branch", and lower the priority.

## Scenario
<img width="438" alt="image" src="https://github.com/user-attachments/assets/694b67f6-aa40-4c71-8961-ce09c520eab8">

- local & remote : main, develop
- local only : localBranch
- remote only : remoteBranch
### AS-IS
<img width="481" alt="image" src="https://github.com/user-attachments/assets/ff1fdaf5-f468-40d1-a3fe-156c12b5e283">
<img width="527" alt="image" src="https://github.com/user-attachments/assets/79426cb7-c581-4fb2-a779-7dd06330d827">
<img width="700" alt="image" src="https://github.com/user-attachments/assets/ee492618-c593-4720-881e-1ef2332d7de4">


### TO-BE
<img width="693" alt="image" src="https://github.com/user-attachments/assets/523d3a4d-5249-4502-b68e-ff3e5205f51d">
<img width="702" alt="image" src="https://github.com/user-attachments/assets/41435a8c-5764-46fb-8c09-1ce482f420cd">
<img width="697" alt="image" src="https://github.com/user-attachments/assets/ff8e662d-1481-4f12-ae46-39abe6071285">



There could be multiple solutions, such as showing only local branches. Please provide suggestions, and I will make adjustments accordingly.
