### PR TITLE
fix: ollama.ts lint and typecheck issues

### DIFF
--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -1,11 +1,21 @@
 const ListModelGenerator: Fig.Generator = {
   script: ["bash", "-c", "ollama ls | awk '!/NAME/ { print $1 }'"],
-  postProcess: (out) => out.trim().split("\n"),
+  postProcess: (out) => {
+    return out
+      .trim()
+      .split("\n")
+      .map((model) => ({ name: model }));
+  },
 };
 
 const RunModelGenerator: Fig.Generator = {
   script: ["bash", "-c", "ollama ps | awk '!/NAME/ { print $1 }'"],
-  postProcess: (out) => out.trim().split("\n"),
+  postProcess: (out) => {
+    return out
+      .trim()
+      .split("\n")
+      .map((model) => ({ name: model }));
+  },
 };
 
 const completionSpec: Fig.Spec = {
@@ -81,9 +91,9 @@ const completionSpec: Fig.Spec = {
       name: "cp",
       description: "Copy a model",
       args: {
-          name: "SOURCE",
-          generators: ListModelGenerator,
-        },
+        name: "SOURCE",
+        generators: ListModelGenerator,
+      },
     },
     {
       name: "rm",


### PR DESCRIPTION
Master branch can't build because of lint and type check issues in ollama.ts:

1. 
```bash
Run pnpm lint

> @withfig/autocomplete@2.690.0 lint /home/runner/work/autocomplete/autocomplete
> eslint '**/*.ts' && npx prettier --check '**/*.ts' --parser typescript

Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Checking formatting...
[warn] src/ollama.ts
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```

2.
```bash
Run pnpm test

> @withfig/autocomplete@2.690.0 test /home/runner/work/autocomplete/autocomplete
> tsc --noEmit && echo 'All specs passed validation. You are ready to push!'

Error: src/ollama.ts(3,25): error TS2322: Type 'string[]' is not assignable to type 'Suggestion[]'.
  Type 'string' has no properties in common with type 'Suggestion'.
Error: src/ollama.ts(8,25): error TS2322: Type 'string[]' is not assignable to type 'Suggestion[]'.
 ELIFECYCLE  Test failed. See above for more details.
Error: Process completed with exit code 2.
```