### PR TITLE
Revert "build(deps): bump softprops/action-gh-release from 2.0.8 to 2.2.0"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         # Create a new github release with the newly created specs.zip file
       - name: Release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
         with:
           files: specs.zip
           tag_name: ${{ steps.tag_version.outputs.new_tag }}


### PR DESCRIPTION
Reverts withfig/autocomplete#2526 due to bug in softprops/action-gh-release. See https://github.com/softprops/action-gh-release/issues/556