### PR TITLE
fix(conda): getInstalledPackages generator

### DIFF
--- a/src/conda.ts
+++ b/src/conda.ts
@@ -3,11 +3,15 @@ const getInstalledPackages: Fig.Generator = {
   postProcess: function (out) {
     const lines = out.split("\n");
     const installedPackages = [];
-    for (let i = 2; i < lines.length; i++) {
-      installedPackages.push({
-        name: lines[i],
-        icon: "🐍",
-      });
+    for (let i = 3; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (line) {
+        const packageName = line.split(/\s+/)[0];
+        installedPackages.push({
+          name: packageName,
+          icon: "🐍",
+        });
+      }
     }
     return installedPackages;
   },


### PR DESCRIPTION
This PR fixes #1083. Fixed generator extracts and returns the names of installed Conda packages from the conda list output, instead of packages, versions and build strings.

Before extracting full lines
<img width="750" alt="Screenshot 2024-08-08 at 10 27 57 AM" src="https://github.com/user-attachments/assets/50ac0c8a-3d0f-4372-92d2-bdbd39bdc8d3">

Now extracting only package names
<img width="207" alt="Screenshot 2024-08-08 at 10 28 40 AM" src="https://github.com/user-attachments/assets/649ac335-2659-48fd-83fc-a227d537eee0">

https://github.com/user-attachments/assets/bfedf741-8bde-482a-b051-4fd5c5243019