### PR TITLE
fix(mkdir): Use lower case for arg names

### DIFF
--- a/src/mkdir.ts
+++ b/src/mkdir.ts
@@ -22,8 +22,7 @@ const completionSpec: Fig.Spec = {
     },
     {
       name: ["-Z", "--context"],
-      description:
-        "Set the SELinux security context of each created directory",
+      description: "Set the SELinux security context of each created directory",
       args: { name: "context" },
     },
     { name: "--help", description: "Display this help and exit" },

--- a/src/mkdir.ts
+++ b/src/mkdir.ts
@@ -10,7 +10,7 @@ const completionSpec: Fig.Spec = {
     {
       name: ["-m", "--mode"],
       description: "Set file mode (as in chmod), not a=rwx - umask",
-      args: { name: "MODE" },
+      args: { name: "mode" },
     },
     {
       name: ["-p", "--parents"],
@@ -23,8 +23,8 @@ const completionSpec: Fig.Spec = {
     {
       name: ["-Z", "--context"],
       description:
-        "Set the SELinux security context of each created directory to CTX",
-      args: { name: "CTX" },
+        "Set the SELinux security context of each created directory",
+      args: { name: "context" },
     },
     { name: "--help", description: "Display this help and exit" },
     {


### PR DESCRIPTION
Fixes #2589

The originals were from the man page, so it's somewhat ambiguous what the right thing to do here is.