### PR TITLE
fix(git): wrong argument name for clone --depth

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -7225,7 +7225,7 @@ const completionSpec: Fig.Spec = {
           description:
             "Create a shallow clone with a history truncated to the specified number of commits. Implies --single-branch unless --no-single-branch is given to fetch the histories near the tips of all branches. If you want to clone submodules shallowly, also pass --shallow-submodules",
           args: {
-            name: "date",
+            name: "depth",
           },
         },
         {


### PR DESCRIPTION
`date` was used as the argument name for `git clone --depth`.
The correct argument name is `depth` - https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--depthcodeemltdepthgtem