### PR TITLE
fix(kubectl): Remove "--short" option from "version"

### DIFF
--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -3807,10 +3807,6 @@ const completionSpec: Fig.Spec = {
           description:
             "If true, shows client version only (no server required)",
         },
-        {
-          name: "--short",
-          description: "If true, print just the version number",
-        },
       ],
     },
     {


### PR DESCRIPTION
The option was deprecated, then removed in version 1.28. Short is now the default.