### PR TITLE
Add check for adonisrc.ts for Adonis.js 'node ace' command

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -83,14 +83,19 @@ const completionSpec: Fig.Subcommand = {
     },
   ],
   generateSpec: async (tokens, executeShellCommand) => {
-    const isAdonisJsonPresentCommand = "test -f .adonisrc.json";
+    const isAdonisJsonPresent = await executeShellCommand({
+      command: "bash",
+      args: ["-c", "test -f .adonisrc.json"],
+    });
+
+    const isAdonisRcTsPresent = await executeShellCommand({
+      command: "bash",
+      args: ["-c", "test -f adonisrc.ts"],
+    });
+
     if (
-      (
-        await executeShellCommand({
-          command: "bash",
-          args: ["-c", "isAdonisJsonPresentCommand"],
-        })
-      ).status === 0
+      isAdonisJsonPresent.status === 0 ||
+      isAdonisRcTsPresent.status === 0
     ) {
       return {
         name: "node",


### PR DESCRIPTION
Looks like the latest version of AdonisJS does not ship with .adonisrc.json but rather adonisrc.ts so this checks for both.

Improve generateSpec function to check for both .adonisrc.json and adonisrc.ts files. This ensures compatibility with projects using either configuration file.

- Refactor the use of executeShellCommand to check for .adonisrc.json.
- Add a new check for the presence of adonisrc.ts.