### PR TITLE
Update oh-my-posh.ts to fix an error in the "config export" command description

### DIFF
--- a/src/oh-my-posh.ts
+++ b/src/oh-my-posh.ts
@@ -114,7 +114,7 @@ const completionSpec: Fig.Spec = {
             {
               name: ["--output", "-o"],
               description:
-                "The file to output the migrated config to, example usage: 'oh-my-posh config migrate --output ~/.config.omp.json'",
+                "The file to output the migrated config to, example usage: 'oh-my-posh config export --output ~/.config.omp.json'",
               args: {
                 name: "OUTPUT",
                 description: "The file to write to",


### PR DESCRIPTION
Fixed an error in the description of the "oh-my-posh config export" command.